### PR TITLE
changes go client client type id string to  so it has a length of 3

### DIFF
--- a/internal/protocol/consts.go
+++ b/internal/protocol/consts.go
@@ -19,7 +19,7 @@ import (
 	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
-const CLIENT_TYPE = "GO"
+const CLIENT_TYPE = "GOO"
 
 func DataCalculateSize(d *Data) int {
 	return len(d.Buffer()) + INT_SIZE_IN_BYTES


### PR DESCRIPTION
along with https://github.com/hazelcast/hazelcast/pull/12150/files

fixes https://github.com/hazelcast/hazelcast-go-client/issues/142