### PR TITLE
serialize int as int64

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ You can also refer to Hazelcast Go [API Documentation](https://godoc.org/github.
 
 Hazelcast needs to serialize objects in order to be able to keep them in the server memory. For primitive types, it uses Hazelcast native serialization. For other complex types (e.g. Go objects), it uses Gob serialization.
 
+> **NOTE: `int` and `[]int` types in Go Language are serialized as `int64` and `[]int64` respectively by Hazelcast Serialization.**
+
 For example, when you try to query your data using predicates, this querying is handled on the server side so Hazelcast does not have to bring all data to the client but only the relevant entries. Otherwise, there would be a lot of unneccessary data traffic between the client and the server and the performance would severely drop.
 Because predicates run on the server side, the server should be able to reason about your objects. That is why you need to implement serialization on the server side.
 

--- a/internal/serialization/default_serializer.go
+++ b/internal/serialization/default_serializer.go
@@ -174,7 +174,11 @@ func (*Integer64Serializer) Read(input DataInput) (interface{}, error) {
 }
 
 func (*Integer64Serializer) Write(output DataOutput, i interface{}) error {
-	output.WriteInt64(i.(int64))
+	val, ok := i.(int64)
+	if !ok {
+		val = int64(i.(int))
+	}
+	output.WriteInt64(val)
 	return nil
 }
 
@@ -309,7 +313,16 @@ func (*Integer64ArraySerializer) Read(input DataInput) (interface{}, error) {
 }
 
 func (*Integer64ArraySerializer) Write(output DataOutput, i interface{}) error {
-	output.WriteInt64Array(i.([]int64))
+	val, ok := i.([]int64)
+	if !ok {
+		tmp := i.([]int)
+		length := len(tmp)
+		val = make([]int64, length)
+		for k := 0; k < length; k++ {
+			val[k] = int64(tmp[k])
+		}
+	}
+	output.WriteInt64Array(val)
 	return nil
 }
 

--- a/internal/serialization/serialization.go
+++ b/internal/serialization/serialization.go
@@ -21,6 +21,7 @@ import (
 	. "github.com/hazelcast/hazelcast-go-client/internal/predicates"
 	. "github.com/hazelcast/hazelcast-go-client/serialization"
 	"reflect"
+	"strconv"
 )
 
 ////// SerializationService ///////////
@@ -206,7 +207,11 @@ func (service *SerializationService) registerGlobalSerializer(globalSerializer S
 }
 
 func (service *SerializationService) getIdByObject(obj interface{}) *int32 {
-	if val, ok := service.nameToId[reflect.TypeOf(obj).String()]; ok {
+	typ := reflect.TypeOf(obj).String()
+	if typ == "int" || typ == "[]int" {
+		typ = typ + strconv.Itoa(64)
+	}
+	if val, ok := service.nameToId[typ]; ok {
 		return &val
 	}
 	return nil

--- a/internal/serialization/serialization_test.go
+++ b/internal/serialization/serialization_test.go
@@ -243,3 +243,32 @@ func TestGobSerializer(t *testing.T) {
 	}
 
 }
+
+func TestInt64SerializerWithInt(t *testing.T) {
+	var id int = 15
+	config := NewSerializationConfig()
+	service := NewSerializationService(config)
+	data, _ := service.ToData(id)
+	ret, _ := service.ToObject(data)
+
+	if !reflect.DeepEqual(int64(id), ret) {
+		t.Errorf("int type serialization failed")
+	}
+}
+
+func TestInt64ArraySerializerWithIntArray(t *testing.T) {
+	var ids []int = []int{15, 10, 20, 12, 35}
+	config := NewSerializationConfig()
+	service := NewSerializationService(config)
+	data, _ := service.ToData(ids)
+	ret, _ := service.ToObject(data)
+
+	var ids64 []int64 = make([]int64, 5)
+	for k := 0; k < 5; k++ {
+		ids64[k] = int64(ids[k])
+	}
+
+	if !reflect.DeepEqual(ids64, ret) {
+		t.Errorf("[]int type serialization failed")
+	}
+}

--- a/tests/proxy/map_test.go
+++ b/tests/proxy/map_test.go
@@ -80,6 +80,15 @@ func TestMapProxy_SinglePutGet(t *testing.T) {
 	mp.Clear()
 }
 
+func TestMapProxy_SinglePutGetInt(t *testing.T) {
+	testKey := 1
+	testValue := 25
+	mp.Put(testKey, testValue)
+	res, err := mp.Get(testKey)
+	AssertEqualf(t, err, res, int64(testValue), "get returned a wrong value")
+	mp.Clear()
+}
+
 func TestMapProxy_PutWithNilKey(t *testing.T) {
 	testValue := "testingValue"
 	_, err := mp.Put(nil, testValue)


### PR DESCRIPTION
The `int` type is usually 32 bits wide on 32-bit systems and 64 bits wide on 64-bit systems. Therefore, we decided it to serialize as `int64` type.