### PR TITLE
change constants names according to go convention in codecs

### DIFF
--- a/internal/protocol/client_addmembershiplistener.go
+++ b/internal/protocol/client_addmembershiplistener.go
@@ -28,7 +28,7 @@ func ClientAddMembershipListenerCalculateSize(localOnly bool) int {
 func ClientAddMembershipListenerEncodeRequest(localOnly bool) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ClientAddMembershipListenerCalculateSize(localOnly))
-	clientMessage.SetMessageType(CLIENT_ADDMEMBERSHIPLISTENER)
+	clientMessage.SetMessageType(clientAddMembershipListener)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendBool(localOnly)
 	clientMessage.UpdateFrameLength()

--- a/internal/protocol/client_authentication.go
+++ b/internal/protocol/client_authentication.go
@@ -41,7 +41,7 @@ func ClientAuthenticationCalculateSize(username *string, password *string, uuid 
 func ClientAuthenticationEncodeRequest(username *string, password *string, uuid *string, ownerUuid *string, isOwnerConnection bool, clientType *string, serializationVersion uint8, clientHazelcastVersion *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ClientAuthenticationCalculateSize(username, password, uuid, ownerUuid, isOwnerConnection, clientType, serializationVersion, clientHazelcastVersion))
-	clientMessage.SetMessageType(CLIENT_AUTHENTICATION)
+	clientMessage.SetMessageType(clientAuthentication)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(username)
 	clientMessage.AppendString(password)

--- a/internal/protocol/client_createproxy.go
+++ b/internal/protocol/client_createproxy.go
@@ -28,7 +28,7 @@ func ClientCreateProxyCalculateSize(name *string, serviceName *string, target *A
 func ClientCreateProxyEncodeRequest(name *string, serviceName *string, target *Address) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ClientCreateProxyCalculateSize(name, serviceName, target))
-	clientMessage.SetMessageType(CLIENT_CREATEPROXY)
+	clientMessage.SetMessageType(clientCreateProxy)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendString(serviceName)

--- a/internal/protocol/client_destroyproxy.go
+++ b/internal/protocol/client_destroyproxy.go
@@ -27,7 +27,7 @@ func ClientDestroyProxyCalculateSize(name *string, serviceName *string) int {
 func ClientDestroyProxyEncodeRequest(name *string, serviceName *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ClientDestroyProxyCalculateSize(name, serviceName))
-	clientMessage.SetMessageType(CLIENT_DESTROYPROXY)
+	clientMessage.SetMessageType(clientDestroyProxy)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendString(serviceName)

--- a/internal/protocol/client_getpartitions.go
+++ b/internal/protocol/client_getpartitions.go
@@ -25,7 +25,7 @@ func ClientGetPartitionsCalculateSize() int {
 func ClientGetPartitionsEncodeRequest() *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ClientGetPartitionsCalculateSize())
-	clientMessage.SetMessageType(CLIENT_GETPARTITIONS)
+	clientMessage.SetMessageType(clientGetPartitions)
 	clientMessage.IsRetryable = false
 	clientMessage.UpdateFrameLength()
 	return clientMessage

--- a/internal/protocol/client_messagetype.go
+++ b/internal/protocol/client_messagetype.go
@@ -1,20 +1,35 @@
+// Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package protocol
 
 const (
-	CLIENT_AUTHENTICATION                  = 0x0002
-	CLIENT_AUTHENTICATIONCUSTOM            = 0x0003
-	CLIENT_ADDMEMBERSHIPLISTENER           = 0x0004
-	CLIENT_CREATEPROXY                     = 0x0005
-	CLIENT_DESTROYPROXY                    = 0x0006
-	CLIENT_GETPARTITIONS                   = 0x0008
-	CLIENT_REMOVEALLLISTENERS              = 0x0009
-	CLIENT_ADDPARTITIONLOSTLISTENER        = 0x000a
-	CLIENT_REMOVEPARTITIONLOSTLISTENER     = 0x000b
-	CLIENT_GETDISTRIBUTEDOBJECTS           = 0x000c
-	CLIENT_ADDDISTRIBUTEDOBJECTLISTENER    = 0x000d
-	CLIENT_REMOVEDISTRIBUTEDOBJECTLISTENER = 0x000e
-	CLIENT_PING                            = 0x000f
-	CLIENT_STATISTICS                      = 0x0010
-	CLIENT_DEPLOYCLASSES                   = 0x0011
-	CLIENT_ADDPARTITIONLISTENER            = 0x0012
+	clientAuthentication                  = 0x0002
+	clientAuthenticationCustom            = 0x0003
+	clientAddMembershipListener           = 0x0004
+	clientCreateProxy                     = 0x0005
+	clientDestroyProxy                    = 0x0006
+	clientGetPartitions                   = 0x0008
+	clientRemoveAllListeners              = 0x0009
+	clientAddPartitionLostListener        = 0x000a
+	clientRemovePartitionLostListener     = 0x000b
+	clientGetDistributedObjects           = 0x000c
+	clientAddDistributedObjectListener    = 0x000d
+	clientRemoveDistributedObjectListener = 0x000e
+	clientPing                            = 0x000f
+	clientStatistics                      = 0x0010
+	clientDeployClasses                   = 0x0011
+	clientAddPartitionListener            = 0x0012
+	clientCreateProxies                   = 0x0013
 )

--- a/internal/protocol/client_ping.go
+++ b/internal/protocol/client_ping.go
@@ -25,7 +25,7 @@ func ClientPingCalculateSize() int {
 func ClientPingEncodeRequest() *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ClientPingCalculateSize())
-	clientMessage.SetMessageType(CLIENT_PING)
+	clientMessage.SetMessageType(clientPing)
 	clientMessage.IsRetryable = true
 	clientMessage.UpdateFrameLength()
 	return clientMessage

--- a/internal/protocol/flakeidgenerator_messagetype.go
+++ b/internal/protocol/flakeidgenerator_messagetype.go
@@ -1,5 +1,19 @@
+// Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package protocol
 
 const (
-	FLAKEIDGENERATOR_NEWIDBATCH = 0x1f01
+	flakeidgeneratorNewIdBatch = 0x1f01
 )

--- a/internal/protocol/flakeidgenerator_newidbatch.go
+++ b/internal/protocol/flakeidgenerator_newidbatch.go
@@ -29,7 +29,7 @@ func FlakeIdGeneratorNewIdBatchCalculateSize(name *string, batchSize int32) int 
 func FlakeIdGeneratorNewIdBatchEncodeRequest(name *string, batchSize int32) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, FlakeIdGeneratorNewIdBatchCalculateSize(name, batchSize))
-	clientMessage.SetMessageType(FLAKEIDGENERATOR_NEWIDBATCH)
+	clientMessage.SetMessageType(flakeidgeneratorNewIdBatch)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.AppendInt32(batchSize)

--- a/internal/protocol/list_add.go
+++ b/internal/protocol/list_add.go
@@ -29,7 +29,7 @@ func ListAddCalculateSize(name *string, value *Data) int {
 func ListAddEncodeRequest(name *string, value *Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ListAddCalculateSize(name, value))
-	clientMessage.SetMessageType(LIST_ADD)
+	clientMessage.SetMessageType(listAdd)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(value)

--- a/internal/protocol/list_addall.go
+++ b/internal/protocol/list_addall.go
@@ -34,7 +34,7 @@ func ListAddAllCalculateSize(name *string, valueList []*Data) int {
 func ListAddAllEncodeRequest(name *string, valueList []*Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ListAddAllCalculateSize(name, valueList))
-	clientMessage.SetMessageType(LIST_ADDALL)
+	clientMessage.SetMessageType(listAddAll)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendInt32(int32(len(valueList)))

--- a/internal/protocol/list_addallwithindex.go
+++ b/internal/protocol/list_addallwithindex.go
@@ -35,7 +35,7 @@ func ListAddAllWithIndexCalculateSize(name *string, index int32, valueList []*Da
 func ListAddAllWithIndexEncodeRequest(name *string, index int32, valueList []*Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ListAddAllWithIndexCalculateSize(name, index, valueList))
-	clientMessage.SetMessageType(LIST_ADDALLWITHINDEX)
+	clientMessage.SetMessageType(listAddAllWithIndex)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendInt32(index)

--- a/internal/protocol/list_addlistener.go
+++ b/internal/protocol/list_addlistener.go
@@ -32,7 +32,7 @@ func ListAddListenerCalculateSize(name *string, includeValue bool, localOnly boo
 func ListAddListenerEncodeRequest(name *string, includeValue bool, localOnly bool) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ListAddListenerCalculateSize(name, includeValue, localOnly))
-	clientMessage.SetMessageType(LIST_ADDLISTENER)
+	clientMessage.SetMessageType(listAddListener)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendBool(includeValue)

--- a/internal/protocol/list_addwithindex.go
+++ b/internal/protocol/list_addwithindex.go
@@ -32,7 +32,7 @@ func ListAddWithIndexCalculateSize(name *string, index int32, value *Data) int {
 func ListAddWithIndexEncodeRequest(name *string, index int32, value *Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ListAddWithIndexCalculateSize(name, index, value))
-	clientMessage.SetMessageType(LIST_ADDWITHINDEX)
+	clientMessage.SetMessageType(listAddWithIndex)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendInt32(index)

--- a/internal/protocol/list_clear.go
+++ b/internal/protocol/list_clear.go
@@ -26,7 +26,7 @@ func ListClearCalculateSize(name *string) int {
 func ListClearEncodeRequest(name *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ListClearCalculateSize(name))
-	clientMessage.SetMessageType(LIST_CLEAR)
+	clientMessage.SetMessageType(listClear)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.UpdateFrameLength()

--- a/internal/protocol/list_compareandremoveall.go
+++ b/internal/protocol/list_compareandremoveall.go
@@ -34,7 +34,7 @@ func ListCompareAndRemoveAllCalculateSize(name *string, values []*Data) int {
 func ListCompareAndRemoveAllEncodeRequest(name *string, values []*Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ListCompareAndRemoveAllCalculateSize(name, values))
-	clientMessage.SetMessageType(LIST_COMPAREANDREMOVEALL)
+	clientMessage.SetMessageType(listCompareAndRemoveAll)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendInt32(int32(len(values)))

--- a/internal/protocol/list_compareandretainall.go
+++ b/internal/protocol/list_compareandretainall.go
@@ -34,7 +34,7 @@ func ListCompareAndRetainAllCalculateSize(name *string, values []*Data) int {
 func ListCompareAndRetainAllEncodeRequest(name *string, values []*Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ListCompareAndRetainAllCalculateSize(name, values))
-	clientMessage.SetMessageType(LIST_COMPAREANDRETAINALL)
+	clientMessage.SetMessageType(listCompareAndRetainAll)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendInt32(int32(len(values)))

--- a/internal/protocol/list_contains.go
+++ b/internal/protocol/list_contains.go
@@ -29,7 +29,7 @@ func ListContainsCalculateSize(name *string, value *Data) int {
 func ListContainsEncodeRequest(name *string, value *Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ListContainsCalculateSize(name, value))
-	clientMessage.SetMessageType(LIST_CONTAINS)
+	clientMessage.SetMessageType(listContains)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(value)

--- a/internal/protocol/list_containsall.go
+++ b/internal/protocol/list_containsall.go
@@ -34,7 +34,7 @@ func ListContainsAllCalculateSize(name *string, values []*Data) int {
 func ListContainsAllEncodeRequest(name *string, values []*Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ListContainsAllCalculateSize(name, values))
-	clientMessage.SetMessageType(LIST_CONTAINSALL)
+	clientMessage.SetMessageType(listContainsAll)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.AppendInt32(int32(len(values)))

--- a/internal/protocol/list_get.go
+++ b/internal/protocol/list_get.go
@@ -30,7 +30,7 @@ func ListGetCalculateSize(name *string, index int32) int {
 func ListGetEncodeRequest(name *string, index int32) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ListGetCalculateSize(name, index))
-	clientMessage.SetMessageType(LIST_GET)
+	clientMessage.SetMessageType(listGet)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.AppendInt32(index)

--- a/internal/protocol/list_getall.go
+++ b/internal/protocol/list_getall.go
@@ -28,7 +28,7 @@ func ListGetAllCalculateSize(name *string) int {
 func ListGetAllEncodeRequest(name *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ListGetAllCalculateSize(name))
-	clientMessage.SetMessageType(LIST_GETALL)
+	clientMessage.SetMessageType(listGetAll)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.UpdateFrameLength()

--- a/internal/protocol/list_indexof.go
+++ b/internal/protocol/list_indexof.go
@@ -29,7 +29,7 @@ func ListIndexOfCalculateSize(name *string, value *Data) int {
 func ListIndexOfEncodeRequest(name *string, value *Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ListIndexOfCalculateSize(name, value))
-	clientMessage.SetMessageType(LIST_INDEXOF)
+	clientMessage.SetMessageType(listIndexOf)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(value)

--- a/internal/protocol/list_isempty.go
+++ b/internal/protocol/list_isempty.go
@@ -26,7 +26,7 @@ func ListIsEmptyCalculateSize(name *string) int {
 func ListIsEmptyEncodeRequest(name *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ListIsEmptyCalculateSize(name))
-	clientMessage.SetMessageType(LIST_ISEMPTY)
+	clientMessage.SetMessageType(listIsEmpty)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.UpdateFrameLength()

--- a/internal/protocol/list_lastindexof.go
+++ b/internal/protocol/list_lastindexof.go
@@ -29,7 +29,7 @@ func ListLastIndexOfCalculateSize(name *string, value *Data) int {
 func ListLastIndexOfEncodeRequest(name *string, value *Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ListLastIndexOfCalculateSize(name, value))
-	clientMessage.SetMessageType(LIST_LASTINDEXOF)
+	clientMessage.SetMessageType(listLastIndexOf)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(value)

--- a/internal/protocol/list_messagetype.go
+++ b/internal/protocol/list_messagetype.go
@@ -1,27 +1,41 @@
+// Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package protocol
 
 const (
-	LIST_SIZE                = 0x0501
-	LIST_CONTAINS            = 0x0502
-	LIST_CONTAINSALL         = 0x0503
-	LIST_ADD                 = 0x0504
-	LIST_REMOVE              = 0x0505
-	LIST_ADDALL              = 0x0506
-	LIST_COMPAREANDREMOVEALL = 0x0507
-	LIST_COMPAREANDRETAINALL = 0x0508
-	LIST_CLEAR               = 0x0509
-	LIST_GETALL              = 0x050a
-	LIST_ADDLISTENER         = 0x050b
-	LIST_REMOVELISTENER      = 0x050c
-	LIST_ISEMPTY             = 0x050d
-	LIST_ADDALLWITHINDEX     = 0x050e
-	LIST_GET                 = 0x050f
-	LIST_SET                 = 0x0510
-	LIST_ADDWITHINDEX        = 0x0511
-	LIST_REMOVEWITHINDEX     = 0x0512
-	LIST_LASTINDEXOF         = 0x0513
-	LIST_INDEXOF             = 0x0514
-	LIST_SUB                 = 0x0515
-	LIST_ITERATOR            = 0x0516
-	LIST_LISTITERATOR        = 0x0517
+	listSize                = 0x0501
+	listContains            = 0x0502
+	listContainsAll         = 0x0503
+	listAdd                 = 0x0504
+	listRemove              = 0x0505
+	listAddAll              = 0x0506
+	listCompareAndRemoveAll = 0x0507
+	listCompareAndRetainAll = 0x0508
+	listClear               = 0x0509
+	listGetAll              = 0x050a
+	listAddListener         = 0x050b
+	listRemoveListener      = 0x050c
+	listIsEmpty             = 0x050d
+	listAddAllWithIndex     = 0x050e
+	listGet                 = 0x050f
+	listSet                 = 0x0510
+	listAddWithIndex        = 0x0511
+	listRemoveWithIndex     = 0x0512
+	listLastIndexOf         = 0x0513
+	listIndexOf             = 0x0514
+	listSub                 = 0x0515
+	listIterator            = 0x0516
+	listListIterator        = 0x0517
 )

--- a/internal/protocol/list_remove.go
+++ b/internal/protocol/list_remove.go
@@ -29,7 +29,7 @@ func ListRemoveCalculateSize(name *string, value *Data) int {
 func ListRemoveEncodeRequest(name *string, value *Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ListRemoveCalculateSize(name, value))
-	clientMessage.SetMessageType(LIST_REMOVE)
+	clientMessage.SetMessageType(listRemove)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(value)

--- a/internal/protocol/list_removelistener.go
+++ b/internal/protocol/list_removelistener.go
@@ -27,7 +27,7 @@ func ListRemoveListenerCalculateSize(name *string, registrationId *string) int {
 func ListRemoveListenerEncodeRequest(name *string, registrationId *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ListRemoveListenerCalculateSize(name, registrationId))
-	clientMessage.SetMessageType(LIST_REMOVELISTENER)
+	clientMessage.SetMessageType(listRemoveListener)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.AppendString(registrationId)

--- a/internal/protocol/list_removewithindex.go
+++ b/internal/protocol/list_removewithindex.go
@@ -30,7 +30,7 @@ func ListRemoveWithIndexCalculateSize(name *string, index int32) int {
 func ListRemoveWithIndexEncodeRequest(name *string, index int32) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ListRemoveWithIndexCalculateSize(name, index))
-	clientMessage.SetMessageType(LIST_REMOVEWITHINDEX)
+	clientMessage.SetMessageType(listRemoveWithIndex)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendInt32(index)

--- a/internal/protocol/list_set.go
+++ b/internal/protocol/list_set.go
@@ -32,7 +32,7 @@ func ListSetCalculateSize(name *string, index int32, value *Data) int {
 func ListSetEncodeRequest(name *string, index int32, value *Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ListSetCalculateSize(name, index, value))
-	clientMessage.SetMessageType(LIST_SET)
+	clientMessage.SetMessageType(listSet)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendInt32(index)

--- a/internal/protocol/list_size.go
+++ b/internal/protocol/list_size.go
@@ -26,7 +26,7 @@ func ListSizeCalculateSize(name *string) int {
 func ListSizeEncodeRequest(name *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ListSizeCalculateSize(name))
-	clientMessage.SetMessageType(LIST_SIZE)
+	clientMessage.SetMessageType(listSize)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.UpdateFrameLength()

--- a/internal/protocol/list_sub.go
+++ b/internal/protocol/list_sub.go
@@ -31,7 +31,7 @@ func ListSubCalculateSize(name *string, from int32, to int32) int {
 func ListSubEncodeRequest(name *string, from int32, to int32) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ListSubCalculateSize(name, from, to))
-	clientMessage.SetMessageType(LIST_SUB)
+	clientMessage.SetMessageType(listSub)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.AppendInt32(from)

--- a/internal/protocol/map_addentrylistener.go
+++ b/internal/protocol/map_addentrylistener.go
@@ -33,7 +33,7 @@ func MapAddEntryListenerCalculateSize(name *string, includeValue bool, listenerF
 func MapAddEntryListenerEncodeRequest(name *string, includeValue bool, listenerFlags int32, localOnly bool) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapAddEntryListenerCalculateSize(name, includeValue, listenerFlags, localOnly))
-	clientMessage.SetMessageType(MAP_ADDENTRYLISTENER)
+	clientMessage.SetMessageType(mapAddEntryListener)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendBool(includeValue)

--- a/internal/protocol/map_addentrylistenertokey.go
+++ b/internal/protocol/map_addentrylistenertokey.go
@@ -34,7 +34,7 @@ func MapAddEntryListenerToKeyCalculateSize(name *string, key *Data, includeValue
 func MapAddEntryListenerToKeyEncodeRequest(name *string, key *Data, includeValue bool, listenerFlags int32, localOnly bool) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapAddEntryListenerToKeyCalculateSize(name, key, includeValue, listenerFlags, localOnly))
-	clientMessage.SetMessageType(MAP_ADDENTRYLISTENERTOKEY)
+	clientMessage.SetMessageType(mapAddEntryListenerToKey)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(key)

--- a/internal/protocol/map_addentrylistenertokeywithpredicate.go
+++ b/internal/protocol/map_addentrylistenertokeywithpredicate.go
@@ -35,7 +35,7 @@ func MapAddEntryListenerToKeyWithPredicateCalculateSize(name *string, key *Data,
 func MapAddEntryListenerToKeyWithPredicateEncodeRequest(name *string, key *Data, predicate *Data, includeValue bool, listenerFlags int32, localOnly bool) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapAddEntryListenerToKeyWithPredicateCalculateSize(name, key, predicate, includeValue, listenerFlags, localOnly))
-	clientMessage.SetMessageType(MAP_ADDENTRYLISTENERTOKEYWITHPREDICATE)
+	clientMessage.SetMessageType(mapAddEntryListenerToKeyWithPredicate)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(key)

--- a/internal/protocol/map_addentrylistenerwithpredicate.go
+++ b/internal/protocol/map_addentrylistenerwithpredicate.go
@@ -34,7 +34,7 @@ func MapAddEntryListenerWithPredicateCalculateSize(name *string, predicate *Data
 func MapAddEntryListenerWithPredicateEncodeRequest(name *string, predicate *Data, includeValue bool, listenerFlags int32, localOnly bool) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapAddEntryListenerWithPredicateCalculateSize(name, predicate, includeValue, listenerFlags, localOnly))
-	clientMessage.SetMessageType(MAP_ADDENTRYLISTENERWITHPREDICATE)
+	clientMessage.SetMessageType(mapAddEntryListenerWithPredicate)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(predicate)

--- a/internal/protocol/map_addindex.go
+++ b/internal/protocol/map_addindex.go
@@ -30,7 +30,7 @@ func MapAddIndexCalculateSize(name *string, attribute *string, ordered bool) int
 func MapAddIndexEncodeRequest(name *string, attribute *string, ordered bool) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapAddIndexCalculateSize(name, attribute, ordered))
-	clientMessage.SetMessageType(MAP_ADDINDEX)
+	clientMessage.SetMessageType(mapAddIndex)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendString(attribute)

--- a/internal/protocol/map_clear.go
+++ b/internal/protocol/map_clear.go
@@ -26,7 +26,7 @@ func MapClearCalculateSize(name *string) int {
 func MapClearEncodeRequest(name *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapClearCalculateSize(name))
-	clientMessage.SetMessageType(MAP_CLEAR)
+	clientMessage.SetMessageType(mapClear)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.UpdateFrameLength()

--- a/internal/protocol/map_containskey.go
+++ b/internal/protocol/map_containskey.go
@@ -32,7 +32,7 @@ func MapContainsKeyCalculateSize(name *string, key *Data, threadId int64) int {
 func MapContainsKeyEncodeRequest(name *string, key *Data, threadId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapContainsKeyCalculateSize(name, key, threadId))
-	clientMessage.SetMessageType(MAP_CONTAINSKEY)
+	clientMessage.SetMessageType(mapContainsKey)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(key)

--- a/internal/protocol/map_containsvalue.go
+++ b/internal/protocol/map_containsvalue.go
@@ -29,7 +29,7 @@ func MapContainsValueCalculateSize(name *string, value *Data) int {
 func MapContainsValueEncodeRequest(name *string, value *Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapContainsValueCalculateSize(name, value))
-	clientMessage.SetMessageType(MAP_CONTAINSVALUE)
+	clientMessage.SetMessageType(mapContainsValue)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(value)

--- a/internal/protocol/map_delete.go
+++ b/internal/protocol/map_delete.go
@@ -32,7 +32,7 @@ func MapDeleteCalculateSize(name *string, key *Data, threadId int64) int {
 func MapDeleteEncodeRequest(name *string, key *Data, threadId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapDeleteCalculateSize(name, key, threadId))
-	clientMessage.SetMessageType(MAP_DELETE)
+	clientMessage.SetMessageType(mapDelete)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(key)

--- a/internal/protocol/map_entrieswithpredicate.go
+++ b/internal/protocol/map_entrieswithpredicate.go
@@ -29,7 +29,7 @@ func MapEntriesWithPredicateCalculateSize(name *string, predicate *Data) int {
 func MapEntriesWithPredicateEncodeRequest(name *string, predicate *Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapEntriesWithPredicateCalculateSize(name, predicate))
-	clientMessage.SetMessageType(MAP_ENTRIESWITHPREDICATE)
+	clientMessage.SetMessageType(mapEntriesWithPredicate)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(predicate)

--- a/internal/protocol/map_entryset.go
+++ b/internal/protocol/map_entryset.go
@@ -26,7 +26,7 @@ func MapEntrySetCalculateSize(name *string) int {
 func MapEntrySetEncodeRequest(name *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapEntrySetCalculateSize(name))
-	clientMessage.SetMessageType(MAP_ENTRYSET)
+	clientMessage.SetMessageType(mapEntrySet)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.UpdateFrameLength()

--- a/internal/protocol/map_evict.go
+++ b/internal/protocol/map_evict.go
@@ -32,7 +32,7 @@ func MapEvictCalculateSize(name *string, key *Data, threadId int64) int {
 func MapEvictEncodeRequest(name *string, key *Data, threadId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapEvictCalculateSize(name, key, threadId))
-	clientMessage.SetMessageType(MAP_EVICT)
+	clientMessage.SetMessageType(mapEvict)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(key)

--- a/internal/protocol/map_evictall.go
+++ b/internal/protocol/map_evictall.go
@@ -26,7 +26,7 @@ func MapEvictAllCalculateSize(name *string) int {
 func MapEvictAllEncodeRequest(name *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapEvictAllCalculateSize(name))
-	clientMessage.SetMessageType(MAP_EVICTALL)
+	clientMessage.SetMessageType(mapEvictAll)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.UpdateFrameLength()

--- a/internal/protocol/map_executeonallkeys.go
+++ b/internal/protocol/map_executeonallkeys.go
@@ -29,7 +29,7 @@ func MapExecuteOnAllKeysCalculateSize(name *string, entryProcessor *Data) int {
 func MapExecuteOnAllKeysEncodeRequest(name *string, entryProcessor *Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapExecuteOnAllKeysCalculateSize(name, entryProcessor))
-	clientMessage.SetMessageType(MAP_EXECUTEONALLKEYS)
+	clientMessage.SetMessageType(mapExecuteOnAllKeys)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(entryProcessor)

--- a/internal/protocol/map_executeonkey.go
+++ b/internal/protocol/map_executeonkey.go
@@ -33,7 +33,7 @@ func MapExecuteOnKeyCalculateSize(name *string, entryProcessor *Data, key *Data,
 func MapExecuteOnKeyEncodeRequest(name *string, entryProcessor *Data, key *Data, threadId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapExecuteOnKeyCalculateSize(name, entryProcessor, key, threadId))
-	clientMessage.SetMessageType(MAP_EXECUTEONKEY)
+	clientMessage.SetMessageType(mapExecuteOnKey)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(entryProcessor)

--- a/internal/protocol/map_executeonkeys.go
+++ b/internal/protocol/map_executeonkeys.go
@@ -35,7 +35,7 @@ func MapExecuteOnKeysCalculateSize(name *string, entryProcessor *Data, keys []*D
 func MapExecuteOnKeysEncodeRequest(name *string, entryProcessor *Data, keys []*Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapExecuteOnKeysCalculateSize(name, entryProcessor, keys))
-	clientMessage.SetMessageType(MAP_EXECUTEONKEYS)
+	clientMessage.SetMessageType(mapExecuteOnKeys)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(entryProcessor)

--- a/internal/protocol/map_executewithpredicate.go
+++ b/internal/protocol/map_executewithpredicate.go
@@ -30,7 +30,7 @@ func MapExecuteWithPredicateCalculateSize(name *string, entryProcessor *Data, pr
 func MapExecuteWithPredicateEncodeRequest(name *string, entryProcessor *Data, predicate *Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapExecuteWithPredicateCalculateSize(name, entryProcessor, predicate))
-	clientMessage.SetMessageType(MAP_EXECUTEWITHPREDICATE)
+	clientMessage.SetMessageType(mapExecuteWithPredicate)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(entryProcessor)

--- a/internal/protocol/map_flush.go
+++ b/internal/protocol/map_flush.go
@@ -26,7 +26,7 @@ func MapFlushCalculateSize(name *string) int {
 func MapFlushEncodeRequest(name *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapFlushCalculateSize(name))
-	clientMessage.SetMessageType(MAP_FLUSH)
+	clientMessage.SetMessageType(mapFlush)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.UpdateFrameLength()

--- a/internal/protocol/map_forceunlock.go
+++ b/internal/protocol/map_forceunlock.go
@@ -32,7 +32,7 @@ func MapForceUnlockCalculateSize(name *string, key *Data, referenceId int64) int
 func MapForceUnlockEncodeRequest(name *string, key *Data, referenceId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapForceUnlockCalculateSize(name, key, referenceId))
-	clientMessage.SetMessageType(MAP_FORCEUNLOCK)
+	clientMessage.SetMessageType(mapForceUnlock)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(key)

--- a/internal/protocol/map_get.go
+++ b/internal/protocol/map_get.go
@@ -32,7 +32,7 @@ func MapGetCalculateSize(name *string, key *Data, threadId int64) int {
 func MapGetEncodeRequest(name *string, key *Data, threadId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapGetCalculateSize(name, key, threadId))
-	clientMessage.SetMessageType(MAP_GET)
+	clientMessage.SetMessageType(mapGet)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(key)

--- a/internal/protocol/map_getall.go
+++ b/internal/protocol/map_getall.go
@@ -34,7 +34,7 @@ func MapGetAllCalculateSize(name *string, keys []*Data) int {
 func MapGetAllEncodeRequest(name *string, keys []*Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapGetAllCalculateSize(name, keys))
-	clientMessage.SetMessageType(MAP_GETALL)
+	clientMessage.SetMessageType(mapGetAll)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendInt32(int32(len(keys)))

--- a/internal/protocol/map_getentryview.go
+++ b/internal/protocol/map_getentryview.go
@@ -32,7 +32,7 @@ func MapGetEntryViewCalculateSize(name *string, key *Data, threadId int64) int {
 func MapGetEntryViewEncodeRequest(name *string, key *Data, threadId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapGetEntryViewCalculateSize(name, key, threadId))
-	clientMessage.SetMessageType(MAP_GETENTRYVIEW)
+	clientMessage.SetMessageType(mapGetEntryView)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(key)

--- a/internal/protocol/map_isempty.go
+++ b/internal/protocol/map_isempty.go
@@ -26,7 +26,7 @@ func MapIsEmptyCalculateSize(name *string) int {
 func MapIsEmptyEncodeRequest(name *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapIsEmptyCalculateSize(name))
-	clientMessage.SetMessageType(MAP_ISEMPTY)
+	clientMessage.SetMessageType(mapIsEmpty)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.UpdateFrameLength()

--- a/internal/protocol/map_islocked.go
+++ b/internal/protocol/map_islocked.go
@@ -29,7 +29,7 @@ func MapIsLockedCalculateSize(name *string, key *Data) int {
 func MapIsLockedEncodeRequest(name *string, key *Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapIsLockedCalculateSize(name, key))
-	clientMessage.SetMessageType(MAP_ISLOCKED)
+	clientMessage.SetMessageType(mapIsLocked)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(key)

--- a/internal/protocol/map_keyset.go
+++ b/internal/protocol/map_keyset.go
@@ -28,7 +28,7 @@ func MapKeySetCalculateSize(name *string) int {
 func MapKeySetEncodeRequest(name *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapKeySetCalculateSize(name))
-	clientMessage.SetMessageType(MAP_KEYSET)
+	clientMessage.SetMessageType(mapKeySet)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.UpdateFrameLength()

--- a/internal/protocol/map_keysetwithpredicate.go
+++ b/internal/protocol/map_keysetwithpredicate.go
@@ -29,7 +29,7 @@ func MapKeySetWithPredicateCalculateSize(name *string, predicate *Data) int {
 func MapKeySetWithPredicateEncodeRequest(name *string, predicate *Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapKeySetWithPredicateCalculateSize(name, predicate))
-	clientMessage.SetMessageType(MAP_KEYSETWITHPREDICATE)
+	clientMessage.SetMessageType(mapKeySetWithPredicate)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(predicate)

--- a/internal/protocol/map_lock.go
+++ b/internal/protocol/map_lock.go
@@ -34,7 +34,7 @@ func MapLockCalculateSize(name *string, key *Data, threadId int64, ttl int64, re
 func MapLockEncodeRequest(name *string, key *Data, threadId int64, ttl int64, referenceId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapLockCalculateSize(name, key, threadId, ttl, referenceId))
-	clientMessage.SetMessageType(MAP_LOCK)
+	clientMessage.SetMessageType(mapLock)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(key)

--- a/internal/protocol/map_messagetype.go
+++ b/internal/protocol/map_messagetype.go
@@ -1,73 +1,87 @@
+// Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package protocol
 
 const (
-	MAP_PUT                                = 0x0101
-	MAP_GET                                = 0x0102
-	MAP_REMOVE                             = 0x0103
-	MAP_REPLACE                            = 0x0104
-	MAP_REPLACEIFSAME                      = 0x0105
-	MAP_CONTAINSKEY                        = 0x0109
-	MAP_CONTAINSVALUE                      = 0x010a
-	MAP_REMOVEIFSAME                       = 0x010b
-	MAP_DELETE                             = 0x010c
-	MAP_FLUSH                              = 0x010d
-	MAP_TRYREMOVE                          = 0x010e
-	MAP_TRYPUT                             = 0x010f
-	MAP_PUTTRANSIENT                       = 0x0110
-	MAP_PUTIFABSENT                        = 0x0111
-	MAP_SET                                = 0x0112
-	MAP_LOCK                               = 0x0113
-	MAP_TRYLOCK                            = 0x0114
-	MAP_ISLOCKED                           = 0x0115
-	MAP_UNLOCK                             = 0x0116
-	MAP_ADDINTERCEPTOR                     = 0x0117
-	MAP_REMOVEINTERCEPTOR                  = 0x0118
-	MAP_ADDENTRYLISTENERTOKEYWITHPREDICATE = 0x0119
-	MAP_ADDENTRYLISTENERWITHPREDICATE      = 0x011a
-	MAP_ADDENTRYLISTENERTOKEY              = 0x011b
-	MAP_ADDENTRYLISTENER                   = 0x011c
-	MAP_ADDNEARCACHEENTRYLISTENER          = 0x011d
-	MAP_REMOVEENTRYLISTENER                = 0x011e
-	MAP_ADDPARTITIONLOSTLISTENER           = 0x011f
-	MAP_REMOVEPARTITIONLOSTLISTENER        = 0x0120
-	MAP_GETENTRYVIEW                       = 0x0121
-	MAP_EVICT                              = 0x0122
-	MAP_EVICTALL                           = 0x0123
-	MAP_LOADALL                            = 0x0124
-	MAP_LOADGIVENKEYS                      = 0x0125
-	MAP_KEYSET                             = 0x0126
-	MAP_GETALL                             = 0x0127
-	MAP_VALUES                             = 0x0128
-	MAP_ENTRYSET                           = 0x0129
-	MAP_KEYSETWITHPREDICATE                = 0x012a
-	MAP_VALUESWITHPREDICATE                = 0x012b
-	MAP_ENTRIESWITHPREDICATE               = 0x012c
-	MAP_ADDINDEX                           = 0x012d
-	MAP_SIZE                               = 0x012e
-	MAP_ISEMPTY                            = 0x012f
-	MAP_PUTALL                             = 0x0130
-	MAP_CLEAR                              = 0x0131
-	MAP_EXECUTEONKEY                       = 0x0132
-	MAP_SUBMITTOKEY                        = 0x0133
-	MAP_EXECUTEONALLKEYS                   = 0x0134
-	MAP_EXECUTEWITHPREDICATE               = 0x0135
-	MAP_EXECUTEONKEYS                      = 0x0136
-	MAP_FORCEUNLOCK                        = 0x0137
-	MAP_KEYSETWITHPAGINGPREDICATE          = 0x0138
-	MAP_VALUESWITHPAGINGPREDICATE          = 0x0139
-	MAP_ENTRIESWITHPAGINGPREDICATE         = 0x013a
-	MAP_CLEARNEARCACHE                     = 0x013b
-	MAP_FETCHKEYS                          = 0x013c
-	MAP_FETCHENTRIES                       = 0x013d
-	MAP_AGGREGATE                          = 0x013e
-	MAP_AGGREGATEWITHPREDICATE             = 0x013f
-	MAP_PROJECT                            = 0x0140
-	MAP_PROJECTWITHPREDICATE               = 0x0141
-	MAP_FETCHNEARCACHEINVALIDATIONMETADATA = 0x0142
-	MAP_ASSIGNANDGETUUIDS                  = 0x0143
-	MAP_REMOVEALL                          = 0x0144
-	MAP_ADDNEARCACHEINVALIDATIONLISTENER   = 0x0145
-	MAP_FETCHWITHQUERY                     = 0x0146
-	MAP_EVENTJOURNALSUBSCRIBE              = 0x0147
-	MAP_EVENTJOURNALREAD                   = 0x0148
+	mapPut                                = 0x0101
+	mapGet                                = 0x0102
+	mapRemove                             = 0x0103
+	mapReplace                            = 0x0104
+	mapReplaceIfSame                      = 0x0105
+	mapContainsKey                        = 0x0109
+	mapContainsValue                      = 0x010a
+	mapRemoveIfSame                       = 0x010b
+	mapDelete                             = 0x010c
+	mapFlush                              = 0x010d
+	mapTryRemove                          = 0x010e
+	mapTryPut                             = 0x010f
+	mapPutTransient                       = 0x0110
+	mapPutIfAbsent                        = 0x0111
+	mapSet                                = 0x0112
+	mapLock                               = 0x0113
+	mapTryLock                            = 0x0114
+	mapIsLocked                           = 0x0115
+	mapUnlock                             = 0x0116
+	mapAddInterceptor                     = 0x0117
+	mapRemoveInterceptor                  = 0x0118
+	mapAddEntryListenerToKeyWithPredicate = 0x0119
+	mapAddEntryListenerWithPredicate      = 0x011a
+	mapAddEntryListenerToKey              = 0x011b
+	mapAddEntryListener                   = 0x011c
+	mapAddNearCacheEntryListener          = 0x011d
+	mapRemoveEntryListener                = 0x011e
+	mapAddPartitionLostListener           = 0x011f
+	mapRemovePartitionLostListener        = 0x0120
+	mapGetEntryView                       = 0x0121
+	mapEvict                              = 0x0122
+	mapEvictAll                           = 0x0123
+	mapLoadAll                            = 0x0124
+	mapLoadGivenKeys                      = 0x0125
+	mapKeySet                             = 0x0126
+	mapGetAll                             = 0x0127
+	mapValues                             = 0x0128
+	mapEntrySet                           = 0x0129
+	mapKeySetWithPredicate                = 0x012a
+	mapValuesWithPredicate                = 0x012b
+	mapEntriesWithPredicate               = 0x012c
+	mapAddIndex                           = 0x012d
+	mapSize                               = 0x012e
+	mapIsEmpty                            = 0x012f
+	mapPutAll                             = 0x0130
+	mapClear                              = 0x0131
+	mapExecuteOnKey                       = 0x0132
+	mapSubmitToKey                        = 0x0133
+	mapExecuteOnAllKeys                   = 0x0134
+	mapExecuteWithPredicate               = 0x0135
+	mapExecuteOnKeys                      = 0x0136
+	mapForceUnlock                        = 0x0137
+	mapKeySetWithPagingPredicate          = 0x0138
+	mapValuesWithPagingPredicate          = 0x0139
+	mapEntriesWithPagingPredicate         = 0x013a
+	mapClearNearCache                     = 0x013b
+	mapFetchKeys                          = 0x013c
+	mapFetchEntries                       = 0x013d
+	mapAggregate                          = 0x013e
+	mapAggregateWithPredicate             = 0x013f
+	mapProject                            = 0x0140
+	mapProjectWithPredicate               = 0x0141
+	mapFetchNearCacheInvalidationMetadata = 0x0142
+	mapAssignAndGetUuids                  = 0x0143
+	mapRemoveAll                          = 0x0144
+	mapAddNearCacheInvalidationListener   = 0x0145
+	mapFetchWithQuery                     = 0x0146
+	mapEventJournalSubscribe              = 0x0147
+	mapEventJournalRead                   = 0x0148
 )

--- a/internal/protocol/map_put.go
+++ b/internal/protocol/map_put.go
@@ -34,7 +34,7 @@ func MapPutCalculateSize(name *string, key *Data, value *Data, threadId int64, t
 func MapPutEncodeRequest(name *string, key *Data, value *Data, threadId int64, ttl int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapPutCalculateSize(name, key, value, threadId, ttl))
-	clientMessage.SetMessageType(MAP_PUT)
+	clientMessage.SetMessageType(mapPut)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(key)

--- a/internal/protocol/map_putall.go
+++ b/internal/protocol/map_putall.go
@@ -37,7 +37,7 @@ func MapPutAllCalculateSize(name *string, entries []*Pair) int {
 func MapPutAllEncodeRequest(name *string, entries []*Pair) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapPutAllCalculateSize(name, entries))
-	clientMessage.SetMessageType(MAP_PUTALL)
+	clientMessage.SetMessageType(mapPutAll)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendInt32(int32(len(entries)))

--- a/internal/protocol/map_putifabsent.go
+++ b/internal/protocol/map_putifabsent.go
@@ -34,7 +34,7 @@ func MapPutIfAbsentCalculateSize(name *string, key *Data, value *Data, threadId 
 func MapPutIfAbsentEncodeRequest(name *string, key *Data, value *Data, threadId int64, ttl int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapPutIfAbsentCalculateSize(name, key, value, threadId, ttl))
-	clientMessage.SetMessageType(MAP_PUTIFABSENT)
+	clientMessage.SetMessageType(mapPutIfAbsent)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(key)

--- a/internal/protocol/map_puttransient.go
+++ b/internal/protocol/map_puttransient.go
@@ -34,7 +34,7 @@ func MapPutTransientCalculateSize(name *string, key *Data, value *Data, threadId
 func MapPutTransientEncodeRequest(name *string, key *Data, value *Data, threadId int64, ttl int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapPutTransientCalculateSize(name, key, value, threadId, ttl))
-	clientMessage.SetMessageType(MAP_PUTTRANSIENT)
+	clientMessage.SetMessageType(mapPutTransient)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(key)

--- a/internal/protocol/map_remove.go
+++ b/internal/protocol/map_remove.go
@@ -32,7 +32,7 @@ func MapRemoveCalculateSize(name *string, key *Data, threadId int64) int {
 func MapRemoveEncodeRequest(name *string, key *Data, threadId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapRemoveCalculateSize(name, key, threadId))
-	clientMessage.SetMessageType(MAP_REMOVE)
+	clientMessage.SetMessageType(mapRemove)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(key)

--- a/internal/protocol/map_removeall.go
+++ b/internal/protocol/map_removeall.go
@@ -29,7 +29,7 @@ func MapRemoveAllCalculateSize(name *string, predicate *Data) int {
 func MapRemoveAllEncodeRequest(name *string, predicate *Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapRemoveAllCalculateSize(name, predicate))
-	clientMessage.SetMessageType(MAP_REMOVEALL)
+	clientMessage.SetMessageType(mapRemoveAll)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(predicate)

--- a/internal/protocol/map_removeentrylistener.go
+++ b/internal/protocol/map_removeentrylistener.go
@@ -27,7 +27,7 @@ func MapRemoveEntryListenerCalculateSize(name *string, registrationId *string) i
 func MapRemoveEntryListenerEncodeRequest(name *string, registrationId *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapRemoveEntryListenerCalculateSize(name, registrationId))
-	clientMessage.SetMessageType(MAP_REMOVEENTRYLISTENER)
+	clientMessage.SetMessageType(mapRemoveEntryListener)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.AppendString(registrationId)

--- a/internal/protocol/map_removeifsame.go
+++ b/internal/protocol/map_removeifsame.go
@@ -33,7 +33,7 @@ func MapRemoveIfSameCalculateSize(name *string, key *Data, value *Data, threadId
 func MapRemoveIfSameEncodeRequest(name *string, key *Data, value *Data, threadId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapRemoveIfSameCalculateSize(name, key, value, threadId))
-	clientMessage.SetMessageType(MAP_REMOVEIFSAME)
+	clientMessage.SetMessageType(mapRemoveIfSame)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(key)

--- a/internal/protocol/map_replace.go
+++ b/internal/protocol/map_replace.go
@@ -33,7 +33,7 @@ func MapReplaceCalculateSize(name *string, key *Data, value *Data, threadId int6
 func MapReplaceEncodeRequest(name *string, key *Data, value *Data, threadId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapReplaceCalculateSize(name, key, value, threadId))
-	clientMessage.SetMessageType(MAP_REPLACE)
+	clientMessage.SetMessageType(mapReplace)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(key)

--- a/internal/protocol/map_replaceifsame.go
+++ b/internal/protocol/map_replaceifsame.go
@@ -34,7 +34,7 @@ func MapReplaceIfSameCalculateSize(name *string, key *Data, testValue *Data, val
 func MapReplaceIfSameEncodeRequest(name *string, key *Data, testValue *Data, value *Data, threadId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapReplaceIfSameCalculateSize(name, key, testValue, value, threadId))
-	clientMessage.SetMessageType(MAP_REPLACEIFSAME)
+	clientMessage.SetMessageType(mapReplaceIfSame)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(key)

--- a/internal/protocol/map_set.go
+++ b/internal/protocol/map_set.go
@@ -34,7 +34,7 @@ func MapSetCalculateSize(name *string, key *Data, value *Data, threadId int64, t
 func MapSetEncodeRequest(name *string, key *Data, value *Data, threadId int64, ttl int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapSetCalculateSize(name, key, value, threadId, ttl))
-	clientMessage.SetMessageType(MAP_SET)
+	clientMessage.SetMessageType(mapSet)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(key)

--- a/internal/protocol/map_size.go
+++ b/internal/protocol/map_size.go
@@ -26,7 +26,7 @@ func MapSizeCalculateSize(name *string) int {
 func MapSizeEncodeRequest(name *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapSizeCalculateSize(name))
-	clientMessage.SetMessageType(MAP_SIZE)
+	clientMessage.SetMessageType(mapSize)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.UpdateFrameLength()

--- a/internal/protocol/map_trylock.go
+++ b/internal/protocol/map_trylock.go
@@ -35,7 +35,7 @@ func MapTryLockCalculateSize(name *string, key *Data, threadId int64, lease int6
 func MapTryLockEncodeRequest(name *string, key *Data, threadId int64, lease int64, timeout int64, referenceId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapTryLockCalculateSize(name, key, threadId, lease, timeout, referenceId))
-	clientMessage.SetMessageType(MAP_TRYLOCK)
+	clientMessage.SetMessageType(mapTryLock)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(key)

--- a/internal/protocol/map_tryput.go
+++ b/internal/protocol/map_tryput.go
@@ -34,7 +34,7 @@ func MapTryPutCalculateSize(name *string, key *Data, value *Data, threadId int64
 func MapTryPutEncodeRequest(name *string, key *Data, value *Data, threadId int64, timeout int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapTryPutCalculateSize(name, key, value, threadId, timeout))
-	clientMessage.SetMessageType(MAP_TRYPUT)
+	clientMessage.SetMessageType(mapTryPut)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(key)

--- a/internal/protocol/map_tryremove.go
+++ b/internal/protocol/map_tryremove.go
@@ -33,7 +33,7 @@ func MapTryRemoveCalculateSize(name *string, key *Data, threadId int64, timeout 
 func MapTryRemoveEncodeRequest(name *string, key *Data, threadId int64, timeout int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapTryRemoveCalculateSize(name, key, threadId, timeout))
-	clientMessage.SetMessageType(MAP_TRYREMOVE)
+	clientMessage.SetMessageType(mapTryRemove)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(key)

--- a/internal/protocol/map_unlock.go
+++ b/internal/protocol/map_unlock.go
@@ -33,7 +33,7 @@ func MapUnlockCalculateSize(name *string, key *Data, threadId int64, referenceId
 func MapUnlockEncodeRequest(name *string, key *Data, threadId int64, referenceId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapUnlockCalculateSize(name, key, threadId, referenceId))
-	clientMessage.SetMessageType(MAP_UNLOCK)
+	clientMessage.SetMessageType(mapUnlock)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(key)

--- a/internal/protocol/map_values.go
+++ b/internal/protocol/map_values.go
@@ -28,7 +28,7 @@ func MapValuesCalculateSize(name *string) int {
 func MapValuesEncodeRequest(name *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapValuesCalculateSize(name))
-	clientMessage.SetMessageType(MAP_VALUES)
+	clientMessage.SetMessageType(mapValues)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.UpdateFrameLength()

--- a/internal/protocol/map_valueswithpredicate.go
+++ b/internal/protocol/map_valueswithpredicate.go
@@ -29,7 +29,7 @@ func MapValuesWithPredicateCalculateSize(name *string, predicate *Data) int {
 func MapValuesWithPredicateEncodeRequest(name *string, predicate *Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapValuesWithPredicateCalculateSize(name, predicate))
-	clientMessage.SetMessageType(MAP_VALUESWITHPREDICATE)
+	clientMessage.SetMessageType(mapValuesWithPredicate)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(predicate)

--- a/internal/protocol/multimap_addentrylistener.go
+++ b/internal/protocol/multimap_addentrylistener.go
@@ -32,7 +32,7 @@ func MultiMapAddEntryListenerCalculateSize(name *string, includeValue bool, loca
 func MultiMapAddEntryListenerEncodeRequest(name *string, includeValue bool, localOnly bool) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MultiMapAddEntryListenerCalculateSize(name, includeValue, localOnly))
-	clientMessage.SetMessageType(MULTIMAP_ADDENTRYLISTENER)
+	clientMessage.SetMessageType(multimapAddEntryListener)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendBool(includeValue)

--- a/internal/protocol/multimap_addentrylistenertokey.go
+++ b/internal/protocol/multimap_addentrylistenertokey.go
@@ -33,7 +33,7 @@ func MultiMapAddEntryListenerToKeyCalculateSize(name *string, key *Data, include
 func MultiMapAddEntryListenerToKeyEncodeRequest(name *string, key *Data, includeValue bool, localOnly bool) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MultiMapAddEntryListenerToKeyCalculateSize(name, key, includeValue, localOnly))
-	clientMessage.SetMessageType(MULTIMAP_ADDENTRYLISTENERTOKEY)
+	clientMessage.SetMessageType(multimapAddEntryListenerToKey)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(key)

--- a/internal/protocol/multimap_clear.go
+++ b/internal/protocol/multimap_clear.go
@@ -26,7 +26,7 @@ func MultiMapClearCalculateSize(name *string) int {
 func MultiMapClearEncodeRequest(name *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MultiMapClearCalculateSize(name))
-	clientMessage.SetMessageType(MULTIMAP_CLEAR)
+	clientMessage.SetMessageType(multimapClear)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.UpdateFrameLength()

--- a/internal/protocol/multimap_containsentry.go
+++ b/internal/protocol/multimap_containsentry.go
@@ -33,7 +33,7 @@ func MultiMapContainsEntryCalculateSize(name *string, key *Data, value *Data, th
 func MultiMapContainsEntryEncodeRequest(name *string, key *Data, value *Data, threadId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MultiMapContainsEntryCalculateSize(name, key, value, threadId))
-	clientMessage.SetMessageType(MULTIMAP_CONTAINSENTRY)
+	clientMessage.SetMessageType(multimapContainsEntry)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(key)

--- a/internal/protocol/multimap_containskey.go
+++ b/internal/protocol/multimap_containskey.go
@@ -32,7 +32,7 @@ func MultiMapContainsKeyCalculateSize(name *string, key *Data, threadId int64) i
 func MultiMapContainsKeyEncodeRequest(name *string, key *Data, threadId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MultiMapContainsKeyCalculateSize(name, key, threadId))
-	clientMessage.SetMessageType(MULTIMAP_CONTAINSKEY)
+	clientMessage.SetMessageType(multimapContainsKey)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(key)

--- a/internal/protocol/multimap_containsvalue.go
+++ b/internal/protocol/multimap_containsvalue.go
@@ -29,7 +29,7 @@ func MultiMapContainsValueCalculateSize(name *string, value *Data) int {
 func MultiMapContainsValueEncodeRequest(name *string, value *Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MultiMapContainsValueCalculateSize(name, value))
-	clientMessage.SetMessageType(MULTIMAP_CONTAINSVALUE)
+	clientMessage.SetMessageType(multimapContainsValue)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(value)

--- a/internal/protocol/multimap_delete.go
+++ b/internal/protocol/multimap_delete.go
@@ -32,7 +32,7 @@ func MultiMapDeleteCalculateSize(name *string, key *Data, threadId int64) int {
 func MultiMapDeleteEncodeRequest(name *string, key *Data, threadId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MultiMapDeleteCalculateSize(name, key, threadId))
-	clientMessage.SetMessageType(MULTIMAP_DELETE)
+	clientMessage.SetMessageType(multimapDelete)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(key)

--- a/internal/protocol/multimap_entryset.go
+++ b/internal/protocol/multimap_entryset.go
@@ -26,7 +26,7 @@ func MultiMapEntrySetCalculateSize(name *string) int {
 func MultiMapEntrySetEncodeRequest(name *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MultiMapEntrySetCalculateSize(name))
-	clientMessage.SetMessageType(MULTIMAP_ENTRYSET)
+	clientMessage.SetMessageType(multimapEntrySet)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.UpdateFrameLength()

--- a/internal/protocol/multimap_forceunlock.go
+++ b/internal/protocol/multimap_forceunlock.go
@@ -32,7 +32,7 @@ func MultiMapForceUnlockCalculateSize(name *string, key *Data, referenceId int64
 func MultiMapForceUnlockEncodeRequest(name *string, key *Data, referenceId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MultiMapForceUnlockCalculateSize(name, key, referenceId))
-	clientMessage.SetMessageType(MULTIMAP_FORCEUNLOCK)
+	clientMessage.SetMessageType(multimapForceUnlock)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(key)

--- a/internal/protocol/multimap_get.go
+++ b/internal/protocol/multimap_get.go
@@ -32,7 +32,7 @@ func MultiMapGetCalculateSize(name *string, key *Data, threadId int64) int {
 func MultiMapGetEncodeRequest(name *string, key *Data, threadId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MultiMapGetCalculateSize(name, key, threadId))
-	clientMessage.SetMessageType(MULTIMAP_GET)
+	clientMessage.SetMessageType(multimapGet)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(key)

--- a/internal/protocol/multimap_islocked.go
+++ b/internal/protocol/multimap_islocked.go
@@ -29,7 +29,7 @@ func MultiMapIsLockedCalculateSize(name *string, key *Data) int {
 func MultiMapIsLockedEncodeRequest(name *string, key *Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MultiMapIsLockedCalculateSize(name, key))
-	clientMessage.SetMessageType(MULTIMAP_ISLOCKED)
+	clientMessage.SetMessageType(multimapIsLocked)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(key)

--- a/internal/protocol/multimap_keyset.go
+++ b/internal/protocol/multimap_keyset.go
@@ -28,7 +28,7 @@ func MultiMapKeySetCalculateSize(name *string) int {
 func MultiMapKeySetEncodeRequest(name *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MultiMapKeySetCalculateSize(name))
-	clientMessage.SetMessageType(MULTIMAP_KEYSET)
+	clientMessage.SetMessageType(multimapKeySet)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.UpdateFrameLength()

--- a/internal/protocol/multimap_lock.go
+++ b/internal/protocol/multimap_lock.go
@@ -34,7 +34,7 @@ func MultiMapLockCalculateSize(name *string, key *Data, threadId int64, ttl int6
 func MultiMapLockEncodeRequest(name *string, key *Data, threadId int64, ttl int64, referenceId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MultiMapLockCalculateSize(name, key, threadId, ttl, referenceId))
-	clientMessage.SetMessageType(MULTIMAP_LOCK)
+	clientMessage.SetMessageType(multimapLock)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(key)

--- a/internal/protocol/multimap_messagetype.go
+++ b/internal/protocol/multimap_messagetype.go
@@ -1,26 +1,40 @@
+// Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package protocol
 
 const (
-	MULTIMAP_PUT                   = 0x0201
-	MULTIMAP_GET                   = 0x0202
-	MULTIMAP_REMOVE                = 0x0203
-	MULTIMAP_KEYSET                = 0x0204
-	MULTIMAP_VALUES                = 0x0205
-	MULTIMAP_ENTRYSET              = 0x0206
-	MULTIMAP_CONTAINSKEY           = 0x0207
-	MULTIMAP_CONTAINSVALUE         = 0x0208
-	MULTIMAP_CONTAINSENTRY         = 0x0209
-	MULTIMAP_SIZE                  = 0x020a
-	MULTIMAP_CLEAR                 = 0x020b
-	MULTIMAP_VALUECOUNT            = 0x020c
-	MULTIMAP_ADDENTRYLISTENERTOKEY = 0x020d
-	MULTIMAP_ADDENTRYLISTENER      = 0x020e
-	MULTIMAP_REMOVEENTRYLISTENER   = 0x020f
-	MULTIMAP_LOCK                  = 0x0210
-	MULTIMAP_TRYLOCK               = 0x0211
-	MULTIMAP_ISLOCKED              = 0x0212
-	MULTIMAP_UNLOCK                = 0x0213
-	MULTIMAP_FORCEUNLOCK           = 0x0214
-	MULTIMAP_REMOVEENTRY           = 0x0215
-	MULTIMAP_DELETE                = 0x0216
+	multimapPut                   = 0x0201
+	multimapGet                   = 0x0202
+	multimapRemove                = 0x0203
+	multimapKeySet                = 0x0204
+	multimapValues                = 0x0205
+	multimapEntrySet              = 0x0206
+	multimapContainsKey           = 0x0207
+	multimapContainsValue         = 0x0208
+	multimapContainsEntry         = 0x0209
+	multimapSize                  = 0x020a
+	multimapClear                 = 0x020b
+	multimapValueCount            = 0x020c
+	multimapAddEntryListenerToKey = 0x020d
+	multimapAddEntryListener      = 0x020e
+	multimapRemoveEntryListener   = 0x020f
+	multimapLock                  = 0x0210
+	multimapTryLock               = 0x0211
+	multimapIsLocked              = 0x0212
+	multimapUnlock                = 0x0213
+	multimapForceUnlock           = 0x0214
+	multimapRemoveEntry           = 0x0215
+	multimapDelete                = 0x0216
 )

--- a/internal/protocol/multimap_put.go
+++ b/internal/protocol/multimap_put.go
@@ -33,7 +33,7 @@ func MultiMapPutCalculateSize(name *string, key *Data, value *Data, threadId int
 func MultiMapPutEncodeRequest(name *string, key *Data, value *Data, threadId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MultiMapPutCalculateSize(name, key, value, threadId))
-	clientMessage.SetMessageType(MULTIMAP_PUT)
+	clientMessage.SetMessageType(multimapPut)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(key)

--- a/internal/protocol/multimap_remove.go
+++ b/internal/protocol/multimap_remove.go
@@ -32,7 +32,7 @@ func MultiMapRemoveCalculateSize(name *string, key *Data, threadId int64) int {
 func MultiMapRemoveEncodeRequest(name *string, key *Data, threadId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MultiMapRemoveCalculateSize(name, key, threadId))
-	clientMessage.SetMessageType(MULTIMAP_REMOVE)
+	clientMessage.SetMessageType(multimapRemove)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(key)

--- a/internal/protocol/multimap_removeentry.go
+++ b/internal/protocol/multimap_removeentry.go
@@ -33,7 +33,7 @@ func MultiMapRemoveEntryCalculateSize(name *string, key *Data, value *Data, thre
 func MultiMapRemoveEntryEncodeRequest(name *string, key *Data, value *Data, threadId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MultiMapRemoveEntryCalculateSize(name, key, value, threadId))
-	clientMessage.SetMessageType(MULTIMAP_REMOVEENTRY)
+	clientMessage.SetMessageType(multimapRemoveEntry)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(key)

--- a/internal/protocol/multimap_removeentrylistener.go
+++ b/internal/protocol/multimap_removeentrylistener.go
@@ -27,7 +27,7 @@ func MultiMapRemoveEntryListenerCalculateSize(name *string, registrationId *stri
 func MultiMapRemoveEntryListenerEncodeRequest(name *string, registrationId *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MultiMapRemoveEntryListenerCalculateSize(name, registrationId))
-	clientMessage.SetMessageType(MULTIMAP_REMOVEENTRYLISTENER)
+	clientMessage.SetMessageType(multimapRemoveEntryListener)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.AppendString(registrationId)

--- a/internal/protocol/multimap_size.go
+++ b/internal/protocol/multimap_size.go
@@ -26,7 +26,7 @@ func MultiMapSizeCalculateSize(name *string) int {
 func MultiMapSizeEncodeRequest(name *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MultiMapSizeCalculateSize(name))
-	clientMessage.SetMessageType(MULTIMAP_SIZE)
+	clientMessage.SetMessageType(multimapSize)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.UpdateFrameLength()

--- a/internal/protocol/multimap_trylock.go
+++ b/internal/protocol/multimap_trylock.go
@@ -35,7 +35,7 @@ func MultiMapTryLockCalculateSize(name *string, key *Data, threadId int64, lease
 func MultiMapTryLockEncodeRequest(name *string, key *Data, threadId int64, lease int64, timeout int64, referenceId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MultiMapTryLockCalculateSize(name, key, threadId, lease, timeout, referenceId))
-	clientMessage.SetMessageType(MULTIMAP_TRYLOCK)
+	clientMessage.SetMessageType(multimapTryLock)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(key)

--- a/internal/protocol/multimap_unlock.go
+++ b/internal/protocol/multimap_unlock.go
@@ -33,7 +33,7 @@ func MultiMapUnlockCalculateSize(name *string, key *Data, threadId int64, refere
 func MultiMapUnlockEncodeRequest(name *string, key *Data, threadId int64, referenceId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MultiMapUnlockCalculateSize(name, key, threadId, referenceId))
-	clientMessage.SetMessageType(MULTIMAP_UNLOCK)
+	clientMessage.SetMessageType(multimapUnlock)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(key)

--- a/internal/protocol/multimap_valuecount.go
+++ b/internal/protocol/multimap_valuecount.go
@@ -32,7 +32,7 @@ func MultiMapValueCountCalculateSize(name *string, key *Data, threadId int64) in
 func MultiMapValueCountEncodeRequest(name *string, key *Data, threadId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MultiMapValueCountCalculateSize(name, key, threadId))
-	clientMessage.SetMessageType(MULTIMAP_VALUECOUNT)
+	clientMessage.SetMessageType(multimapValueCount)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(key)

--- a/internal/protocol/multimap_values.go
+++ b/internal/protocol/multimap_values.go
@@ -28,7 +28,7 @@ func MultiMapValuesCalculateSize(name *string) int {
 func MultiMapValuesEncodeRequest(name *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MultiMapValuesCalculateSize(name))
-	clientMessage.SetMessageType(MULTIMAP_VALUES)
+	clientMessage.SetMessageType(multimapValues)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.UpdateFrameLength()

--- a/internal/protocol/pncounter_add.go
+++ b/internal/protocol/pncounter_add.go
@@ -38,7 +38,7 @@ func PNCounterAddCalculateSize(name *string, delta int64, getBeforeUpdate bool, 
 func PNCounterAddEncodeRequest(name *string, delta int64, getBeforeUpdate bool, replicaTimestamps []*Pair, targetReplica *Address) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, PNCounterAddCalculateSize(name, delta, getBeforeUpdate, replicaTimestamps, targetReplica))
-	clientMessage.SetMessageType(PNCOUNTER_ADD)
+	clientMessage.SetMessageType(pncounterAdd)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendInt64(delta)

--- a/internal/protocol/pncounter_get.go
+++ b/internal/protocol/pncounter_get.go
@@ -36,7 +36,7 @@ func PNCounterGetCalculateSize(name *string, replicaTimestamps []*Pair, targetRe
 func PNCounterGetEncodeRequest(name *string, replicaTimestamps []*Pair, targetReplica *Address) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, PNCounterGetCalculateSize(name, replicaTimestamps, targetReplica))
-	clientMessage.SetMessageType(PNCOUNTER_GET)
+	clientMessage.SetMessageType(pncounterGet)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.AppendInt32(int32(len(replicaTimestamps)))

--- a/internal/protocol/pncounter_getconfiguredreplicacount.go
+++ b/internal/protocol/pncounter_getconfiguredreplicacount.go
@@ -14,6 +14,8 @@
 
 package protocol
 
+import ()
+
 func PNCounterGetConfiguredReplicaCountCalculateSize(name *string) int {
 	// Calculates the request payload size
 	dataSize := 0
@@ -24,7 +26,7 @@ func PNCounterGetConfiguredReplicaCountCalculateSize(name *string) int {
 func PNCounterGetConfiguredReplicaCountEncodeRequest(name *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, PNCounterGetConfiguredReplicaCountCalculateSize(name))
-	clientMessage.SetMessageType(PNCOUNTER_GETCONFIGUREDREPLICACOUNT)
+	clientMessage.SetMessageType(pncounterGetConfiguredReplicaCount)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.UpdateFrameLength()

--- a/internal/protocol/pncounter_messagetype.go
+++ b/internal/protocol/pncounter_messagetype.go
@@ -1,7 +1,21 @@
+// Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package protocol
 
 const (
-	PNCOUNTER_GET                       = 0x2001
-	PNCOUNTER_ADD                       = 0x2002
-	PNCOUNTER_GETCONFIGUREDREPLICACOUNT = 0x2003
+	pncounterGet                       = 0x2001
+	pncounterAdd                       = 0x2002
+	pncounterGetConfiguredReplicaCount = 0x2003
 )

--- a/internal/protocol/queue_addall.go
+++ b/internal/protocol/queue_addall.go
@@ -34,7 +34,7 @@ func QueueAddAllCalculateSize(name *string, dataList []*Data) int {
 func QueueAddAllEncodeRequest(name *string, dataList []*Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, QueueAddAllCalculateSize(name, dataList))
-	clientMessage.SetMessageType(QUEUE_ADDALL)
+	clientMessage.SetMessageType(queueAddAll)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendInt32(int32(len(dataList)))

--- a/internal/protocol/queue_addlistener.go
+++ b/internal/protocol/queue_addlistener.go
@@ -32,7 +32,7 @@ func QueueAddListenerCalculateSize(name *string, includeValue bool, localOnly bo
 func QueueAddListenerEncodeRequest(name *string, includeValue bool, localOnly bool) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, QueueAddListenerCalculateSize(name, includeValue, localOnly))
-	clientMessage.SetMessageType(QUEUE_ADDLISTENER)
+	clientMessage.SetMessageType(queueAddListener)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendBool(includeValue)

--- a/internal/protocol/queue_clear.go
+++ b/internal/protocol/queue_clear.go
@@ -26,7 +26,7 @@ func QueueClearCalculateSize(name *string) int {
 func QueueClearEncodeRequest(name *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, QueueClearCalculateSize(name))
-	clientMessage.SetMessageType(QUEUE_CLEAR)
+	clientMessage.SetMessageType(queueClear)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.UpdateFrameLength()

--- a/internal/protocol/queue_compareandremoveall.go
+++ b/internal/protocol/queue_compareandremoveall.go
@@ -34,7 +34,7 @@ func QueueCompareAndRemoveAllCalculateSize(name *string, dataList []*Data) int {
 func QueueCompareAndRemoveAllEncodeRequest(name *string, dataList []*Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, QueueCompareAndRemoveAllCalculateSize(name, dataList))
-	clientMessage.SetMessageType(QUEUE_COMPAREANDREMOVEALL)
+	clientMessage.SetMessageType(queueCompareAndRemoveAll)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendInt32(int32(len(dataList)))

--- a/internal/protocol/queue_compareandretainall.go
+++ b/internal/protocol/queue_compareandretainall.go
@@ -34,7 +34,7 @@ func QueueCompareAndRetainAllCalculateSize(name *string, dataList []*Data) int {
 func QueueCompareAndRetainAllEncodeRequest(name *string, dataList []*Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, QueueCompareAndRetainAllCalculateSize(name, dataList))
-	clientMessage.SetMessageType(QUEUE_COMPAREANDRETAINALL)
+	clientMessage.SetMessageType(queueCompareAndRetainAll)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendInt32(int32(len(dataList)))

--- a/internal/protocol/queue_contains.go
+++ b/internal/protocol/queue_contains.go
@@ -29,7 +29,7 @@ func QueueContainsCalculateSize(name *string, value *Data) int {
 func QueueContainsEncodeRequest(name *string, value *Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, QueueContainsCalculateSize(name, value))
-	clientMessage.SetMessageType(QUEUE_CONTAINS)
+	clientMessage.SetMessageType(queueContains)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(value)

--- a/internal/protocol/queue_containsall.go
+++ b/internal/protocol/queue_containsall.go
@@ -34,7 +34,7 @@ func QueueContainsAllCalculateSize(name *string, dataList []*Data) int {
 func QueueContainsAllEncodeRequest(name *string, dataList []*Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, QueueContainsAllCalculateSize(name, dataList))
-	clientMessage.SetMessageType(QUEUE_CONTAINSALL)
+	clientMessage.SetMessageType(queueContainsAll)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendInt32(int32(len(dataList)))

--- a/internal/protocol/queue_drainto.go
+++ b/internal/protocol/queue_drainto.go
@@ -28,7 +28,7 @@ func QueueDrainToCalculateSize(name *string) int {
 func QueueDrainToEncodeRequest(name *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, QueueDrainToCalculateSize(name))
-	clientMessage.SetMessageType(QUEUE_DRAINTO)
+	clientMessage.SetMessageType(queueDrainTo)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.UpdateFrameLength()

--- a/internal/protocol/queue_draintomaxsize.go
+++ b/internal/protocol/queue_draintomaxsize.go
@@ -30,7 +30,7 @@ func QueueDrainToMaxSizeCalculateSize(name *string, maxSize int32) int {
 func QueueDrainToMaxSizeEncodeRequest(name *string, maxSize int32) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, QueueDrainToMaxSizeCalculateSize(name, maxSize))
-	clientMessage.SetMessageType(QUEUE_DRAINTOMAXSIZE)
+	clientMessage.SetMessageType(queueDrainToMaxSize)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendInt32(maxSize)

--- a/internal/protocol/queue_isempty.go
+++ b/internal/protocol/queue_isempty.go
@@ -26,7 +26,7 @@ func QueueIsEmptyCalculateSize(name *string) int {
 func QueueIsEmptyEncodeRequest(name *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, QueueIsEmptyCalculateSize(name))
-	clientMessage.SetMessageType(QUEUE_ISEMPTY)
+	clientMessage.SetMessageType(queueIsEmpty)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.UpdateFrameLength()

--- a/internal/protocol/queue_iterator.go
+++ b/internal/protocol/queue_iterator.go
@@ -28,7 +28,7 @@ func QueueIteratorCalculateSize(name *string) int {
 func QueueIteratorEncodeRequest(name *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, QueueIteratorCalculateSize(name))
-	clientMessage.SetMessageType(QUEUE_ITERATOR)
+	clientMessage.SetMessageType(queueIterator)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.UpdateFrameLength()

--- a/internal/protocol/queue_messagetype.go
+++ b/internal/protocol/queue_messagetype.go
@@ -1,24 +1,38 @@
+// Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package protocol
 
 const (
-	QUEUE_OFFER               = 0x0301
-	QUEUE_PUT                 = 0x0302
-	QUEUE_SIZE                = 0x0303
-	QUEUE_REMOVE              = 0x0304
-	QUEUE_POLL                = 0x0305
-	QUEUE_TAKE                = 0x0306
-	QUEUE_PEEK                = 0x0307
-	QUEUE_ITERATOR            = 0x0308
-	QUEUE_DRAINTO             = 0x0309
-	QUEUE_DRAINTOMAXSIZE      = 0x030a
-	QUEUE_CONTAINS            = 0x030b
-	QUEUE_CONTAINSALL         = 0x030c
-	QUEUE_COMPAREANDREMOVEALL = 0x030d
-	QUEUE_COMPAREANDRETAINALL = 0x030e
-	QUEUE_CLEAR               = 0x030f
-	QUEUE_ADDALL              = 0x0310
-	QUEUE_ADDLISTENER         = 0x0311
-	QUEUE_REMOVELISTENER      = 0x0312
-	QUEUE_REMAININGCAPACITY   = 0x0313
-	QUEUE_ISEMPTY             = 0x0314
+	queueOffer               = 0x0301
+	queuePut                 = 0x0302
+	queueSize                = 0x0303
+	queueRemove              = 0x0304
+	queuePoll                = 0x0305
+	queueTake                = 0x0306
+	queuePeek                = 0x0307
+	queueIterator            = 0x0308
+	queueDrainTo             = 0x0309
+	queueDrainToMaxSize      = 0x030a
+	queueContains            = 0x030b
+	queueContainsAll         = 0x030c
+	queueCompareAndRemoveAll = 0x030d
+	queueCompareAndRetainAll = 0x030e
+	queueClear               = 0x030f
+	queueAddAll              = 0x0310
+	queueAddListener         = 0x0311
+	queueRemoveListener      = 0x0312
+	queueRemainingCapacity   = 0x0313
+	queueIsEmpty             = 0x0314
 )

--- a/internal/protocol/queue_offer.go
+++ b/internal/protocol/queue_offer.go
@@ -32,7 +32,7 @@ func QueueOfferCalculateSize(name *string, value *Data, timeoutMillis int64) int
 func QueueOfferEncodeRequest(name *string, value *Data, timeoutMillis int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, QueueOfferCalculateSize(name, value, timeoutMillis))
-	clientMessage.SetMessageType(QUEUE_OFFER)
+	clientMessage.SetMessageType(queueOffer)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(value)

--- a/internal/protocol/queue_peek.go
+++ b/internal/protocol/queue_peek.go
@@ -28,7 +28,7 @@ func QueuePeekCalculateSize(name *string) int {
 func QueuePeekEncodeRequest(name *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, QueuePeekCalculateSize(name))
-	clientMessage.SetMessageType(QUEUE_PEEK)
+	clientMessage.SetMessageType(queuePeek)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.UpdateFrameLength()

--- a/internal/protocol/queue_poll.go
+++ b/internal/protocol/queue_poll.go
@@ -30,7 +30,7 @@ func QueuePollCalculateSize(name *string, timeoutMillis int64) int {
 func QueuePollEncodeRequest(name *string, timeoutMillis int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, QueuePollCalculateSize(name, timeoutMillis))
-	clientMessage.SetMessageType(QUEUE_POLL)
+	clientMessage.SetMessageType(queuePoll)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendInt64(timeoutMillis)

--- a/internal/protocol/queue_put.go
+++ b/internal/protocol/queue_put.go
@@ -29,7 +29,7 @@ func QueuePutCalculateSize(name *string, value *Data) int {
 func QueuePutEncodeRequest(name *string, value *Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, QueuePutCalculateSize(name, value))
-	clientMessage.SetMessageType(QUEUE_PUT)
+	clientMessage.SetMessageType(queuePut)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(value)

--- a/internal/protocol/queue_remainingcapacity.go
+++ b/internal/protocol/queue_remainingcapacity.go
@@ -26,7 +26,7 @@ func QueueRemainingCapacityCalculateSize(name *string) int {
 func QueueRemainingCapacityEncodeRequest(name *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, QueueRemainingCapacityCalculateSize(name))
-	clientMessage.SetMessageType(QUEUE_REMAININGCAPACITY)
+	clientMessage.SetMessageType(queueRemainingCapacity)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.UpdateFrameLength()

--- a/internal/protocol/queue_remove.go
+++ b/internal/protocol/queue_remove.go
@@ -29,7 +29,7 @@ func QueueRemoveCalculateSize(name *string, value *Data) int {
 func QueueRemoveEncodeRequest(name *string, value *Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, QueueRemoveCalculateSize(name, value))
-	clientMessage.SetMessageType(QUEUE_REMOVE)
+	clientMessage.SetMessageType(queueRemove)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(value)

--- a/internal/protocol/queue_removelistener.go
+++ b/internal/protocol/queue_removelistener.go
@@ -27,7 +27,7 @@ func QueueRemoveListenerCalculateSize(name *string, registrationId *string) int 
 func QueueRemoveListenerEncodeRequest(name *string, registrationId *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, QueueRemoveListenerCalculateSize(name, registrationId))
-	clientMessage.SetMessageType(QUEUE_REMOVELISTENER)
+	clientMessage.SetMessageType(queueRemoveListener)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.AppendString(registrationId)

--- a/internal/protocol/queue_size.go
+++ b/internal/protocol/queue_size.go
@@ -26,7 +26,7 @@ func QueueSizeCalculateSize(name *string) int {
 func QueueSizeEncodeRequest(name *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, QueueSizeCalculateSize(name))
-	clientMessage.SetMessageType(QUEUE_SIZE)
+	clientMessage.SetMessageType(queueSize)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.UpdateFrameLength()

--- a/internal/protocol/queue_take.go
+++ b/internal/protocol/queue_take.go
@@ -28,7 +28,7 @@ func QueueTakeCalculateSize(name *string) int {
 func QueueTakeEncodeRequest(name *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, QueueTakeCalculateSize(name))
-	clientMessage.SetMessageType(QUEUE_TAKE)
+	clientMessage.SetMessageType(queueTake)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.UpdateFrameLength()

--- a/internal/protocol/replicatedmap_addentrylistener.go
+++ b/internal/protocol/replicatedmap_addentrylistener.go
@@ -31,7 +31,7 @@ func ReplicatedMapAddEntryListenerCalculateSize(name *string, localOnly bool) in
 func ReplicatedMapAddEntryListenerEncodeRequest(name *string, localOnly bool) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ReplicatedMapAddEntryListenerCalculateSize(name, localOnly))
-	clientMessage.SetMessageType(REPLICATEDMAP_ADDENTRYLISTENER)
+	clientMessage.SetMessageType(replicatedmapAddEntryListener)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendBool(localOnly)

--- a/internal/protocol/replicatedmap_addentrylistenertokey.go
+++ b/internal/protocol/replicatedmap_addentrylistenertokey.go
@@ -32,7 +32,7 @@ func ReplicatedMapAddEntryListenerToKeyCalculateSize(name *string, key *Data, lo
 func ReplicatedMapAddEntryListenerToKeyEncodeRequest(name *string, key *Data, localOnly bool) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ReplicatedMapAddEntryListenerToKeyCalculateSize(name, key, localOnly))
-	clientMessage.SetMessageType(REPLICATEDMAP_ADDENTRYLISTENERTOKEY)
+	clientMessage.SetMessageType(replicatedmapAddEntryListenerToKey)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(key)

--- a/internal/protocol/replicatedmap_addentrylistenertokeywithpredicate.go
+++ b/internal/protocol/replicatedmap_addentrylistenertokeywithpredicate.go
@@ -33,7 +33,7 @@ func ReplicatedMapAddEntryListenerToKeyWithPredicateCalculateSize(name *string, 
 func ReplicatedMapAddEntryListenerToKeyWithPredicateEncodeRequest(name *string, key *Data, predicate *Data, localOnly bool) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ReplicatedMapAddEntryListenerToKeyWithPredicateCalculateSize(name, key, predicate, localOnly))
-	clientMessage.SetMessageType(REPLICATEDMAP_ADDENTRYLISTENERTOKEYWITHPREDICATE)
+	clientMessage.SetMessageType(replicatedmapAddEntryListenerToKeyWithPredicate)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(key)

--- a/internal/protocol/replicatedmap_addentrylistenerwithpredicate.go
+++ b/internal/protocol/replicatedmap_addentrylistenerwithpredicate.go
@@ -32,7 +32,7 @@ func ReplicatedMapAddEntryListenerWithPredicateCalculateSize(name *string, predi
 func ReplicatedMapAddEntryListenerWithPredicateEncodeRequest(name *string, predicate *Data, localOnly bool) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ReplicatedMapAddEntryListenerWithPredicateCalculateSize(name, predicate, localOnly))
-	clientMessage.SetMessageType(REPLICATEDMAP_ADDENTRYLISTENERWITHPREDICATE)
+	clientMessage.SetMessageType(replicatedmapAddEntryListenerWithPredicate)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(predicate)

--- a/internal/protocol/replicatedmap_addnearcacheentrylistener.go
+++ b/internal/protocol/replicatedmap_addnearcacheentrylistener.go
@@ -32,7 +32,7 @@ func ReplicatedMapAddNearCacheEntryListenerCalculateSize(name *string, includeVa
 func ReplicatedMapAddNearCacheEntryListenerEncodeRequest(name *string, includeValue bool, localOnly bool) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ReplicatedMapAddNearCacheEntryListenerCalculateSize(name, includeValue, localOnly))
-	clientMessage.SetMessageType(REPLICATEDMAP_ADDNEARCACHEENTRYLISTENER)
+	clientMessage.SetMessageType(replicatedmapAddNearCacheEntryListener)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendBool(includeValue)

--- a/internal/protocol/replicatedmap_clear.go
+++ b/internal/protocol/replicatedmap_clear.go
@@ -26,7 +26,7 @@ func ReplicatedMapClearCalculateSize(name *string) int {
 func ReplicatedMapClearEncodeRequest(name *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ReplicatedMapClearCalculateSize(name))
-	clientMessage.SetMessageType(REPLICATEDMAP_CLEAR)
+	clientMessage.SetMessageType(replicatedmapClear)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.UpdateFrameLength()

--- a/internal/protocol/replicatedmap_containskey.go
+++ b/internal/protocol/replicatedmap_containskey.go
@@ -29,7 +29,7 @@ func ReplicatedMapContainsKeyCalculateSize(name *string, key *Data) int {
 func ReplicatedMapContainsKeyEncodeRequest(name *string, key *Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ReplicatedMapContainsKeyCalculateSize(name, key))
-	clientMessage.SetMessageType(REPLICATEDMAP_CONTAINSKEY)
+	clientMessage.SetMessageType(replicatedmapContainsKey)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(key)

--- a/internal/protocol/replicatedmap_containsvalue.go
+++ b/internal/protocol/replicatedmap_containsvalue.go
@@ -29,7 +29,7 @@ func ReplicatedMapContainsValueCalculateSize(name *string, value *Data) int {
 func ReplicatedMapContainsValueEncodeRequest(name *string, value *Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ReplicatedMapContainsValueCalculateSize(name, value))
-	clientMessage.SetMessageType(REPLICATEDMAP_CONTAINSVALUE)
+	clientMessage.SetMessageType(replicatedmapContainsValue)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(value)

--- a/internal/protocol/replicatedmap_entryset.go
+++ b/internal/protocol/replicatedmap_entryset.go
@@ -26,7 +26,7 @@ func ReplicatedMapEntrySetCalculateSize(name *string) int {
 func ReplicatedMapEntrySetEncodeRequest(name *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ReplicatedMapEntrySetCalculateSize(name))
-	clientMessage.SetMessageType(REPLICATEDMAP_ENTRYSET)
+	clientMessage.SetMessageType(replicatedmapEntrySet)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.UpdateFrameLength()

--- a/internal/protocol/replicatedmap_get.go
+++ b/internal/protocol/replicatedmap_get.go
@@ -29,7 +29,7 @@ func ReplicatedMapGetCalculateSize(name *string, key *Data) int {
 func ReplicatedMapGetEncodeRequest(name *string, key *Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ReplicatedMapGetCalculateSize(name, key))
-	clientMessage.SetMessageType(REPLICATEDMAP_GET)
+	clientMessage.SetMessageType(replicatedmapGet)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(key)

--- a/internal/protocol/replicatedmap_isempty.go
+++ b/internal/protocol/replicatedmap_isempty.go
@@ -26,7 +26,7 @@ func ReplicatedMapIsEmptyCalculateSize(name *string) int {
 func ReplicatedMapIsEmptyEncodeRequest(name *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ReplicatedMapIsEmptyCalculateSize(name))
-	clientMessage.SetMessageType(REPLICATEDMAP_ISEMPTY)
+	clientMessage.SetMessageType(replicatedmapIsEmpty)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.UpdateFrameLength()

--- a/internal/protocol/replicatedmap_keyset.go
+++ b/internal/protocol/replicatedmap_keyset.go
@@ -28,7 +28,7 @@ func ReplicatedMapKeySetCalculateSize(name *string) int {
 func ReplicatedMapKeySetEncodeRequest(name *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ReplicatedMapKeySetCalculateSize(name))
-	clientMessage.SetMessageType(REPLICATEDMAP_KEYSET)
+	clientMessage.SetMessageType(replicatedmapKeySet)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.UpdateFrameLength()

--- a/internal/protocol/replicatedmap_messagetype.go
+++ b/internal/protocol/replicatedmap_messagetype.go
@@ -1,22 +1,36 @@
+// Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package protocol
 
 const (
-	REPLICATEDMAP_PUT                                = 0x0e01
-	REPLICATEDMAP_SIZE                               = 0x0e02
-	REPLICATEDMAP_ISEMPTY                            = 0x0e03
-	REPLICATEDMAP_CONTAINSKEY                        = 0x0e04
-	REPLICATEDMAP_CONTAINSVALUE                      = 0x0e05
-	REPLICATEDMAP_GET                                = 0x0e06
-	REPLICATEDMAP_REMOVE                             = 0x0e07
-	REPLICATEDMAP_PUTALL                             = 0x0e08
-	REPLICATEDMAP_CLEAR                              = 0x0e09
-	REPLICATEDMAP_ADDENTRYLISTENERTOKEYWITHPREDICATE = 0x0e0a
-	REPLICATEDMAP_ADDENTRYLISTENERWITHPREDICATE      = 0x0e0b
-	REPLICATEDMAP_ADDENTRYLISTENERTOKEY              = 0x0e0c
-	REPLICATEDMAP_ADDENTRYLISTENER                   = 0x0e0d
-	REPLICATEDMAP_REMOVEENTRYLISTENER                = 0x0e0e
-	REPLICATEDMAP_KEYSET                             = 0x0e0f
-	REPLICATEDMAP_VALUES                             = 0x0e10
-	REPLICATEDMAP_ENTRYSET                           = 0x0e11
-	REPLICATEDMAP_ADDNEARCACHEENTRYLISTENER          = 0x0e12
+	replicatedmapPut                                = 0x0e01
+	replicatedmapSize                               = 0x0e02
+	replicatedmapIsEmpty                            = 0x0e03
+	replicatedmapContainsKey                        = 0x0e04
+	replicatedmapContainsValue                      = 0x0e05
+	replicatedmapGet                                = 0x0e06
+	replicatedmapRemove                             = 0x0e07
+	replicatedmapPutAll                             = 0x0e08
+	replicatedmapClear                              = 0x0e09
+	replicatedmapAddEntryListenerToKeyWithPredicate = 0x0e0a
+	replicatedmapAddEntryListenerWithPredicate      = 0x0e0b
+	replicatedmapAddEntryListenerToKey              = 0x0e0c
+	replicatedmapAddEntryListener                   = 0x0e0d
+	replicatedmapRemoveEntryListener                = 0x0e0e
+	replicatedmapKeySet                             = 0x0e0f
+	replicatedmapValues                             = 0x0e10
+	replicatedmapEntrySet                           = 0x0e11
+	replicatedmapAddNearCacheEntryListener          = 0x0e12
 )

--- a/internal/protocol/replicatedmap_put.go
+++ b/internal/protocol/replicatedmap_put.go
@@ -33,7 +33,7 @@ func ReplicatedMapPutCalculateSize(name *string, key *Data, value *Data, ttl int
 func ReplicatedMapPutEncodeRequest(name *string, key *Data, value *Data, ttl int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ReplicatedMapPutCalculateSize(name, key, value, ttl))
-	clientMessage.SetMessageType(REPLICATEDMAP_PUT)
+	clientMessage.SetMessageType(replicatedmapPut)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(key)

--- a/internal/protocol/replicatedmap_putall.go
+++ b/internal/protocol/replicatedmap_putall.go
@@ -37,7 +37,7 @@ func ReplicatedMapPutAllCalculateSize(name *string, entries []*Pair) int {
 func ReplicatedMapPutAllEncodeRequest(name *string, entries []*Pair) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ReplicatedMapPutAllCalculateSize(name, entries))
-	clientMessage.SetMessageType(REPLICATEDMAP_PUTALL)
+	clientMessage.SetMessageType(replicatedmapPutAll)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendInt32(int32(len(entries)))

--- a/internal/protocol/replicatedmap_remove.go
+++ b/internal/protocol/replicatedmap_remove.go
@@ -29,7 +29,7 @@ func ReplicatedMapRemoveCalculateSize(name *string, key *Data) int {
 func ReplicatedMapRemoveEncodeRequest(name *string, key *Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ReplicatedMapRemoveCalculateSize(name, key))
-	clientMessage.SetMessageType(REPLICATEDMAP_REMOVE)
+	clientMessage.SetMessageType(replicatedmapRemove)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(key)

--- a/internal/protocol/replicatedmap_removeentrylistener.go
+++ b/internal/protocol/replicatedmap_removeentrylistener.go
@@ -27,7 +27,7 @@ func ReplicatedMapRemoveEntryListenerCalculateSize(name *string, registrationId 
 func ReplicatedMapRemoveEntryListenerEncodeRequest(name *string, registrationId *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ReplicatedMapRemoveEntryListenerCalculateSize(name, registrationId))
-	clientMessage.SetMessageType(REPLICATEDMAP_REMOVEENTRYLISTENER)
+	clientMessage.SetMessageType(replicatedmapRemoveEntryListener)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.AppendString(registrationId)

--- a/internal/protocol/replicatedmap_size.go
+++ b/internal/protocol/replicatedmap_size.go
@@ -26,7 +26,7 @@ func ReplicatedMapSizeCalculateSize(name *string) int {
 func ReplicatedMapSizeEncodeRequest(name *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ReplicatedMapSizeCalculateSize(name))
-	clientMessage.SetMessageType(REPLICATEDMAP_SIZE)
+	clientMessage.SetMessageType(replicatedmapSize)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.UpdateFrameLength()

--- a/internal/protocol/replicatedmap_values.go
+++ b/internal/protocol/replicatedmap_values.go
@@ -28,7 +28,7 @@ func ReplicatedMapValuesCalculateSize(name *string) int {
 func ReplicatedMapValuesEncodeRequest(name *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ReplicatedMapValuesCalculateSize(name))
-	clientMessage.SetMessageType(REPLICATEDMAP_VALUES)
+	clientMessage.SetMessageType(replicatedmapValues)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.UpdateFrameLength()

--- a/internal/protocol/ringbuffer_add.go
+++ b/internal/protocol/ringbuffer_add.go
@@ -32,7 +32,7 @@ func RingbufferAddCalculateSize(name *string, overflowPolicy int32, value *Data)
 func RingbufferAddEncodeRequest(name *string, overflowPolicy int32, value *Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, RingbufferAddCalculateSize(name, overflowPolicy, value))
-	clientMessage.SetMessageType(RINGBUFFER_ADD)
+	clientMessage.SetMessageType(ringbufferAdd)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendInt32(overflowPolicy)

--- a/internal/protocol/ringbuffer_addall.go
+++ b/internal/protocol/ringbuffer_addall.go
@@ -35,7 +35,7 @@ func RingbufferAddAllCalculateSize(name *string, valueList []*Data, overflowPoli
 func RingbufferAddAllEncodeRequest(name *string, valueList []*Data, overflowPolicy int32) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, RingbufferAddAllCalculateSize(name, valueList, overflowPolicy))
-	clientMessage.SetMessageType(RINGBUFFER_ADDALL)
+	clientMessage.SetMessageType(ringbufferAddAll)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendInt32(int32(len(valueList)))

--- a/internal/protocol/ringbuffer_capacity.go
+++ b/internal/protocol/ringbuffer_capacity.go
@@ -26,7 +26,7 @@ func RingbufferCapacityCalculateSize(name *string) int {
 func RingbufferCapacityEncodeRequest(name *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, RingbufferCapacityCalculateSize(name))
-	clientMessage.SetMessageType(RINGBUFFER_CAPACITY)
+	clientMessage.SetMessageType(ringbufferCapacity)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.UpdateFrameLength()

--- a/internal/protocol/ringbuffer_headsequence.go
+++ b/internal/protocol/ringbuffer_headsequence.go
@@ -26,7 +26,7 @@ func RingbufferHeadSequenceCalculateSize(name *string) int {
 func RingbufferHeadSequenceEncodeRequest(name *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, RingbufferHeadSequenceCalculateSize(name))
-	clientMessage.SetMessageType(RINGBUFFER_HEADSEQUENCE)
+	clientMessage.SetMessageType(ringbufferHeadSequence)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.UpdateFrameLength()

--- a/internal/protocol/ringbuffer_messagetype.go
+++ b/internal/protocol/ringbuffer_messagetype.go
@@ -1,13 +1,27 @@
+// Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package protocol
 
 const (
-	RINGBUFFER_SIZE              = 0x1901
-	RINGBUFFER_TAILSEQUENCE      = 0x1902
-	RINGBUFFER_HEADSEQUENCE      = 0x1903
-	RINGBUFFER_CAPACITY          = 0x1904
-	RINGBUFFER_REMAININGCAPACITY = 0x1905
-	RINGBUFFER_ADD               = 0x1906
-	RINGBUFFER_READONE           = 0x1908
-	RINGBUFFER_ADDALL            = 0x1909
-	RINGBUFFER_READMANY          = 0x190a
+	ringbufferSize              = 0x1901
+	ringbufferTailSequence      = 0x1902
+	ringbufferHeadSequence      = 0x1903
+	ringbufferCapacity          = 0x1904
+	ringbufferRemainingCapacity = 0x1905
+	ringbufferAdd               = 0x1906
+	ringbufferReadOne           = 0x1908
+	ringbufferAddAll            = 0x1909
+	ringbufferReadMany          = 0x190a
 )

--- a/internal/protocol/ringbuffer_readone.go
+++ b/internal/protocol/ringbuffer_readone.go
@@ -30,7 +30,7 @@ func RingbufferReadOneCalculateSize(name *string, sequence int64) int {
 func RingbufferReadOneEncodeRequest(name *string, sequence int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, RingbufferReadOneCalculateSize(name, sequence))
-	clientMessage.SetMessageType(RINGBUFFER_READONE)
+	clientMessage.SetMessageType(ringbufferReadOne)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.AppendInt64(sequence)

--- a/internal/protocol/ringbuffer_remainingcapacity.go
+++ b/internal/protocol/ringbuffer_remainingcapacity.go
@@ -26,7 +26,7 @@ func RingbufferRemainingCapacityCalculateSize(name *string) int {
 func RingbufferRemainingCapacityEncodeRequest(name *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, RingbufferRemainingCapacityCalculateSize(name))
-	clientMessage.SetMessageType(RINGBUFFER_REMAININGCAPACITY)
+	clientMessage.SetMessageType(ringbufferRemainingCapacity)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.UpdateFrameLength()

--- a/internal/protocol/ringbuffer_size.go
+++ b/internal/protocol/ringbuffer_size.go
@@ -26,7 +26,7 @@ func RingbufferSizeCalculateSize(name *string) int {
 func RingbufferSizeEncodeRequest(name *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, RingbufferSizeCalculateSize(name))
-	clientMessage.SetMessageType(RINGBUFFER_SIZE)
+	clientMessage.SetMessageType(ringbufferSize)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.UpdateFrameLength()

--- a/internal/protocol/ringbuffer_tailsequence.go
+++ b/internal/protocol/ringbuffer_tailsequence.go
@@ -26,7 +26,7 @@ func RingbufferTailSequenceCalculateSize(name *string) int {
 func RingbufferTailSequenceEncodeRequest(name *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, RingbufferTailSequenceCalculateSize(name))
-	clientMessage.SetMessageType(RINGBUFFER_TAILSEQUENCE)
+	clientMessage.SetMessageType(ringbufferTailSequence)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.UpdateFrameLength()

--- a/internal/protocol/set_add.go
+++ b/internal/protocol/set_add.go
@@ -29,7 +29,7 @@ func SetAddCalculateSize(name *string, value *Data) int {
 func SetAddEncodeRequest(name *string, value *Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, SetAddCalculateSize(name, value))
-	clientMessage.SetMessageType(SET_ADD)
+	clientMessage.SetMessageType(setAdd)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(value)

--- a/internal/protocol/set_addall.go
+++ b/internal/protocol/set_addall.go
@@ -34,7 +34,7 @@ func SetAddAllCalculateSize(name *string, valueList []*Data) int {
 func SetAddAllEncodeRequest(name *string, valueList []*Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, SetAddAllCalculateSize(name, valueList))
-	clientMessage.SetMessageType(SET_ADDALL)
+	clientMessage.SetMessageType(setAddAll)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendInt32(int32(len(valueList)))

--- a/internal/protocol/set_addlistener.go
+++ b/internal/protocol/set_addlistener.go
@@ -32,7 +32,7 @@ func SetAddListenerCalculateSize(name *string, includeValue bool, localOnly bool
 func SetAddListenerEncodeRequest(name *string, includeValue bool, localOnly bool) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, SetAddListenerCalculateSize(name, includeValue, localOnly))
-	clientMessage.SetMessageType(SET_ADDLISTENER)
+	clientMessage.SetMessageType(setAddListener)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendBool(includeValue)

--- a/internal/protocol/set_clear.go
+++ b/internal/protocol/set_clear.go
@@ -26,7 +26,7 @@ func SetClearCalculateSize(name *string) int {
 func SetClearEncodeRequest(name *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, SetClearCalculateSize(name))
-	clientMessage.SetMessageType(SET_CLEAR)
+	clientMessage.SetMessageType(setClear)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.UpdateFrameLength()

--- a/internal/protocol/set_compareandremoveall.go
+++ b/internal/protocol/set_compareandremoveall.go
@@ -34,7 +34,7 @@ func SetCompareAndRemoveAllCalculateSize(name *string, values []*Data) int {
 func SetCompareAndRemoveAllEncodeRequest(name *string, values []*Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, SetCompareAndRemoveAllCalculateSize(name, values))
-	clientMessage.SetMessageType(SET_COMPAREANDREMOVEALL)
+	clientMessage.SetMessageType(setCompareAndRemoveAll)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendInt32(int32(len(values)))

--- a/internal/protocol/set_compareandretainall.go
+++ b/internal/protocol/set_compareandretainall.go
@@ -34,7 +34,7 @@ func SetCompareAndRetainAllCalculateSize(name *string, values []*Data) int {
 func SetCompareAndRetainAllEncodeRequest(name *string, values []*Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, SetCompareAndRetainAllCalculateSize(name, values))
-	clientMessage.SetMessageType(SET_COMPAREANDRETAINALL)
+	clientMessage.SetMessageType(setCompareAndRetainAll)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendInt32(int32(len(values)))

--- a/internal/protocol/set_contains.go
+++ b/internal/protocol/set_contains.go
@@ -29,7 +29,7 @@ func SetContainsCalculateSize(name *string, value *Data) int {
 func SetContainsEncodeRequest(name *string, value *Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, SetContainsCalculateSize(name, value))
-	clientMessage.SetMessageType(SET_CONTAINS)
+	clientMessage.SetMessageType(setContains)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(value)

--- a/internal/protocol/set_containsall.go
+++ b/internal/protocol/set_containsall.go
@@ -34,7 +34,7 @@ func SetContainsAllCalculateSize(name *string, items []*Data) int {
 func SetContainsAllEncodeRequest(name *string, items []*Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, SetContainsAllCalculateSize(name, items))
-	clientMessage.SetMessageType(SET_CONTAINSALL)
+	clientMessage.SetMessageType(setContainsAll)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendInt32(int32(len(items)))

--- a/internal/protocol/set_getall.go
+++ b/internal/protocol/set_getall.go
@@ -28,7 +28,7 @@ func SetGetAllCalculateSize(name *string) int {
 func SetGetAllEncodeRequest(name *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, SetGetAllCalculateSize(name))
-	clientMessage.SetMessageType(SET_GETALL)
+	clientMessage.SetMessageType(setGetAll)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.UpdateFrameLength()

--- a/internal/protocol/set_isempty.go
+++ b/internal/protocol/set_isempty.go
@@ -26,7 +26,7 @@ func SetIsEmptyCalculateSize(name *string) int {
 func SetIsEmptyEncodeRequest(name *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, SetIsEmptyCalculateSize(name))
-	clientMessage.SetMessageType(SET_ISEMPTY)
+	clientMessage.SetMessageType(setIsEmpty)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.UpdateFrameLength()

--- a/internal/protocol/set_messagetype.go
+++ b/internal/protocol/set_messagetype.go
@@ -1,17 +1,31 @@
+// Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package protocol
 
 const (
-	SET_SIZE                = 0x0601
-	SET_CONTAINS            = 0x0602
-	SET_CONTAINSALL         = 0x0603
-	SET_ADD                 = 0x0604
-	SET_REMOVE              = 0x0605
-	SET_ADDALL              = 0x0606
-	SET_COMPAREANDREMOVEALL = 0x0607
-	SET_COMPAREANDRETAINALL = 0x0608
-	SET_CLEAR               = 0x0609
-	SET_GETALL              = 0x060a
-	SET_ADDLISTENER         = 0x060b
-	SET_REMOVELISTENER      = 0x060c
-	SET_ISEMPTY             = 0x060d
+	setSize                = 0x0601
+	setContains            = 0x0602
+	setContainsAll         = 0x0603
+	setAdd                 = 0x0604
+	setRemove              = 0x0605
+	setAddAll              = 0x0606
+	setCompareAndRemoveAll = 0x0607
+	setCompareAndRetainAll = 0x0608
+	setClear               = 0x0609
+	setGetAll              = 0x060a
+	setAddListener         = 0x060b
+	setRemoveListener      = 0x060c
+	setIsEmpty             = 0x060d
 )

--- a/internal/protocol/set_remove.go
+++ b/internal/protocol/set_remove.go
@@ -29,7 +29,7 @@ func SetRemoveCalculateSize(name *string, value *Data) int {
 func SetRemoveEncodeRequest(name *string, value *Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, SetRemoveCalculateSize(name, value))
-	clientMessage.SetMessageType(SET_REMOVE)
+	clientMessage.SetMessageType(setRemove)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(value)

--- a/internal/protocol/set_removelistener.go
+++ b/internal/protocol/set_removelistener.go
@@ -27,7 +27,7 @@ func SetRemoveListenerCalculateSize(name *string, registrationId *string) int {
 func SetRemoveListenerEncodeRequest(name *string, registrationId *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, SetRemoveListenerCalculateSize(name, registrationId))
-	clientMessage.SetMessageType(SET_REMOVELISTENER)
+	clientMessage.SetMessageType(setRemoveListener)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.AppendString(registrationId)

--- a/internal/protocol/set_size.go
+++ b/internal/protocol/set_size.go
@@ -26,7 +26,7 @@ func SetSizeCalculateSize(name *string) int {
 func SetSizeEncodeRequest(name *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, SetSizeCalculateSize(name))
-	clientMessage.SetMessageType(SET_SIZE)
+	clientMessage.SetMessageType(setSize)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.UpdateFrameLength()

--- a/internal/protocol/topic_addmessagelistener.go
+++ b/internal/protocol/topic_addmessagelistener.go
@@ -31,7 +31,7 @@ func TopicAddMessageListenerCalculateSize(name *string, localOnly bool) int {
 func TopicAddMessageListenerEncodeRequest(name *string, localOnly bool) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, TopicAddMessageListenerCalculateSize(name, localOnly))
-	clientMessage.SetMessageType(TOPIC_ADDMESSAGELISTENER)
+	clientMessage.SetMessageType(topicAddMessageListener)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendBool(localOnly)

--- a/internal/protocol/topic_messagetype.go
+++ b/internal/protocol/topic_messagetype.go
@@ -1,7 +1,21 @@
+// Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package protocol
 
 const (
-	TOPIC_PUBLISH               = 0x0401
-	TOPIC_ADDMESSAGELISTENER    = 0x0402
-	TOPIC_REMOVEMESSAGELISTENER = 0x0403
+	topicPublish               = 0x0401
+	topicAddMessageListener    = 0x0402
+	topicRemoveMessageListener = 0x0403
 )

--- a/internal/protocol/topic_publish.go
+++ b/internal/protocol/topic_publish.go
@@ -29,7 +29,7 @@ func TopicPublishCalculateSize(name *string, message *Data) int {
 func TopicPublishEncodeRequest(name *string, message *Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, TopicPublishCalculateSize(name, message))
-	clientMessage.SetMessageType(TOPIC_PUBLISH)
+	clientMessage.SetMessageType(topicPublish)
 	clientMessage.IsRetryable = false
 	clientMessage.AppendString(name)
 	clientMessage.AppendData(message)

--- a/internal/protocol/topic_removemessagelistener.go
+++ b/internal/protocol/topic_removemessagelistener.go
@@ -27,7 +27,7 @@ func TopicRemoveMessageListenerCalculateSize(name *string, registrationId *strin
 func TopicRemoveMessageListenerEncodeRequest(name *string, registrationId *string) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, TopicRemoveMessageListenerCalculateSize(name, registrationId))
-	clientMessage.SetMessageType(TOPIC_REMOVEMESSAGELISTENER)
+	clientMessage.SetMessageType(topicRemoveMessageListener)
 	clientMessage.IsRetryable = true
 	clientMessage.AppendString(name)
 	clientMessage.AppendString(registrationId)

--- a/internal/ringbuffer.go
+++ b/internal/ringbuffer.go
@@ -115,7 +115,7 @@ func (rp *RingbufferProxy) ReadMany(startSequence int64, minCount int32, maxCoun
 	if err != nil {
 		return
 	}
-	readCount, itemsData, itemSeqs := RingbufferReadManyDecodeResponse(responseMessage)()
+	readCount, itemsData, itemSeqs, _ /*nextSeq*/ := RingbufferReadManyDecodeResponse(responseMessage)()
 	return NewLazyReadResultSet(readCount, itemsData, itemSeqs, rp.client.SerializationService), nil
 }
 


### PR DESCRIPTION
This pr changes constants names in codecs according to go conventions. Also missing licenses are added to message type codecs.

Message types are changed from public to private.

