### PR TITLE
fix a bug in error handling

### DIFF
--- a/internal/invocation.go
+++ b/internal/invocation.go
@@ -356,9 +356,6 @@ func (invocationService *InvocationService) handleException(invocation *Invocati
 		return
 	}
 	if invocationService.shouldRetryInvocation(invocation, err) {
-		if invocation.boundConnection != nil {
-			return
-		}
 		go func() {
 			if invocationService.isShutdown.Load().(bool) {
 				invocation.err <- NewHazelcastClientNotActiveError(err.Error(), err)


### PR DESCRIPTION
After investigating the issues #139  #109 with @furkansenharputlu. We found that there was a bug in `handleException`, when there was an error for an invocation with bound connection this method wasn't returning any error so client was waiting for the response forever. To be more specific, server was returning 'HazelcastInstanceNotActiveError' and `handleException` method was terminating without returning any error or response to the corresponding invocation. 