### PR TITLE
add validateAndSerialize methods to simplify proxies

### DIFF
--- a/core/IMap.go
+++ b/core/IMap.go
@@ -224,7 +224,7 @@ type IMap interface {
 
 	// PutAll copies all of the mappings from the specified map to this map. No atomicity guarantees are
 	// given. In the case of a failure, some of the key-value tuples may get written, while others are not.
-	PutAll(mp map[interface{}]interface{}) (err error)
+	PutAll(entries map[interface{}]interface{}) (err error)
 
 	// KeySet returns a slice clone of the keys contained in this map.
 	// Warning:

--- a/core/errors.go
+++ b/core/errors.go
@@ -97,6 +97,16 @@ type HazelcastIOError struct {
 	*HazelcastErrorType
 }
 
+// HazelcastNilError is returned when a nil argument has been passed to a method.
+type HazelcastNilPointerError struct {
+	*HazelcastErrorType
+}
+
+// NewHazelcastNilPointerError returns HazelcastNilPointerError
+func NewHazelcastNilPointerError(message string, cause error) *HazelcastNilPointerError {
+	return &HazelcastNilPointerError{&HazelcastErrorType{message: message, cause: cause}}
+}
+
 // HazelcastIllegalStateError returns HazelcastIOError.
 func NewHazelcastIOError(message string, cause error) *HazelcastIOError {
 	return &HazelcastIOError{&HazelcastErrorType{message: message, cause: cause}}

--- a/internal/common/consts.go
+++ b/internal/common/consts.go
@@ -201,11 +201,12 @@ const (
 	ENTRYEVENT_INVALIDATION int32 = 256
 )
 const (
-	NIL_KEY_IS_NOT_ALLOWED        string = "Nil key is not allowed!"
-	NIL_KEYS_ARE_NOT_ALLOWED      string = "Nil keys collection is not allowed!"
-	NIL_VALUE_IS_NOT_ALLOWED      string = "Nil value is not allowed!"
-	NIL_PREDICATE_IS_NOT_ALLOWED  string = "Predicate should not be null!"
-	NIL_LISTENER_IS_NOT_ALLOWED   string = "Nil listener is not allowed!"
-	NIL_AGGREGATOR_IS_NOT_ALLOWED string = "Aggregator should not be null!"
-	NIL_PROJECTION_IS_NOT_ALLOWED string = "Projection should not be null!"
+	NIL_KEY_IS_NOT_ALLOWED        string = "nil key is not allowed"
+	NIL_KEYS_ARE_NOT_ALLOWED      string = "nil keys collection is not allowed"
+	NIL_VALUE_IS_NOT_ALLOWED      string = "nil value is not allowed"
+	NIL_PREDICATE_IS_NOT_ALLOWED  string = "predicate should not be nil"
+	NIL_MAP_IS_NOT_ALLOWED        string = "nil map is not allowed"
+	NIL_LISTENER_IS_NOT_ALLOWED   string = "nil listener is not allowed"
+	NIL_AGGREGATOR_IS_NOT_ALLOWED string = "aggregator should not be nil"
+	NIL_PROJECTION_IS_NOT_ALLOWED string = "projection should not be nil"
 )

--- a/internal/proxy.go
+++ b/internal/proxy.go
@@ -15,6 +15,8 @@
 package internal
 
 import (
+	"github.com/hazelcast/hazelcast-go-client/core"
+	. "github.com/hazelcast/hazelcast-go-client/internal/common"
 	. "github.com/hazelcast/hazelcast-go-client/internal/protocol"
 	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
@@ -39,6 +41,56 @@ func (proxy *proxy) PartitionKey() string {
 }
 func (proxy *proxy) ServiceName() string {
 	return *proxy.serviceName
+}
+
+func (proxy *proxy) validateAndSerialize(arg1 interface{}) (arg1Data *Data, err error) {
+	if arg1 == nil {
+		return nil, core.NewHazelcastNilPointerError(NIL_KEY_IS_NOT_ALLOWED, nil)
+	}
+	arg1Data, err = proxy.ToData(arg1)
+	return
+}
+
+func (proxy *proxy) validateAndSerialize2(arg1 interface{}, arg2 interface{}) (arg1Data *Data, arg2Data *Data, err error) {
+	if arg1 == nil {
+		return nil, nil, core.NewHazelcastNilPointerError(NIL_KEY_IS_NOT_ALLOWED, nil)
+	}
+	if arg2 == nil {
+		return nil, nil, core.NewHazelcastNilPointerError(NIL_VALUE_IS_NOT_ALLOWED, nil)
+	}
+	arg1Data, err = proxy.ToData(arg1)
+	if err != nil {
+		return
+	}
+	arg2Data, err = proxy.ToData(arg2)
+	return
+}
+
+func (proxy *proxy) validateAndSerialize3(arg1 interface{}, arg2 interface{}, arg3 interface{}) (arg1Data *Data, arg2Data *Data, arg3Data *Data, err error) {
+	if arg1 == nil {
+		return nil, nil, nil, core.NewHazelcastNilPointerError(NIL_KEY_IS_NOT_ALLOWED, nil)
+	}
+	if arg2 == nil || arg3 == nil {
+		return nil, nil, nil, core.NewHazelcastNilPointerError(NIL_VALUE_IS_NOT_ALLOWED, nil)
+	}
+	arg1Data, err = proxy.ToData(arg1)
+	if err != nil {
+		return
+	}
+	arg2Data, err = proxy.ToData(arg2)
+	if err != nil {
+		return
+	}
+	arg3Data, err = proxy.ToData(arg3)
+	return
+}
+
+func (proxy *proxy) validateAndSerializePredicate(arg1 interface{}) (arg1Data *Data, err error) {
+	if arg1 == nil {
+		return nil, core.NewHazelcastSerializationError(NIL_PREDICATE_IS_NOT_ALLOWED, nil)
+	}
+	arg1Data, err = proxy.ToData(arg1)
+	return
 }
 
 func (proxy *proxy) InvokeOnKey(request *ClientMessage, keyData *Data) (*ClientMessage, error) {


### PR DESCRIPTION
This PR adds ValidateAndSerialize helper methods so that proxies can be simplified. 
This PR also changes the errors to HazelcastErrors.

