### PR TITLE
return interface instead of data to user

### DIFF
--- a/core/api.go
+++ b/core/api.go
@@ -14,8 +14,6 @@
 
 package core
 
-import . "github.com/hazelcast/go-client/serialization"
-
 type IAddress interface {
 	Host() string
 	Port() int
@@ -51,8 +49,8 @@ type IStackTraceElement interface {
 }
 
 type IEntryView interface {
-	Key() IData
-	Value() IData
+	Key() interface{}
+	Value() interface{}
 	Cost() int64
 	CreationTime() int64
 	ExpirationTime() int64
@@ -65,10 +63,10 @@ type IEntryView interface {
 	Ttl() int64
 }
 type IEntryEvent interface {
-	KeyData() IData
-	ValueData() IData
-	OldValueData() IData
-	MergingValueData() IData
+	Key() interface{}
+	Value() interface{}
+	OldValue() interface{}
+	MergingValue() interface{}
 	EventType() int32
 	Uuid() *string
 }

--- a/internal/protocol/core.go
+++ b/internal/protocol/core.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hazelcast/go-client/core"
 	. "github.com/hazelcast/go-client/internal/common"
 	. "github.com/hazelcast/go-client/internal/serialization"
-	. "github.com/hazelcast/go-client/serialization"
 	"reflect"
 )
 
@@ -117,9 +116,9 @@ func (obj *DistributedObjectInfo) ServiceName() string {
 	return obj.serviceName
 }
 
-type EntryView struct {
-	key                    Data
-	value                  Data
+type DataEntryView struct {
+	keyData                *Data
+	valueData              *Data
 	cost                   int64
 	creationTime           int64
 	expirationTime         int64
@@ -132,11 +131,91 @@ type EntryView struct {
 	ttl                    int64
 }
 
-func (ev1 *EntryView) Key() IData {
+func (ev1 *DataEntryView) KeyData() *Data {
+	return ev1.keyData
+}
+
+func (ev1 *DataEntryView) ValueData() *Data {
+	return ev1.valueData
+}
+
+func (ev1 *DataEntryView) Cost() int64 {
+	return ev1.cost
+}
+
+func (ev1 *DataEntryView) CreationTime() int64 {
+	return ev1.creationTime
+}
+
+func (ev1 *DataEntryView) ExpirationTime() int64 {
+	return ev1.expirationTime
+}
+
+func (ev1 *DataEntryView) Hits() int64 {
+	return ev1.hits
+}
+
+func (ev1 *DataEntryView) LastAccessTime() int64 {
+	return ev1.lastAccessTime
+}
+
+func (ev1 *DataEntryView) LastStoredTime() int64 {
+	return ev1.lastStoredTime
+}
+
+func (ev1 *DataEntryView) LastUpdateTime() int64 {
+	return ev1.lastUpdateTime
+}
+
+func (ev1 *DataEntryView) Version() int64 {
+	return ev1.version
+}
+
+func (ev1 *DataEntryView) EvictionCriteriaNumber() int64 {
+	return ev1.evictionCriteriaNumber
+}
+
+func (ev1 *DataEntryView) Ttl() int64 {
+	return ev1.ttl
+}
+
+type EntryView struct {
+	key                    interface{}
+	value                  interface{}
+	cost                   int64
+	creationTime           int64
+	expirationTime         int64
+	hits                   int64
+	lastAccessTime         int64
+	lastStoredTime         int64
+	lastUpdateTime         int64
+	version                int64
+	evictionCriteriaNumber int64
+	ttl                    int64
+}
+
+func NewEntryView(key interface{}, value interface{}, cost int64, creationTime int64, expirationTime int64, hits int64,
+	lastAccessTime int64, lastStoredTime int64, lastUpdateTime int64, version int64, evictionCriteriaNumber int64, ttl int64) *EntryView {
+	return &EntryView{
+		key:                    key,
+		value:                  value,
+		cost:                   cost,
+		creationTime:           creationTime,
+		expirationTime:         expirationTime,
+		hits:                   hits,
+		lastAccessTime:         lastAccessTime,
+		lastStoredTime:         lastStoredTime,
+		lastUpdateTime:         lastUpdateTime,
+		version:                version,
+		evictionCriteriaNumber: evictionCriteriaNumber,
+		ttl: ttl,
+	}
+}
+func (ev1 *EntryView) Key() interface{} {
 	return ev1.key
 }
 
-func (ev1 *EntryView) Value() IData {
+func (ev1 *EntryView) Value() interface{} {
 	return ev1.value
 }
 
@@ -180,8 +259,8 @@ func (ev1 *EntryView) Ttl() int64 {
 	return ev1.ttl
 }
 
-func (ev1 EntryView) Equal(ev2 EntryView) bool {
-	if !bytes.Equal(ev1.key.Buffer(), ev2.key.Buffer()) || !bytes.Equal(ev1.value.Buffer(), ev2.value.Buffer()) {
+func (ev1 DataEntryView) Equal(ev2 DataEntryView) bool {
+	if !bytes.Equal(ev1.keyData.Buffer(), ev2.keyData.Buffer()) || !bytes.Equal(ev1.valueData.Buffer(), ev2.valueData.Buffer()) {
 		return false
 	}
 	if ev1.cost != ev2.cost || ev1.creationTime != ev2.creationTime || ev1.expirationTime != ev2.expirationTime || ev1.hits != ev2.hits {
@@ -261,28 +340,28 @@ func (st *StackTraceElement) LineNumber() int32 {
 }
 
 type EntryEvent struct {
-	keyData          *Data
-	valueData        *Data
-	oldValueData     *Data
-	mergingValueData *Data
-	eventType        int32
-	uuid             *string
+	key          interface{}
+	value        interface{}
+	oldValue     interface{}
+	mergingValue interface{}
+	eventType    int32
+	uuid         *string
 }
 
-func (entryEvent *EntryEvent) KeyData() IData {
-	return entryEvent.keyData
+func (entryEvent *EntryEvent) Key() interface{} {
+	return entryEvent.key
 }
 
-func (entryEvent *EntryEvent) ValueData() IData {
-	return entryEvent.valueData
+func (entryEvent *EntryEvent) Value() interface{} {
+	return entryEvent.value
 }
 
-func (entryEvent *EntryEvent) OldValueData() IData {
-	return entryEvent.oldValueData
+func (entryEvent *EntryEvent) OldValue() interface{} {
+	return entryEvent.oldValue
 }
 
-func (entryEvent *EntryEvent) MergingValueData() IData {
-	return entryEvent.mergingValueData
+func (entryEvent *EntryEvent) MergingValue() interface{} {
+	return entryEvent.mergingValue
 }
 
 func (entryEvent *EntryEvent) Uuid() *string {
@@ -292,8 +371,8 @@ func (entryEvent *EntryEvent) EventType() int32 {
 	return entryEvent.eventType
 }
 
-func NewEntryEvent(keyData *Data, valueData *Data, oldValueData *Data, mergingValueData *Data, eventType int32, Uuid *string) *EntryEvent {
-	return &EntryEvent{keyData: keyData, valueData: valueData, oldValueData: oldValueData, eventType: eventType, uuid: Uuid}
+func NewEntryEvent(key interface{}, value interface{}, oldValue interface{}, mergingValue interface{}, eventType int32, Uuid *string) *EntryEvent {
+	return &EntryEvent{key: key, value: value, oldValue: oldValue, mergingValue: mergingValue, eventType: eventType, uuid: Uuid}
 }
 
 type MapEvent struct {

--- a/internal/protocol/custom_codec.go
+++ b/internal/protocol/custom_codec.go
@@ -70,6 +70,22 @@ func EntryViewCodecDecode(msg *ClientMessage) *EntryView {
 	entryView.ttl = msg.ReadInt64()
 	return &entryView
 }
+func DataEntryViewCodecDecode(msg *ClientMessage) *DataEntryView {
+	dataEntryView := DataEntryView{}
+	dataEntryView.keyData = msg.ReadData()
+	dataEntryView.valueData = msg.ReadData()
+	dataEntryView.cost = msg.ReadInt64()
+	dataEntryView.creationTime = msg.ReadInt64()
+	dataEntryView.expirationTime = msg.ReadInt64()
+	dataEntryView.hits = msg.ReadInt64()
+	dataEntryView.lastAccessTime = msg.ReadInt64()
+	dataEntryView.lastStoredTime = msg.ReadInt64()
+	dataEntryView.lastUpdateTime = msg.ReadInt64()
+	dataEntryView.version = msg.ReadInt64()
+	dataEntryView.evictionCriteriaNumber = msg.ReadInt64()
+	dataEntryView.ttl = msg.ReadInt64()
+	return &dataEntryView
+}
 
 func UuidCodecEncode(msg *ClientMessage, uuid Uuid) {
 	msg.AppendInt64(uuid.Msb)

--- a/internal/protocol/custom_codec_test.go
+++ b/internal/protocol/custom_codec_test.go
@@ -66,12 +66,12 @@ func TestMemberCodecEncodeDecode(t *testing.T) {
 		t.Errorf("MemberCodecDecode returned a wrong member")
 	}
 }
-func TestEntryViewCodecEncodeDecode(t *testing.T) {
+func TestDataEntryViewCodecEncodeDecode(t *testing.T) {
 	key := "test-key"
 	value := "test-value"
-	entryView := EntryView{}
-	entryView.key = Data{[]byte(key)}
-	entryView.value = Data{[]byte(value)}
+	entryView := DataEntryView{}
+	entryView.keyData = &Data{[]byte(key)}
+	entryView.valueData = &Data{[]byte(value)}
 	entryView.cost = 123123
 	entryView.creationTime = 1212
 	entryView.expirationTime = 12
@@ -82,13 +82,13 @@ func TestEntryViewCodecEncodeDecode(t *testing.T) {
 	entryView.version = 1
 	entryView.evictionCriteriaNumber = 122
 	entryView.ttl = 14555
-	msg := NewClientMessage(nil, EntryViewCalculateSize(&entryView))
-	EntryViewCodecEncode(msg, &entryView)
+	msg := NewClientMessage(nil, DataEntryViewCalculateSize(&entryView))
+	DataEntryViewCodecEncode(msg, &entryView)
 	//Skip the header.
 	for i := 0; i < len(READ_HEADER); i++ {
 		msg.ReadUint8()
 	}
-	if result := EntryViewCodecDecode(msg); !result.Equal(entryView) {
+	if result := DataEntryViewCodecDecode(msg); !result.Equal(entryView) {
 		t.Errorf("EntryViewCodecDecode returned a wrong member")
 	}
 
@@ -100,9 +100,9 @@ func TestEntryViewCodecEncodeDecode(t *testing.T) {
 /*
 	EntryView helper functions
 */
-func EntryViewCodecEncode(msg *ClientMessage, entryView *EntryView) {
-	msg.AppendData(&entryView.key)
-	msg.AppendData(&entryView.value)
+func DataEntryViewCodecEncode(msg *ClientMessage, entryView *DataEntryView) {
+	msg.AppendData(entryView.keyData)
+	msg.AppendData(entryView.valueData)
 	msg.AppendInt64(entryView.cost)
 	//msg.AppendInt64(entryView.Cost)
 	msg.AppendInt64(entryView.creationTime)
@@ -115,10 +115,10 @@ func EntryViewCodecEncode(msg *ClientMessage, entryView *EntryView) {
 	msg.AppendInt64(entryView.evictionCriteriaNumber)
 	msg.AppendInt64(entryView.ttl)
 }
-func EntryViewCalculateSize(ev *EntryView) int {
+func DataEntryViewCalculateSize(ev *DataEntryView) int {
 	dataSize := 0
-	dataSize += DataCalculateSize(&ev.key)
-	dataSize += DataCalculateSize(&ev.value)
+	dataSize += DataCalculateSize(ev.keyData)
+	dataSize += DataCalculateSize(ev.valueData)
 	dataSize += 10 * INT64_SIZE_IN_BYTES
 	return dataSize
 }

--- a/internal/protocol/map_getentryview.go
+++ b/internal/protocol/map_getentryview.go
@@ -20,7 +20,7 @@ import (
 )
 
 type MapGetEntryViewResponseParameters struct {
-	Response *EntryView
+	Response *DataEntryView
 }
 
 func MapGetEntryViewCalculateSize(name *string, key *Data, threadId int64) int {
@@ -49,7 +49,7 @@ func MapGetEntryViewDecodeResponse(clientMessage *ClientMessage) *MapGetEntryVie
 	parameters := new(MapGetEntryViewResponseParameters)
 
 	if !clientMessage.ReadBool() {
-		parameters.Response = EntryViewCodecDecode(clientMessage)
+		parameters.Response = DataEntryViewCodecDecode(clientMessage)
 	}
 	return parameters
 }

--- a/tests/proxy/map_test.go
+++ b/tests/proxy/map_test.go
@@ -464,6 +464,8 @@ func TestMapProxy_GetEntryView(t *testing.T) {
 	mp.Put("key", "newValue")
 
 	entryView, err := mp.GetEntryView("key")
+	AssertEqualf(t, err, entryView.Key(), "key", "Map GetEntryView returned a wrong view.")
+	AssertEqualf(t, err, entryView.Value(), "newValue", "Map GetEntryView returned a wrong view.")
 	AssertEqualf(t, err, entryView.Hits(), int64(2), "Map GetEntryView returned a wrong view.")
 	AssertEqualf(t, err, entryView.EvictionCriteriaNumber(), int64(0), "Map GetEntryView returned a wrong view.")
 	AssertEqualf(t, err, entryView.Version(), int64(1), "Map GetEntryView returned a wrong view.")


### PR DESCRIPTION
In IEntryView and  IEntryEvent instead of returning IData to user,
return interfaces so that user can use them. I changed the corresponding
files to make this change. I added DataEntryView for codecs and then
converted it to EntryView in the corresponding method in map.go