### PR TITLE
add apiDoc for some parts of config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -13,8 +13,6 @@ const (
 	DEFAULT_INVOCATION_TIMEOUT = 120 * time.Second //secs
 )
 
-////////////////////// ClientConfig //////////////////////////////
-
 type ClientConfig struct {
 	membershipListeners []interface{}
 	lifecycleListeners  []interface{}
@@ -71,8 +69,6 @@ func (clientConfig *ClientConfig) SetClientNetworkConfig(clientNetworkConfig *Cl
 func (clientConfig *ClientConfig) SetSerializationConfig(serializationConfig *SerializationConfig) {
 	clientConfig.serializationConfig = serializationConfig
 }
-
-////////////////////// SerializationConfig //////////////////////////////
 
 type SerializationConfig struct {
 	isBigEndian               bool
@@ -146,40 +142,74 @@ func (serializationConfig *SerializationConfig) SetGlobalSerializer(serializer S
 	return nil
 }
 
-////////////////////// GroupConfig //////////////////////////////
+// GroupConfig contains the configuration for Hazelcast groups.
+// With groups it is possible to create multiple clusters where each cluster has its own group and doesn't
+// interfere with other clusters.
 type GroupConfig struct {
-	name     string
+	// the group name of the group.
+	name string
+
+	// the group password of the group.
 	password string
 }
 
+// NewGroupConfig creates a new GroupConfig with default group name and password.
 func NewGroupConfig() *GroupConfig {
 	return &GroupConfig{name: DEFAULT_GROUP_NAME, password: DEFAULT_GROUP_PASSWORD}
 }
 
+// Name returns the group name of the group.
 func (groupConfig *GroupConfig) Name() string {
 	return groupConfig.name
 }
 
+// Password returns the group password of the group.
 func (groupConfig *GroupConfig) Password() string {
 	return groupConfig.password
 }
 
+// SetName sets the group name of the group.
+// SetName returns the configured GroupConfig for chaining.
 func (groupConfig *GroupConfig) SetName(name string) {
 	groupConfig.name = name
 }
 
+// SetPassword sets the group password of the group.
+// SetPassword returns the configured GroupConfig for chaining.
 func (groupConfig *GroupConfig) SetPassword(password string) {
 	groupConfig.password = password
 }
 
-////////////////////// ClientNetworkConfig //////////////////////////////
+// ClientNetworkConfig contains network related configuration parameters.
 type ClientNetworkConfig struct {
-	addresses                  []string
-	connectionAttemptLimit     int32
-	connectionAttemptPeriod    int32
-	connectionTimeout          int32
-	redoOperation              bool
-	smartRouting               bool
+
+	// addresses are the candidate addresses slice that client will use to establish initial connection.
+	addresses []string
+
+	// While client is trying to connect initially to one of the members in the addresses slice, all might not be
+	// available. Instead of giving up, returning Error and stopping client, it will attempt to retry as much as defined
+	// by this parameter.
+	connectionAttemptLimit int32
+
+	// connectionAttemptPeriod is the period for the next attempt to find a member to connect.
+	connectionAttemptPeriod int32
+
+	// Socket connection timeout is an int32, given in seconds.
+	// Setting a timeout of zero disables the timeout feature and is equivalent to block the socket until it connects.
+	connectionTimeout int32
+
+	// If true, client will redo the operations that were executing on the server when client recovers the connection after a failure.
+	// This can be because of network, or simply because the member died. However it is not clear whether the
+	// application is performed or not. For idempotent operations this is harmless, but for non idempotent ones
+	// retrying can cause to undesirable effects. Note that the redo can perform on any member.
+	redoOperation bool
+
+	// If true, client will route the key based operations to owner of the key at the best effort. Note that it uses a
+	// cached value of partition count and doesn't guarantee that the operation will always be executed on the owner.
+	// The cached table is updated every 10 seconds.
+	smartRouting bool
+
+	// The invocation timeout for sending invocation.
 	invocationTimeoutInSeconds time.Duration
 }
 
@@ -195,69 +225,101 @@ func NewClientNetworkConfig() *ClientNetworkConfig {
 	}
 }
 
+// Addresses returns the slice of candidate addresses that client will use to establish initial connection.
 func (clientNetworkConfig *ClientNetworkConfig) Addresses() []string {
 	return clientNetworkConfig.addresses
 }
 
+// ConnectionAttemptLimit returns connection attempt limit.
 func (clientNetworkConfig *ClientNetworkConfig) ConnectionAttemptLimit() int32 {
 	return clientNetworkConfig.connectionAttemptLimit
 }
 
+// ConnectionAttemptPeriod returns the period for the next attempt to find a member to connect.
 func (clientNetworkConfig *ClientNetworkConfig) ConnectionAttemptPeriod() int32 {
 	return clientNetworkConfig.connectionAttemptPeriod
 }
 
+// ConnectionTimeout returns the timeout value in seconds for nodes to accept client connection requests.
 func (clientNetworkConfig *ClientNetworkConfig) ConnectionTimeout() int32 {
 	return clientNetworkConfig.connectionTimeout
 }
 
+// IsRedoOperation returns true if redo operations are enabled.
 func (clientNetworkConfig *ClientNetworkConfig) IsRedoOperation() bool {
 	return clientNetworkConfig.redoOperation
 }
 
+// IsSmartRouting returns true if client is smart.
 func (clientNetworkConfig *ClientNetworkConfig) IsSmartRouting() bool {
 	return clientNetworkConfig.smartRouting
 }
 
+// InvocationTimeout returns the invocation timeout in seconds.
 func (clientNetworkConfig *ClientNetworkConfig) InvocationTimeout() time.Duration {
 	return clientNetworkConfig.invocationTimeoutInSeconds
 }
 
+// AddAddress adds given addresses to candidate address list that client will use to establish initial connection.
+// AddAddress returns the configured ClientNetworkConfig for chaining.
 func (clientNetworkConfig *ClientNetworkConfig) AddAddress(addresses ...string) *ClientNetworkConfig {
 	clientNetworkConfig.addresses = append(clientNetworkConfig.addresses, addresses...)
 	return clientNetworkConfig
 }
 
+// SetAddresses sets given addresses as candidate address list that client will use to establish initial connection.
+// SetAddresses returns the configured ClientNetworkConfig for chaining.
 func (clientNetworkConfig *ClientNetworkConfig) SetAddresses(addresses []string) *ClientNetworkConfig {
 	clientNetworkConfig.addresses = addresses
 	return clientNetworkConfig
 }
 
+// While client is trying to connect initially to one of the members in the addresses slice, all might not be
+// available. Instead of giving up, returning Error and stopping client, it will attempt to retry as much as defined
+// by this parameter.
+// SetConnectionAttemptLimit returns the configured ClientNetworkConfig for chaining.
 func (clientNetworkConfig *ClientNetworkConfig) SetConnectionAttemptLimit(connectionAttemptLimit int32) *ClientNetworkConfig {
 	clientNetworkConfig.connectionAttemptLimit = connectionAttemptLimit
 	return clientNetworkConfig
 }
 
+// SetConnectionAttemptPeriod sets the period for the next attempt to find a member to connect in seconds.
+// SetConnectionAttemptPeriod returns the configured ClientNetworkConfig for chaining.
 func (clientNetworkConfig *ClientNetworkConfig) SetConnectionAttemptPeriod(connectionAttemptPeriod int32) *ClientNetworkConfig {
 	clientNetworkConfig.connectionAttemptPeriod = connectionAttemptPeriod
 	return clientNetworkConfig
 }
 
+// Socket connection timeout is an int32, given in seconds.
+// Setting a timeout of zero disables the timeout feature and is equivalent to block the socket until it connects.
+// SetConnectionTimeout returns the configured ClientNetworkConfig for chaining.
 func (clientNetworkConfig *ClientNetworkConfig) SetConnectionTimeout(connectionTimeout int32) *ClientNetworkConfig {
 	clientNetworkConfig.connectionTimeout = connectionTimeout
 	return clientNetworkConfig
 }
 
+// If true, client will redo the operations that were executing on the server when client recovers the connection after a failure.
+// This can be because of network, or simply because the member died. However it is not clear whether the
+// application is performed or not. For idempotent operations this is harmless, but for non idempotent ones
+// retrying can cause to undesirable effects. Note that the redo can perform on any member.
+// SetRedoOperation returns the configured ClientNetworkConfig for chaining.
 func (clientNetworkConfig *ClientNetworkConfig) SetRedoOperation(redoOperation bool) *ClientNetworkConfig {
 	clientNetworkConfig.redoOperation = redoOperation
 	return clientNetworkConfig
 }
 
+// If true, client will route the key based operations to owner of the key at the best effort.
+// Note that it uses a cached version of partitionService and doesn't
+// guarantee that the operation will always be executed on the owner. The cached table is updated every 10 seconds.
+// Default value is true.
+// SetSmartRouting returns the configured ClientNetworkConfig for chaining.
 func (clientNetworkConfig *ClientNetworkConfig) SetSmartRouting(smartRouting bool) *ClientNetworkConfig {
 	clientNetworkConfig.smartRouting = smartRouting
 	return clientNetworkConfig
 }
 
+// SetInvocationTimeoutInSeconds sets the invocation timeout for sending invocation.
+// SetInvocationTimeoutInSeconds returns the configured ClientNetworkConfig for chaining.
 func (clientNetworkConfig *ClientNetworkConfig) SetInvocationTimeoutInSeconds(invocationTimeoutInSeconds int32) {
 	clientNetworkConfig.invocationTimeoutInSeconds = time.Duration(invocationTimeoutInSeconds) * time.Second
 }


### PR DESCRIPTION
#37 .

This pr contains apiDoc for some part of config.


To see the html run:
```godoc -http ":8080"```

and go to:
[http://localhost:8080/pkg/github.com/hazelcast/go-client/config/](http://localhost:8080/pkg/github.com/hazelcast/go-client/config/)