### PR TITLE
refactor predicates

### DIFF
--- a/core/predicates/predicates.go
+++ b/core/predicates/predicates.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package core
+package predicates
 
 import (
 	. "github.com/hazelcast/hazelcast-go-client/internal/predicates"

--- a/samples/map/predicate/predicate_example.go
+++ b/samples/map/predicate/predicate_example.go
@@ -17,7 +17,7 @@ package main
 import (
 	"fmt"
 	"github.com/hazelcast/hazelcast-go-client"
-	"github.com/hazelcast/hazelcast-go-client/core"
+	"github.com/hazelcast/hazelcast-go-client/core/predicates"
 	"strconv"
 )
 
@@ -35,7 +35,7 @@ func main() {
 		mp.Put("key"+strconv.Itoa(i), int32(i))
 	}
 
-	betweenPredicate := core.Between("this", int32(5), int32(35))
+	betweenPredicate := predicates.Between("this", int32(5), int32(35))
 
 	set, err := mp.EntrySetWithPredicate(betweenPredicate)
 	if err != nil {

--- a/samples/map_soak.go
+++ b/samples/map_soak.go
@@ -18,6 +18,7 @@ import (
 	"flag"
 	"github.com/hazelcast/hazelcast-go-client"
 	"github.com/hazelcast/hazelcast-go-client/core"
+	"github.com/hazelcast/hazelcast-go-client/core/predicates"
 	. "github.com/hazelcast/hazelcast-go-client/serialization"
 	"log"
 	"math/rand"
@@ -77,7 +78,7 @@ func startMapSoak() {
 						log.Println("error in Put() ", err)
 					}
 				} else if op < 80 {
-					_, err := mp.ValuesWithPredicate(core.Between("this", int32(0), int32(10)))
+					_, err := mp.ValuesWithPredicate(predicates.Between("this", int32(0), int32(10)))
 					if err != nil {
 						log.Println("error in ValuesWithPredicate() ", err)
 					}

--- a/samples/org_website_samples/query_sample.go
+++ b/samples/org_website_samples/query_sample.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"github.com/hazelcast/hazelcast-go-client"
 	. "github.com/hazelcast/hazelcast-go-client/core"
+	. "github.com/hazelcast/hazelcast-go-client/core/predicates"
 	"github.com/hazelcast/hazelcast-go-client/serialization"
 )
 

--- a/tests/proxy/map/map_member_down/map_member_down_test.go
+++ b/tests/proxy/map/map_member_down/map_member_down_test.go
@@ -17,6 +17,7 @@ package map_member_down
 import (
 	"github.com/hazelcast/hazelcast-go-client"
 	. "github.com/hazelcast/hazelcast-go-client/core"
+	. "github.com/hazelcast/hazelcast-go-client/core/predicates"
 	. "github.com/hazelcast/hazelcast-go-client/rc"
 	. "github.com/hazelcast/hazelcast-go-client/tests"
 	"log"

--- a/tests/proxy/map/map_test.go
+++ b/tests/proxy/map/map_test.go
@@ -17,6 +17,7 @@ package _map
 import (
 	"github.com/hazelcast/hazelcast-go-client"
 	. "github.com/hazelcast/hazelcast-go-client/core"
+	"github.com/hazelcast/hazelcast-go-client/core/predicates"
 	"github.com/hazelcast/hazelcast-go-client/internal/common"
 	. "github.com/hazelcast/hazelcast-go-client/rc"
 	. "github.com/hazelcast/hazelcast-go-client/serialization"
@@ -188,7 +189,7 @@ func TestMapProxy_RemoveAll(t *testing.T) {
 			testMap["testingKey"+strconv.Itoa(i)] = int32(i)
 		}
 	}
-	mp.RemoveAll(GreaterThan("this", int32(40)))
+	mp.RemoveAll(predicates.GreaterThan("this", int32(40)))
 	entryList, _ := mp.EntrySet()
 	if len(testMap) != len(entryList) {
 		t.Fatalf("map RemoveAll failed")
@@ -635,7 +636,7 @@ func TestMapProxy_KeySetWihPredicate(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		mp.Put(strconv.Itoa(i), int32(i))
 	}
-	keySet, _ := mp.KeySetWithPredicate(Equal("this", "5"))
+	keySet, _ := mp.KeySetWithPredicate(predicates.Equal("this", "5"))
 	if len(keySet) != 1 || keySet[0].(string) != expected {
 		t.Fatalf("map KeySetWithPredicate failed")
 	}
@@ -669,7 +670,7 @@ func TestMapProxy_ValuesWithPredicate(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		mp.Put(strconv.Itoa(i), strconv.Itoa(i))
 	}
-	values, _ := mp.ValuesWithPredicate(Equal("this", "5"))
+	values, _ := mp.ValuesWithPredicate(predicates.Equal("this", "5"))
 	if len(values) != 1 || values[0].(string) != expected {
 		t.Fatalf("map ValuesWithPredicate failed")
 	}
@@ -697,7 +698,7 @@ func TestMapProxy_EntrySetWithPredicate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	} else {
-		entryList, err := mp.EntrySetWithPredicate(Sql("this == wantedValue"))
+		entryList, err := mp.EntrySetWithPredicate(predicates.Sql("this == wantedValue"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -926,7 +927,7 @@ func TestMapProxy_AddEntryListenerClear(t *testing.T) {
 func TestMapProxy_AddEntryListenerWithPredicate(t *testing.T) {
 	var wg *sync.WaitGroup = new(sync.WaitGroup)
 	entryListener := &entryListener{wg: wg}
-	registrationId, err := mp.AddEntryListenerWithPredicate(entryListener, Equal("this", "value"), true)
+	registrationId, err := mp.AddEntryListenerWithPredicate(entryListener, predicates.Equal("this", "value"), true)
 	AssertEqual(t, err, nil, nil)
 	wg.Add(1)
 	mp.Put("key123", "value")
@@ -956,7 +957,7 @@ func TestMapProxy_AddEntryListenerToKey(t *testing.T) {
 func TestMapProxy_AddEntryListenerToKeyWithPredicate(t *testing.T) {
 	var wg *sync.WaitGroup = new(sync.WaitGroup)
 	entryListener := &entryListener{wg: wg}
-	registrationId, err := mp.AddEntryListenerToKeyWithPredicate(entryListener, Equal("this", "value1"), "key1", true)
+	registrationId, err := mp.AddEntryListenerToKeyWithPredicate(entryListener, predicates.Equal("this", "value1"), "key1", true)
 	AssertEqual(t, err, nil, nil)
 	wg.Add(1)
 	mp.Put("key1", "value1")
@@ -1062,7 +1063,7 @@ func TestMapProxy_ExecuteOnEntriesWithPredicate(t *testing.T) {
 		testValue := int32(i)
 		mp2.Put(testKey, testValue)
 	}
-	result, err := mp2.ExecuteOnEntriesWithPredicate(processor, GreaterThan("this", int32(6)))
+	result, err := mp2.ExecuteOnEntriesWithPredicate(processor, predicates.GreaterThan("this", int32(6)))
 	if len(result) != 3 {
 		t.Fatal("ExecuteOnEntriesWithPredicate failed")
 	}

--- a/tests/proxy/map/predicates_test.go
+++ b/tests/proxy/map/predicates_test.go
@@ -16,7 +16,7 @@ package _map
 
 import (
 	. "github.com/hazelcast/hazelcast-go-client/config"
-	. "github.com/hazelcast/hazelcast-go-client/core"
+	"github.com/hazelcast/hazelcast-go-client/core/predicates"
 	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
 	"github.com/hazelcast/hazelcast-go-client/serialization"
 	"log"
@@ -76,14 +76,14 @@ func testPredicate(t *testing.T, predicate serialization.IPredicate, expecteds m
 func TestSql(t *testing.T) {
 	expecteds := make(map[interface{}]interface{}, 0)
 	expecteds["key10"] = int32(10)
-	sql := Sql("this == 10")
+	sql := predicates.Sql("this == 10")
 	testSerialization(t, sql)
 	testPredicate(t, sql, expecteds)
 }
 
 func TestAnd(t *testing.T) {
 	expecteds := make(map[interface{}]interface{}, 0)
-	and := And(Equal("this", int32(10)), Equal("this", int32(11)))
+	and := predicates.And(predicates.Equal("this", int32(10)), predicates.Equal("this", int32(11)))
 	testSerialization(t, and)
 	testPredicate(t, and, expecteds)
 }
@@ -93,7 +93,7 @@ func TestBetween(t *testing.T) {
 	for i := 5; i < 29; i++ {
 		expecteds["key"+strconv.Itoa(i)] = int32(i)
 	}
-	between := Between("this", int32(5), int32(28))
+	between := predicates.Between("this", int32(5), int32(28))
 	testSerialization(t, between)
 	testPredicate(t, between, expecteds)
 }
@@ -102,7 +102,7 @@ func TestGreaterThan(t *testing.T) {
 	expecteds := make(map[interface{}]interface{}, 0)
 	expecteds["key48"] = int32(48)
 	expecteds["key49"] = int32(49)
-	greaterThan := GreaterThan("this", int32(47))
+	greaterThan := predicates.GreaterThan("this", int32(47))
 	testSerialization(t, greaterThan)
 	testPredicate(t, greaterThan, expecteds)
 }
@@ -112,7 +112,7 @@ func TestGreaterEqual(t *testing.T) {
 	expecteds["key47"] = int32(47)
 	expecteds["key48"] = int32(48)
 	expecteds["key49"] = int32(49)
-	greaterEqual := GreaterEqual("this", int32(47))
+	greaterEqual := predicates.GreaterEqual("this", int32(47))
 	testSerialization(t, greaterEqual)
 	testPredicate(t, greaterEqual, expecteds)
 }
@@ -123,7 +123,7 @@ func TestLessThan(t *testing.T) {
 	expecteds["key1"] = int32(1)
 	expecteds["key2"] = int32(2)
 	expecteds["key3"] = int32(3)
-	lessThan := LessThan("this", int32(4))
+	lessThan := predicates.LessThan("this", int32(4))
 	testSerialization(t, lessThan)
 	testPredicate(t, lessThan, expecteds)
 }
@@ -135,7 +135,7 @@ func TestLessEqual(t *testing.T) {
 	expecteds["key2"] = int32(2)
 	expecteds["key3"] = int32(3)
 	expecteds["key4"] = int32(4)
-	lessEqual := LessEqual("this", int32(4))
+	lessEqual := predicates.LessEqual("this", int32(4))
 	testSerialization(t, lessEqual)
 	testPredicate(t, lessEqual, expecteds)
 }
@@ -146,7 +146,7 @@ func TestLike(t *testing.T) {
 	localMap.Put("temp1", "tempval1")
 	localMap.Put("temp2", "val2")
 	localMap.Put("temp3", "tempval3")
-	like := Like("this", "tempv%")
+	like := predicates.Like("this", "tempv%")
 	testSerialization(t, like)
 	set, err := localMap.EntrySetWithPredicate(like)
 	if err != nil {
@@ -177,7 +177,7 @@ func TestILike(t *testing.T) {
 	localMap.Put("TEMP", "TeMPVAL")
 	localMap.Put("temp1", "teMpvAl1")
 	localMap.Put("TEMP1", "TEMpVAL1")
-	ilike := ILike("this", "tempv%")
+	ilike := predicates.ILike("this", "tempv%")
 	testSerialization(t, ilike)
 	set, err := localMap.EntrySetWithPredicate(ilike)
 	if err != nil {
@@ -207,7 +207,7 @@ func TestIn(t *testing.T) {
 	expecteds := make(map[interface{}]interface{}, 0)
 	expecteds["key48"] = int32(48)
 	expecteds["key49"] = int32(49)
-	in := In("this", int32(48), int32(49), int32(50), int32(51), int32(52))
+	in := predicates.In("this", int32(48), int32(49), int32(50), int32(51), int32(52))
 	testSerialization(t, in)
 	testPredicate(t, in, expecteds)
 }
@@ -217,7 +217,7 @@ func TestInstanceOf(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		expecteds["key"+strconv.Itoa(i)] = int32(i)
 	}
-	instanceOf := InstanceOf("java.lang.Integer")
+	instanceOf := predicates.InstanceOf("java.lang.Integer")
 	testSerialization(t, instanceOf)
 	testPredicate(t, instanceOf, expecteds)
 }
@@ -225,7 +225,7 @@ func TestInstanceOf(t *testing.T) {
 func TestEqual(t *testing.T) {
 	expecteds := make(map[interface{}]interface{}, 0)
 	expecteds["key1"] = int32(1)
-	equal := Equal("this", int32(1))
+	equal := predicates.Equal("this", int32(1))
 	testSerialization(t, equal)
 	testPredicate(t, equal, expecteds)
 }
@@ -235,7 +235,7 @@ func TestNotEqual(t *testing.T) {
 	for i := 0; i < 49; i++ {
 		expecteds["key"+strconv.Itoa(i)] = int32(i)
 	}
-	notEqual := NotEqual("this", int32(49))
+	notEqual := predicates.NotEqual("this", int32(49))
 	testSerialization(t, notEqual)
 	testPredicate(t, notEqual, expecteds)
 }
@@ -244,7 +244,7 @@ func TestNot(t *testing.T) {
 	expecteds := make(map[interface{}]interface{}, 0)
 	expecteds["key0"] = int32(0)
 	expecteds["key1"] = int32(1)
-	not := Not(GreaterEqual("this", int32(2)))
+	not := predicates.Not(predicates.GreaterEqual("this", int32(2)))
 	testSerialization(t, not)
 	testPredicate(t, not, expecteds)
 }
@@ -254,7 +254,8 @@ func TestOr(t *testing.T) {
 	expecteds["key0"] = int32(0)
 	expecteds["key35"] = int32(35)
 	expecteds["key49"] = int32(49)
-	or := Or(GreaterEqual("this", int32(49)), Equal("this", int32(35)), LessEqual("this", int32(0)))
+	or := predicates.Or(predicates.GreaterEqual("this", int32(49)),
+		predicates.Equal("this", int32(35)), predicates.LessEqual("this", int32(0)))
 	testSerialization(t, or)
 	testPredicate(t, or, expecteds)
 }
@@ -262,7 +263,7 @@ func TestOr(t *testing.T) {
 func TestRegex(t *testing.T) {
 	localMap, _ := client.GetMap("regexMap")
 	localMap.PutAll(map[interface{}]interface{}{"06": "ankara", "07": "antalya"})
-	rp := Regex("this", "^.*ya$")
+	rp := predicates.Regex("this", "^.*ya$")
 	testSerialization(t, rp)
 	set, _ := localMap.EntrySetWithPredicate(rp)
 	expecteds := make(map[interface{}]interface{}, 0)
@@ -279,7 +280,7 @@ func TestRegex(t *testing.T) {
 
 func TestFalse(t *testing.T) {
 	expecteds := make(map[interface{}]interface{}, 0)
-	false := False()
+	false := predicates.False()
 	testSerialization(t, false)
 	testPredicate(t, false, expecteds)
 }
@@ -289,7 +290,7 @@ func TestTrue(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		expecteds["key"+strconv.Itoa(i)] = int32(i)
 	}
-	true := True()
+	true := predicates.True()
 	testSerialization(t, true)
 	testPredicate(t, true, expecteds)
 }

--- a/tests/proxy/replicated_map/replicated_map_test.go
+++ b/tests/proxy/replicated_map/replicated_map_test.go
@@ -17,6 +17,7 @@ package replicated_map
 import (
 	"github.com/hazelcast/hazelcast-go-client"
 	"github.com/hazelcast/hazelcast-go-client/core"
+	"github.com/hazelcast/hazelcast-go-client/core/predicates"
 	. "github.com/hazelcast/hazelcast-go-client/rc"
 	. "github.com/hazelcast/hazelcast-go-client/tests"
 	"log"
@@ -341,7 +342,7 @@ func TestReplicatedMapProxy_AddEntryListenerWithPredicate(t *testing.T) {
 	defer rmp.Clear()
 	var wg *sync.WaitGroup = new(sync.WaitGroup)
 	entryListener := &entryListener{wg: wg}
-	registrationId, err := rmp.AddEntryListenerWithPredicate(entryListener, core.Equal("this", "value"))
+	registrationId, err := rmp.AddEntryListenerWithPredicate(entryListener, predicates.Equal("this", "value"))
 	defer rmp.RemoveEntryListener(registrationId)
 	AssertEqual(t, err, nil, nil)
 	wg.Add(1)
@@ -380,7 +381,7 @@ func TestReplicatedMapProxy_AddEntryListenerToKey(t *testing.T) {
 func TestReplicatedMapProxy_AddEntryListenerToKeyWithPredicate(t *testing.T) {
 	var wg *sync.WaitGroup = new(sync.WaitGroup)
 	entryListener := &entryListener{wg: wg}
-	registrationId, err := rmp.AddEntryListenerToKeyWithPredicate(entryListener, core.Equal("this", "value1"), "key1")
+	registrationId, err := rmp.AddEntryListenerToKeyWithPredicate(entryListener, predicates.Equal("this", "value1"), "key1")
 	AssertEqual(t, err, nil, nil)
 	wg.Add(1)
 	rmp.Put("key1", "value1")


### PR DESCRIPTION
This pr moves predicates to `core/predicates` from `core` so that they can be used as:
``` predicates.And()```
instead of 
```core.And()```
