### PR TITLE
return corresponding structs in config for chaining, remove unnecessa…

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -184,14 +184,16 @@ func (groupConfig *GroupConfig) Password() string {
 
 // SetName sets the group name of the group.
 // SetName returns the configured GroupConfig for chaining.
-func (groupConfig *GroupConfig) SetName(name string) {
+func (groupConfig *GroupConfig) SetName(name string) *GroupConfig {
 	groupConfig.name = name
+	return groupConfig
 }
 
 // SetPassword sets the group password of the group.
 // SetPassword returns the configured GroupConfig for chaining.
-func (groupConfig *GroupConfig) SetPassword(password string) {
+func (groupConfig *GroupConfig) SetPassword(password string) *GroupConfig {
 	groupConfig.password = password
+	return groupConfig
 }
 
 // ClientNetworkConfig contains network related configuration parameters.
@@ -334,6 +336,7 @@ func (clientNetworkConfig *ClientNetworkConfig) SetSmartRouting(smartRouting boo
 
 // SetInvocationTimeoutInSeconds sets the invocation timeout for sending invocation.
 // SetInvocationTimeoutInSeconds returns the configured ClientNetworkConfig for chaining.
-func (clientNetworkConfig *ClientNetworkConfig) SetInvocationTimeoutInSeconds(invocationTimeoutInSeconds int32) {
+func (clientNetworkConfig *ClientNetworkConfig) SetInvocationTimeoutInSeconds(invocationTimeoutInSeconds int32) *ClientNetworkConfig {
 	clientNetworkConfig.invocationTimeoutInSeconds = time.Duration(invocationTimeoutInSeconds) * time.Second
+	return clientNetworkConfig
 }

--- a/core/IMap.go
+++ b/core/IMap.go
@@ -111,7 +111,7 @@ type IMap interface {
 	//	mp, _ := client.GetMap("employee")
 	//	mp.AddIndex("age", true);        // ordered, since we have ranged queries for this field
 	//	mp.AddIndex("active", false);    // not ordered, because boolean field cannot have range
-	AddIndex(attributes *string, ordered bool) (err error)
+	AddIndex(attribute string, ordered bool) (err error)
 
 	// Evict evicts the specified key from this map.
 	// Evict returns true if the key is evicted, false otherwise.
@@ -224,7 +224,7 @@ type IMap interface {
 
 	// PutAll copies all of the mappings from the specified map to this map. No atomicity guarantees are
 	// given. In the case of a failure, some of the key-value tuples may get written, while others are not.
-	PutAll(mp *map[interface{}]interface{}) (err error)
+	PutAll(mp map[interface{}]interface{}) (err error)
 
 	// KeySet returns a slice clone of the keys contained in this map.
 	// Warning:
@@ -294,7 +294,7 @@ type IMap interface {
 	// GetAll returns the entries for the given keys.
 	// The returned map is NOT backed by the original map,
 	// so changes to the original map are NOT reflected in the returned map, and vice-versa.
-	GetAll(keys []interface{}) (entryPairs []IPair, err error)
+	GetAll(keys []interface{}) (entryMap map[interface{}]interface{}, err error)
 
 	// GetEntryView returns the IEntryView for the specified key.
 	// GetEntryView returns a clone of original mapping, modifying the returned value does not change

--- a/internal/map.go
+++ b/internal/map.go
@@ -258,8 +258,8 @@ func (imap *MapProxy) IsEmpty() (empty bool, err error) {
 	response := MapIsEmptyDecodeResponse(responseMessage).Response
 	return response, nil
 }
-func (imap *MapProxy) AddIndex(attributes *string, ordered bool) (err error) {
-	request := MapAddIndexEncodeRequest(imap.name, attributes, ordered)
+func (imap *MapProxy) AddIndex(attribute string, ordered bool) (err error) {
+	request := MapAddIndexEncodeRequest(imap.name, &attribute, ordered)
 	_, err = imap.InvokeOnRandomTarget(request)
 	return err
 }
@@ -481,12 +481,12 @@ func (imap *MapProxy) PutIfAbsent(key interface{}, value interface{}) (oldValue 
 	responseData := MapPutIfAbsentDecodeResponse(responseMessage).Response
 	return imap.ToObject(responseData)
 }
-func (imap *MapProxy) PutAll(mp *map[interface{}]interface{}) (err error) {
+func (imap *MapProxy) PutAll(mp map[interface{}]interface{}) (err error) {
 	if !CheckNotNil(mp) {
 		return errors.New("Null argument map is not allowed")
 	}
 	partitions := make(map[int32][]Pair)
-	for key, value := range *mp {
+	for key, value := range mp {
 		keyData, err := imap.ToData(key)
 		if err != nil {
 			return err
@@ -637,12 +637,12 @@ func (imap *MapProxy) EntrySetWithPredicate(predicate IPredicate) (resultPairs [
 	}
 	return pairList, nil
 }
-func (imap *MapProxy) GetAll(keys []interface{}) (entryPairs []core.IPair, err error) {
+func (imap *MapProxy) GetAll(keys []interface{}) (entryMap map[interface{}]interface{}, err error) {
 	if !CheckNotEmpty(keys) {
 		return nil, errors.New(NIL_KEYS_ARE_NOT_ALLOWED)
 	}
 	partitions := make(map[int32][]serialization.Data)
-	pairList := make([]core.IPair, 0)
+	entryMap = make(map[interface{}]interface{}, 0)
 	for _, key := range keys {
 		keyData, err := imap.ToData(key)
 		if err != nil {
@@ -667,10 +667,10 @@ func (imap *MapProxy) GetAll(keys []interface{}) (entryPairs []core.IPair, err e
 			if err != nil {
 				return nil, err
 			}
-			pairList = append(pairList, core.IPair(NewPair(key, value)))
+			entryMap[key] = value
 		}
 	}
-	return pairList, nil
+	return entryMap, nil
 }
 func (imap *MapProxy) GetEntryView(key interface{}) (entryView core.IEntryView, err error) {
 	if !CheckNotNil(key) {

--- a/tests/proxy/map_test.go
+++ b/tests/proxy/map_test.go
@@ -326,7 +326,7 @@ func TestMapProxy_PutAll(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		testMap["testingKey"+strconv.Itoa(i)] = "testingValue" + strconv.Itoa(i)
 	}
-	err := mp.PutAll(&testMap)
+	err := mp.PutAll(testMap)
 	if err != nil {
 		t.Fatal(err)
 	} else {
@@ -409,7 +409,7 @@ func TestMapProxy_EntrySetWithPredicate(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		testMap["testingKey"+strconv.Itoa(i)] = values[i]
 	}
-	err := mp.PutAll(&testMap)
+	err := mp.PutAll(testMap)
 	if err != nil {
 		t.Fatal(err)
 	} else {
@@ -436,7 +436,7 @@ func TestMapProxy_GetAll(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		testMap["testingKey"+strconv.Itoa(i)] = "testingValue" + strconv.Itoa(i)
 	}
-	err := mp.PutAll(&testMap)
+	err := mp.PutAll(testMap)
 	if err != nil {
 		t.Fatal(err)
 	} else {
@@ -444,15 +444,12 @@ func TestMapProxy_GetAll(t *testing.T) {
 		for k, _ := range testMap {
 			keys = append(keys, k)
 		}
-		valueList, err := mp.GetAll(keys)
+		valueMap, err := mp.GetAll(keys)
 		if err != nil {
 			t.Fatal(err)
 		}
-		for _, pair := range valueList {
-			key := pair.Key()
-			value := pair.Value()
+		for key, value := range valueMap {
 			expectedValue, found := testMap[key]
-
 			if !found || expectedValue != value {
 				t.Fatalf("Map GetAll failed")
 			}

--- a/tests/proxy/predicates_test.go
+++ b/tests/proxy/predicates_test.go
@@ -203,7 +203,7 @@ func TestOr(t *testing.T) {
 
 func TestRegex(t *testing.T) {
 	localMap, _ := client.GetMap("regexMap")
-	localMap.PutAll(&map[interface{}]interface{}{"06": "ankara", "07": "antalya"})
+	localMap.PutAll(map[interface{}]interface{}{"06": "ankara", "07": "antalya"})
 	rp := Regex("this", "^.*ya$")
 	set, _ := localMap.EntrySetWithPredicate(rp)
 	expecteds := make(map[interface{}]interface{}, 0)


### PR DESCRIPTION
…ry pointers to pointers and return map in GetAll

We were using pointer to a map in PutAll however since maps are passed by reference it was not necessary.
You can see the go map here :
[https://blog.golang.org/go-maps-in-action](https://blog.golang.org/go-maps-in-action)

It says :
```Map types are reference types, like pointers or slices```