### PR TITLE
replace IPredicate with interface{}

### DIFF
--- a/core/map.go
+++ b/core/map.go
@@ -15,7 +15,6 @@
 package core
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/serialization"
 	"time"
 )
 
@@ -66,7 +65,7 @@ type IMap interface {
 	// If this map has index, matching entries will be found via index search,
 	// otherwise they will be found by full-scan.
 	// Note that calling this method also removes all entries from caller's Near Cache.
-	RemoveAll(predicate IPredicate) (err error)
+	RemoveAll(predicate interface{}) (err error)
 
 	// Size returns the number of entries in this map.
 	Size() (size int32, err error)
@@ -235,7 +234,7 @@ type IMap interface {
 	// returns the keys of matching entries.
 	// Specified predicate runs on all members in parallel.
 	// The slice is NOT backed by the map, so changes to the map are NOT reflected in the slice, and vice-versa.
-	KeySetWithPredicate(predicate IPredicate) (keySet []interface{}, err error)
+	KeySetWithPredicate(predicate interface{}) (keySet []interface{}, err error)
 
 	// Values returns a slice clone of the values contained in this map.
 	// The slice is NOT backed by the map, so changes to the map are NOT reflected in the slice, and vice-versa.
@@ -244,7 +243,7 @@ type IMap interface {
 	// ValuesWithPredicate queries the map based on the specified predicate and returns the values of matching entries.
 	// Specified predicate runs on all members in parallel.
 	// The slice is NOT backed by the map, so changes to the map are NOT reflected in the slice, and vice-versa.
-	ValuesWithPredicate(predicate IPredicate) (values []interface{}, err error)
+	ValuesWithPredicate(predicate interface{}) (values []interface{}, err error)
 
 	// EntrySet returns a slice of IPairs clone of the mappings contained in this map.
 	// The slice is NOT backed by the map, so changes to the map are NOT reflected in the slice, and vice-versa.
@@ -253,7 +252,7 @@ type IMap interface {
 	// EntrySetWithPredicate queries the map based on the specified predicate and returns the matching entries.
 	// Specified predicate runs on all members in parallel.
 	// The slice is NOT backed by the map, so changes to the map are NOT reflected in the slice, and vice-versa.
-	EntrySetWithPredicate(predicate IPredicate) (resultPairs []IPair, err error)
+	EntrySetWithPredicate(predicate interface{}) (resultPairs []IPair, err error)
 
 	// TryLock tries to acquire the lock for the specified key.
 	// If the lock is not available then the current thread
@@ -317,7 +316,7 @@ type IMap interface {
 	// To receive an event, you should implement a corresponding interface for that event such as
 	// IEntryAddedListener, IEntryRemovedListener, IEntryUpdatedListener etc.
 	// AddEntryListenerWithPredicate returns UUID which is used as a key to remove the listener.
-	AddEntryListenerWithPredicate(listener interface{}, predicate IPredicate, includeValue bool) (registrationID *string, err error)
+	AddEntryListenerWithPredicate(listener interface{}, predicate interface{}, includeValue bool) (registrationID *string, err error)
 
 	// AddEntryListenerToKey adds a continuous entry listener for this map filtered with the given key.
 	// To receive an event, you should implement a corresponding interface for that event such as
@@ -329,7 +328,7 @@ type IMap interface {
 	// To receive an event, you should implement a corresponding interface for that event such as
 	// IEntryAddedListener, IEntryRemovedListener, IEntryUpdatedListener.
 	// AddEntryListenerToKeyWithPredicate returns UUID which is used as a key to remove the listener.
-	AddEntryListenerToKeyWithPredicate(listener interface{}, predicate IPredicate, key interface{}, includeValue bool) (registrationID *string, err error)
+	AddEntryListenerToKeyWithPredicate(listener interface{}, predicate interface{}, key interface{}, includeValue bool) (registrationID *string, err error)
 
 	// RemoveEntryListener removes the specified entry listener with the given registrationId.
 	// RemoveEntryListener returns silently if there is no such listener added before.
@@ -367,5 +366,5 @@ type IMap interface {
 	// on the server side.
 	// This struct must have a serializable EntryProcessor counter part registered on server side with the actual
 	// org.hazelcast.map.EntryProcessor implementation.
-	ExecuteOnEntriesWithPredicate(entryProcessor interface{}, predicate IPredicate) (keyToResultPairs []IPair, err error)
+	ExecuteOnEntriesWithPredicate(entryProcessor interface{}, predicate interface{}) (keyToResultPairs []IPair, err error)
 }

--- a/core/predicates/predicates.go
+++ b/core/predicates/predicates.go
@@ -16,95 +16,94 @@ package predicates
 
 import (
 	. "github.com/hazelcast/hazelcast-go-client/internal/predicates"
-	. "github.com/hazelcast/hazelcast-go-client/serialization"
 )
 
 // Sql is a helper function for creating SqlPredicate.
-func Sql(sql string) IPredicate {
+func Sql(sql string) interface{} {
 	return NewSqlPredicate(sql)
 }
 
 // And is a helper function for creating AndPredicate.
-func And(predicates ...IPredicate) IPredicate {
+func And(predicates ...interface{}) interface{} {
 	return NewAndPredicate(predicates)
 }
 
 // Between is a helper function for creating BetweenPredicate.
-func Between(field string, from interface{}, to interface{}) IPredicate {
+func Between(field string, from interface{}, to interface{}) interface{} {
 	return NewBetweenPredicate(field, from, to)
 }
 
 // Equal is a helper function for creating EqualPredicate.
-func Equal(field string, value interface{}) IPredicate {
+func Equal(field string, value interface{}) interface{} {
 	return NewEqualPredicate(field, value)
 }
 
 // GreaterThan is a helper function for creating GreaterLessPredicate behaving like greater than.
-func GreaterThan(field string, value interface{}) IPredicate {
+func GreaterThan(field string, value interface{}) interface{} {
 	return NewGreaterLessPredicate(field, value, false, false)
 }
 
 // GreaterEqual is a helper function for creating GreaterLessPredicate behaving like greater equal.
-func GreaterEqual(field string, value interface{}) IPredicate {
+func GreaterEqual(field string, value interface{}) interface{} {
 	return NewGreaterLessPredicate(field, value, true, false)
 }
 
 // LessThan is a helper function for creating GreaterLessPredicate behaving like less than.
-func LessThan(field string, value interface{}) IPredicate {
+func LessThan(field string, value interface{}) interface{} {
 	return NewGreaterLessPredicate(field, value, false, true)
 }
 
 // LessEqual is a helper function for creating GreaterLessPredicate behaving like less equal.
-func LessEqual(field string, value interface{}) IPredicate {
+func LessEqual(field string, value interface{}) interface{} {
 	return NewGreaterLessPredicate(field, value, true, true)
 }
 
 // Like is a helper function for creating LikePredicate.
-func Like(field string, expr string) IPredicate {
+func Like(field string, expr string) interface{} {
 	return NewLikePredicate(field, expr)
 }
 
 // ILike is a helper function for creating ILikePredicate.
-func ILike(field string, expr string) IPredicate {
+func ILike(field string, expr string) interface{} {
 	return NewILikePredicate(field, expr)
 }
 
 // In is a helper function for creating InPredicate.
-func In(field string, values ...interface{}) IPredicate {
+func In(field string, values ...interface{}) interface{} {
 	return NewInPredicate(field, values)
 }
 
 // InstanceOf is a helper function for creating InstanceOfPredicate.
-func InstanceOf(className string) IPredicate {
+func InstanceOf(className string) interface{} {
 	return NewInstanceOfPredicate(className)
 }
 
 // NotEqual is a helper function for creating NotEqualPredicate.
-func NotEqual(field string, value interface{}) IPredicate {
+func NotEqual(field string, value interface{}) interface{} {
 	return NewNotEqualPredicate(field, value)
 }
 
 // Not is a helper function for creating NotPredicate.
-func Not(predicate IPredicate) IPredicate {
+func Not(predicate interface{}) interface{} {
 	return NewNotPredicate(predicate)
 }
 
 // Or is a helper function for creating OrPredicate.
-func Or(predicates ...IPredicate) IPredicate {
+func Or(predicates ...interface{}) interface{} {
 	return NewOrPredicate(predicates)
 }
 
 // Regex is a helper function for creating RegexPredicate.
-func Regex(field string, regex string) IPredicate {
+func Regex(field string, regex string) interface{} {
 	return NewRegexPredicate(field, regex)
 }
 
 // True is a helper function for creating TruePredicate.
-func True() IPredicate {
+func True() interface{} {
 	return NewTruePredicate()
 }
 
 // False is a helper function for creating FalsePredicate.
-func False() IPredicate {
+func False() interface{} {
 	return NewFalsePredicate()
 }

--- a/core/replicated_map.go
+++ b/core/replicated_map.go
@@ -15,7 +15,6 @@
 package core
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/serialization"
 	"time"
 )
 
@@ -99,7 +98,7 @@ type ReplicatedMap interface {
 	// AddEntryListenerWithPredicate adds a continuous entry listener for this map. The listener will be notified for
 	// map add/remove/update/evict events filtered by the given predicate.
 	// It returns registration id of the listener.
-	AddEntryListenerWithPredicate(listener interface{}, predicate IPredicate) (registrationID *string, err error)
+	AddEntryListenerWithPredicate(listener interface{}, predicate interface{}) (registrationID *string, err error)
 
 	// AddEntryListenerToKey adds the specified entry listener for the specified key. The listener will be
 	// notified for all add/remove/update/evict events of the specified key only.
@@ -109,7 +108,7 @@ type ReplicatedMap interface {
 	// AddEntryListenerToKeyWithPredicate adds a continuous entry listener for this map. The listener will be notified for
 	// map add/remove/update/evict events filtered by the given predicate and key.
 	// It returns registration id of the listener.
-	AddEntryListenerToKeyWithPredicate(listener interface{}, predicate IPredicate, key interface{}) (registrationID *string, err error)
+	AddEntryListenerToKeyWithPredicate(listener interface{}, predicate interface{}, key interface{}) (registrationID *string, err error)
 
 	// RemoveEntryListener removes the specified entry listener and returns silently if there was no such
 	// listener added before.

--- a/internal/map.go
+++ b/internal/map.go
@@ -19,7 +19,6 @@ import (
 	. "github.com/hazelcast/hazelcast-go-client/internal/common"
 	. "github.com/hazelcast/hazelcast-go-client/internal/protocol"
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
-	. "github.com/hazelcast/hazelcast-go-client/serialization"
 	"time"
 )
 
@@ -89,7 +88,7 @@ func (imap *MapProxy) RemoveIfSame(key interface{}, value interface{}) (ok bool,
 	return imap.decodeToBoolAndError(responseMessage, err, MapRemoveIfSameDecodeResponse)
 
 }
-func (imap *MapProxy) RemoveAll(predicate IPredicate) (err error) {
+func (imap *MapProxy) RemoveAll(predicate interface{}) (err error) {
 	predicateData, err := imap.validateAndSerializePredicate(predicate)
 	if err != nil {
 		return err
@@ -303,7 +302,7 @@ func (imap *MapProxy) KeySet() (keySet []interface{}, err error) {
 	responseMessage, err := imap.invokeOnRandomTarget(request)
 	return imap.decodeToInterfaceSliceAndError(responseMessage, err, MapKeySetDecodeResponse)
 }
-func (imap *MapProxy) KeySetWithPredicate(predicate IPredicate) (keySet []interface{}, err error) {
+func (imap *MapProxy) KeySetWithPredicate(predicate interface{}) (keySet []interface{}, err error) {
 	predicateData, err := imap.validateAndSerializePredicate(predicate)
 	if err != nil {
 		return nil, err
@@ -317,7 +316,7 @@ func (imap *MapProxy) Values() (values []interface{}, err error) {
 	responseMessage, err := imap.invokeOnRandomTarget(request)
 	return imap.decodeToInterfaceSliceAndError(responseMessage, err, MapValuesDecodeResponse)
 }
-func (imap *MapProxy) ValuesWithPredicate(predicate IPredicate) (values []interface{}, err error) {
+func (imap *MapProxy) ValuesWithPredicate(predicate interface{}) (values []interface{}, err error) {
 	predicateData, err := imap.validateAndSerializePredicate(predicate)
 	if err != nil {
 		return nil, err
@@ -331,7 +330,7 @@ func (imap *MapProxy) EntrySet() (resultPairs []IPair, err error) {
 	responseMessage, err := imap.invokeOnRandomTarget(request)
 	return imap.decodeToPairSliceAndError(responseMessage, err, MapEntrySetDecodeResponse)
 }
-func (imap *MapProxy) EntrySetWithPredicate(predicate IPredicate) (resultPairs []IPair, err error) {
+func (imap *MapProxy) EntrySetWithPredicate(predicate interface{}) (resultPairs []IPair, err error) {
 	predicateData, err := imap.validateAndSerializePredicate(predicate)
 	if err != nil {
 		return nil, err
@@ -408,7 +407,7 @@ func (imap *MapProxy) AddEntryListener(listener interface{}, includeValue bool) 
 		return MapAddEntryListenerDecodeResponse(clientMessage)()
 	})
 }
-func (imap *MapProxy) AddEntryListenerWithPredicate(listener interface{}, predicate IPredicate, includeValue bool) (*string, error) {
+func (imap *MapProxy) AddEntryListenerWithPredicate(listener interface{}, predicate interface{}, includeValue bool) (*string, error) {
 	var request *ClientMessage
 	listenerFlags := GetEntryListenerFlags(listener)
 	predicateData, err := imap.validateAndSerializePredicate(predicate)
@@ -447,7 +446,7 @@ func (imap *MapProxy) AddEntryListenerToKey(listener interface{}, key interface{
 		return MapAddEntryListenerToKeyDecodeResponse(clientMessage)()
 	})
 }
-func (imap *MapProxy) AddEntryListenerToKeyWithPredicate(listener interface{}, predicate IPredicate, key interface{}, includeValue bool) (*string, error) {
+func (imap *MapProxy) AddEntryListenerToKeyWithPredicate(listener interface{}, predicate interface{}, key interface{}, includeValue bool) (*string, error) {
 	var request *ClientMessage
 	listenerFlags := GetEntryListenerFlags(listener)
 	keyData, err := imap.validateAndSerialize(key)
@@ -540,7 +539,7 @@ func (imap *MapProxy) ExecuteOnEntries(entryProcessor interface{}) (keyToResultP
 	return imap.decodeToPairSliceAndError(responseMessage, err, MapExecuteOnAllKeysDecodeResponse)
 }
 
-func (imap *MapProxy) ExecuteOnEntriesWithPredicate(entryProcessor interface{}, predicate IPredicate) (keyToResultPairs []IPair, err error) {
+func (imap *MapProxy) ExecuteOnEntriesWithPredicate(entryProcessor interface{}, predicate interface{}) (keyToResultPairs []IPair, err error) {
 	predicateData, err := imap.validateAndSerializePredicate(predicate)
 	if err != nil {
 		return nil, err

--- a/internal/predicates/predicates_impl.go
+++ b/internal/predicates/predicates_impl.go
@@ -67,10 +67,10 @@ func (sp *SqlPredicate) WriteData(output DataOutput) error {
 
 type AndPredicate struct {
 	*predicate
-	predicates []IPredicate
+	predicates []interface{}
 }
 
-func NewAndPredicate(predicates []IPredicate) *AndPredicate {
+func NewAndPredicate(predicates []interface{}) *AndPredicate {
 	return &AndPredicate{newPredicate(AND_PREDICATE), predicates}
 }
 
@@ -80,13 +80,13 @@ func (ap *AndPredicate) ReadData(input DataInput) error {
 	if err != nil {
 		return err
 	}
-	ap.predicates = make([]IPredicate, length)
+	ap.predicates = make([]interface{}, length)
 	for i := 0; i < int(length); i++ {
 		pred, err := input.ReadObject()
 		if err != nil {
 			return err
 		}
-		ap.predicates[i] = pred.(IPredicate)
+		ap.predicates[i] = pred
 	}
 	return nil
 }
@@ -339,17 +339,17 @@ func (nep *NotEqualPredicate) ReadData(input DataInput) error {
 
 type NotPredicate struct {
 	*predicate
-	pred IPredicate
+	pred interface{}
 }
 
-func NewNotPredicate(pred IPredicate) *NotPredicate {
+func NewNotPredicate(pred interface{}) *NotPredicate {
 	return &NotPredicate{newPredicate(NOT_PREDICATE), pred}
 }
 
 func (np *NotPredicate) ReadData(input DataInput) error {
 	np.predicate = newPredicate(NOT_PREDICATE)
 	i, err := input.ReadObject()
-	np.pred = i.(IPredicate)
+	np.pred = i.(interface{})
 	return err
 }
 
@@ -359,10 +359,10 @@ func (np *NotPredicate) WriteData(output DataOutput) error {
 
 type OrPredicate struct {
 	*predicate
-	predicates []IPredicate
+	predicates []interface{}
 }
 
-func NewOrPredicate(predicates []IPredicate) *OrPredicate {
+func NewOrPredicate(predicates []interface{}) *OrPredicate {
 	return &OrPredicate{newPredicate(OR_PREDICATE), predicates}
 }
 
@@ -373,13 +373,13 @@ func (or *OrPredicate) ReadData(input DataInput) error {
 	if err != nil {
 		return err
 	}
-	or.predicates = make([]IPredicate, length)
+	or.predicates = make([]interface{}, length)
 	for i := 0; i < int(length); i++ {
 		pred, err := input.ReadObject()
 		if err != nil {
 			return err
 		}
-		or.predicates[i] = pred.(IPredicate)
+		or.predicates[i] = pred.(interface{})
 	}
 	return err
 }

--- a/internal/replicated_map.go
+++ b/internal/replicated_map.go
@@ -19,7 +19,6 @@ import (
 	. "github.com/hazelcast/hazelcast-go-client/internal/common"
 	. "github.com/hazelcast/hazelcast-go-client/internal/protocol"
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
-	. "github.com/hazelcast/hazelcast-go-client/serialization"
 	"math/rand"
 	"time"
 )
@@ -154,7 +153,7 @@ func (rmp *ReplicatedMapProxy) AddEntryListener(listener interface{}) (registrat
 	})
 }
 
-func (rmp *ReplicatedMapProxy) AddEntryListenerWithPredicate(listener interface{}, predicate IPredicate) (registrationID *string, err error) {
+func (rmp *ReplicatedMapProxy) AddEntryListenerWithPredicate(listener interface{}, predicate interface{}) (registrationID *string, err error) {
 	predicateData, err := rmp.validateAndSerializePredicate(predicate)
 	if err != nil {
 		return nil, err
@@ -182,7 +181,7 @@ func (rmp *ReplicatedMapProxy) AddEntryListenerToKey(listener interface{}, key i
 	})
 }
 
-func (rmp *ReplicatedMapProxy) AddEntryListenerToKeyWithPredicate(listener interface{}, predicate IPredicate, key interface{}) (registrationID *string, err error) {
+func (rmp *ReplicatedMapProxy) AddEntryListenerToKeyWithPredicate(listener interface{}, predicate interface{}, key interface{}) (registrationID *string, err error) {
 	predicateData, err := rmp.validateAndSerializePredicate(predicate)
 	if err != nil {
 		return nil, err

--- a/serialization/api.go
+++ b/serialization/api.go
@@ -413,12 +413,6 @@ type PortableReader interface {
 	ReadPortableArray(fieldName string) ([]Portable, error)
 }
 
-// Represents a predicate (boolean-valued function) of one argument.
-type IPredicate interface {
-	// IPredicate implements IdentifiedDataSerializable interface.
-	IdentifiedDataSerializable
-}
-
 // ClassDefinition defines a class schema for Portable structs.
 type ClassDefinition interface {
 	// FactoryId returns factory ID of struct.

--- a/tests/proxy/map/predicates_test.go
+++ b/tests/proxy/map/predicates_test.go
@@ -18,7 +18,6 @@ import (
 	. "github.com/hazelcast/hazelcast-go-client/config"
 	"github.com/hazelcast/hazelcast-go-client/core/predicates"
 	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
-	"github.com/hazelcast/hazelcast-go-client/serialization"
 	"log"
 	"reflect"
 	"strconv"
@@ -44,7 +43,7 @@ func fillMapForPredicates() {
 	}
 }
 
-func testSerialization(t *testing.T, predicate serialization.IPredicate) {
+func testSerialization(t *testing.T, predicate interface{}) {
 	predicateData, err := serializationService.ToData(predicate)
 	if err != nil {
 		t.Fatal(err)
@@ -53,12 +52,12 @@ func testSerialization(t *testing.T, predicate serialization.IPredicate) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(predicate, retPredicate.(serialization.IPredicate)) {
+	if !reflect.DeepEqual(predicate, retPredicate.(interface{})) {
 		t.Errorf("%s failed", reflect.TypeOf(predicate))
 	}
 }
 
-func testPredicate(t *testing.T, predicate serialization.IPredicate, expecteds map[interface{}]interface{}) {
+func testPredicate(t *testing.T, predicate interface{}, expecteds map[interface{}]interface{}) {
 	set, err := mp2.EntrySetWithPredicate(predicate)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Predicates were only `IdentifiedDataSerializable` which is different than the Java client. So we have decided to change it to `interface`.

