### PR TITLE
combine running tests and add dependencies in build sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,7 @@
 
 gofmt -d . 2>&1 | read; [ $? == 1 ]
 
+
 if [ "$?" = "1" ]; then
     echo "gofmt -d .  detected formatting problems"
     gofmt -d .
@@ -21,11 +22,16 @@ export CLIENT_IMPORT_PATH="github.com/hazelcast/hazelcast-go-client"
 export PACKAGE_LIST=$(go list $CLIENT_IMPORT_PATH/... | grep -vE ".*/tests|.*/compatibility|.*/rc|.*/samples" | sed -e 'H;${x;s/\n/,/g;s/^,//;p;};d')
 echo $PACKAGE_LIST
 
-go get git.apache.org/thrift.git/lib/go/thrift
-pushd $GOPATH/src/git.apache.org/thrift.git/
-git fetch --tags --quiet
-git checkout 0.10.0
-popd
+
+if [ -d $GOPATH/src/git.apache.org/thrift.git/ ]; then
+    echo "thrift already exists, not downloading."
+else
+    go get git.apache.org/thrift.git/lib/go/thrift
+    pushd $GOPATH/src/git.apache.org/thrift.git/
+    git fetch --tags --quiet
+    git checkout 0.10.0
+    popd
+fi
 
 pushd $GOPATH/src/$CLIENT_IMPORT_PATH
 go build
@@ -41,9 +47,21 @@ do
     if [[ $pkg != *"vendor"* ]]; then
       echo "testing with race detection on ... $pkg"
       go test -race -v  $pkg
+
     fi
 done
 
+# Run vet tools (Compiler warning plugin)
+go vet $CLIENT_IMPORT_PATH > vet.txt
+
+# if --with-coverage flag is not given then dont generate coverage report.
+if [[ $* != *--with-coverage* ]] ;then
+    exit 0;
+fi
+
+
+go get github.com/t-yuki/gocover-cobertura
+go get github.com/tebeka/go2xunit
 
 # Run tests (JUnit plugin)
 echo "mode: set" > coverage.out
@@ -57,14 +75,12 @@ do
       fi
     fi
 done
+
 rm -f ./tmp.out
 cat test.out | go2xunit -output tests.xml
 
 # Generate coverage reports (Cobertura plugin)
 gocover-cobertura < coverage.out > cobertura-coverage.xml
-
-# Run vet tools (Compiler warning plugin)
-go vet $CLIENT_IMPORT_PATH > vet.txt
 
 ## Run lint tools (Compiler warning plugin)
 #golint $PRJ > lint.txt

--- a/build.sh
+++ b/build.sh
@@ -41,36 +41,22 @@ bash ./start-rc.sh
 
 sleep 10
 
-# Run tests (JUnit plugin) with race detection
-#for pkg in $(go list $CLIENT_IMPORT_PATH/...);
-#do
-#    if [[ $pkg != *"vendor"* ]]; then
-#      echo "testing with race detection on ... $pkg"
-#      go test -race -v  $pkg
-#
-#    fi
-#done
 
 # Run vet tools (Compiler warning plugin)
 go vet $CLIENT_IMPORT_PATH > vet.txt
 
-# if --with-coverage flag is not given then dont generate coverage report.
-#if [[ $* != *--with-coverage* ]] ;then
-#    exit 0;
-#fi
-
-
 go get github.com/t-yuki/gocover-cobertura
 go get github.com/tebeka/go2xunit
-# Run tests (JUnit plugin)
 
+
+# Run tests (JUnit plugin)
 echo "mode: atomic" > coverage.out
 
 for pkg in $(go list $CLIENT_IMPORT_PATH/...);
 do
     if [[ $pkg != *"vendor"* ]]; then
       echo "testing... $pkg"
-      go test -race -covermode=atomic  -v -coverprofile=tmp.out ${pkg}
+      go test -race -covermode=atomic  -v -coverprofile=tmp.out ${pkg} | tee -a test.out
       if [ -f tmp.out ]; then
          cat tmp.out | grep -v "mode: atomic" >> coverage.out | echo
       fi

--- a/rc/rc.go
+++ b/rc/rc.go
@@ -8,7 +8,7 @@ import (
 	"database/sql/driver"
 	"errors"
 	"fmt"
-	"git.apache.org/thrift.git/lib/go/thrift"
+	"github.com/apache/thrift/lib/go/thrift"
 )
 
 // (needed to ensure safety because of naive import list construction.)


### PR DESCRIPTION
Fixes #202.

This pr combines race and coverage flags into one command to avoid running tests twice.
If thrift exists it wont be downloaded again.
There seems to be a problem with thrift repository therefore it is changed to its github mirror.
Test output is redirected to both stdout and test.out