### PR TITLE
fix some bugs in invocation service

### DIFF
--- a/core/errors.go
+++ b/core/errors.go
@@ -146,3 +146,13 @@ func NewHazelcastAuthenticationError(message string, cause error) *HazelcastAuth
 func NewHazelcastTimeoutError(message string, cause error) *HazelcastTimeoutError {
 	return &HazelcastTimeoutError{&HazelcastErrorType{message: message, cause: cause}}
 }
+
+// NewHazelcastInstanceNotActiveError returns HazelcastInstanceNotActiveError
+func NewHazelcastInstanceNotActiveError(message string, cause error) *HazelcastInstanceNotActiveError {
+	return &HazelcastInstanceNotActiveError{&HazelcastErrorType{message: message, cause: cause}}
+}
+
+// NewHazelcastTargetNotMemberError returns HazelcastTargetNotMemberError
+func NewHazelcastTargetNotMemberError(message string, cause error) *HazelcastTargetNotMemberError {
+	return &HazelcastTargetNotMemberError{&HazelcastErrorType{message: message, cause: cause}}
+}

--- a/internal/connection.go
+++ b/internal/connection.go
@@ -16,7 +16,6 @@ package internal
 
 import (
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"github.com/hazelcast/hazelcast-go-client/internal/common"
 	. "github.com/hazelcast/hazelcast-go-client/internal/protocol"
@@ -52,8 +51,8 @@ type Connection struct {
 
 func NewConnection(address *Address, responseChannel chan *ClientMessage, sendingError chan int64, connectionId int64, connectionManager *ConnectionManager) *Connection {
 	connection := Connection{pending: make(chan *ClientMessage, 1),
-		received:             make(chan *ClientMessage, 0),
-		closed:               make(chan bool, 0),
+		received:             make(chan *ClientMessage, 1),
+		closed:               make(chan bool, 1),
 		clientMessageBuilder: &ClientMessageBuilder{responseChannel: responseChannel, incompleteMessages: make(map[int64]*ClientMessage)}, sendingError: sendingError,
 		heartBeating:      true,
 		readBuffer:        make([]byte, 0),
@@ -79,7 +78,7 @@ func NewConnection(address *Address, responseChannel chan *ClientMessage, sendin
 }
 
 func (connection *Connection) IsAlive() bool {
-	return connection.status == 0
+	return atomic.LoadInt32(&connection.status) == 0
 }
 func (connection *Connection) writePool() {
 	//Writer process
@@ -97,12 +96,16 @@ func (connection *Connection) writePool() {
 	}
 }
 
-func (connection *Connection) Send(clientMessage *ClientMessage) error {
+func (connection *Connection) Send(clientMessage *ClientMessage) bool {
+	if !connection.IsAlive() {
+		return false
+	}
 	select {
-	case connection.pending <- clientMessage:
-		return nil
 	case <-connection.closed:
-		return errors.New("Connection Closed.")
+		return false
+	case connection.pending <- clientMessage:
+		return true
+
 	}
 }
 

--- a/internal/connection_manager.go
+++ b/internal/connection_manager.go
@@ -121,8 +121,10 @@ func (connectionManager *ConnectionManager) GetOrConnect(address *Address, asOwn
 			return
 		}
 		//Open new connection
-		err <- connectionManager.openNewConnection(address, ch, asOwner)
-
+		error := connectionManager.openNewConnection(address, ch, asOwner)
+		if error != nil {
+			err <- error
+		}
 	}()
 	return ch, err
 }

--- a/internal/error.go
+++ b/internal/error.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"github.com/hazelcast/hazelcast-go-client/core"
+	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol"
+)
+
+func CreateHazelcastError(err *protocol.Error) core.HazelcastError {
+	switch ErrorCode(err.ErrorCode()) {
+	case ERROR_CODE_AUTHENTICATION:
+		return core.NewHazelcastAuthenticationError(err.Message(), nil)
+	case ERROR_CODE_HAZELCAST_INSTANCE_NOT_ACTIVE:
+		return core.NewHazelcastInstanceNotActiveError(err.Message(), nil)
+	case ERROR_CODE_HAZELCAST_SERIALIZATION:
+		return core.NewHazelcastSerializationError(err.Message(), nil)
+	case ERROR_CODE_TARGET_DISCONNECTED:
+		return core.NewHazelcastTargetDisconnectedError(err.Message(), nil)
+	case ERROR_CODE_TARGET_NOT_MEMBER:
+		return core.NewHazelcastTargetNotMemberError(err.Message(), nil)
+	}
+	return core.NewHazelcastErrorType(err.Message(), nil)
+}


### PR DESCRIPTION
This pr fixes problems related to notSentInvocations, which happens when
a node is shutdown and an invocation was not sent. When server returns
an error the client will use handleError method instead of returning the
error directly to user. Unused invokeOnTarget method is removed, it will
be added back when necessary.