### PR TITLE
change adding a new connection Connections place

### DIFF
--- a/internal/connection_manager.go
+++ b/internal/connection_manager.go
@@ -130,7 +130,6 @@ func (connectionManager *ConnectionManager) openNewConnection(address *Address, 
 	if con == nil {
 		return common.NewHazelcastTargetDisconnectedError("target is disconnected", nil)
 	}
-	connectionManager.connections[address.Host()+":"+strconv.Itoa(address.Port())] = con
 	err := connectionManager.clusterAuthenticator(con, asOwner)
 	if err != nil {
 		return err
@@ -173,6 +172,7 @@ func (connectionManager *ConnectionManager) clusterAuthenticator(connection *Con
 			connection.serverHazelcastVersion = parameters.ServerHazelcastVersion
 			connection.endpoint = parameters.Address
 			connection.isOwnerConnection = asOwner
+			connectionManager.connections[connection.endpoint.Host()+":"+strconv.Itoa(connection.endpoint.Port())] = connection
 			if asOwner {
 				connectionManager.ownerAddress.Store(connection.endpoint)
 			}


### PR DESCRIPTION
fixes #93 .
We were adding the connection to connection map right after sending them however  we should have added them after authenticated with the response endpoint. This bug appeared when the response ip address was different than the one sent.