### PR TITLE
remove members while shutting down

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -93,6 +93,7 @@ func (client *HazelcastClient) Shutdown() {
 		client.PartitionService.shutdown()
 		client.InvocationService.shutdown()
 		client.HeartBeatService.shutdown()
+		client.ClusterService.shutdown()
 		client.LifecycleService.fireLifecycleEvent(LIFECYCLE_STATE_SHUTDOWN)
 	}
 }

--- a/internal/cluster.go
+++ b/internal/cluster.go
@@ -325,3 +325,7 @@ func (clusterService *ClusterService) onConnectionClosed(connection *Connection,
 func (clusterSerice *ClusterService) onConnectionOpened(connection *Connection) {
 
 }
+
+func (clusterService *ClusterService) shutdown() {
+	clusterService.members.Store(make([]Member, 0))
+}


### PR DESCRIPTION
While shutting down members we should clear members from clusterService. GetMemberList was returning the last list instead of returning zero after shutting down the client.


