### PR TITLE
add contributing and issue template

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+#### Contributing
+If you would like to contribute to hazelcast-go-client;
+- Fork the original repo
+- Commit your contributions in a new branch
+- Send a Pull Request
+
+For detailed instructions for our git process: [Developing with Git](https://hazelcast.atlassian.net/wiki/display/COM/Developing+with+Git)
+
+In order to merge your pull request, we need the contributor to sign [Hazelcast Contributor Agreement](https://hazelcast.atlassian.net/wiki/display/COM/Hazelcast+Contributor+Agreement). You do not have to wait for approval for doing this step.
+
+Please make sure that your code passes `sh linter.sh`. This is a script for [gometalinter](https://github.com/alecthomas/gometalinter)
+Please make sure that your code compiles and passes all the tests by running `localTest.sh` before sending a pull request.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,14 @@
+Go version:
+Hazelcast Go Client version:
+Hazelcast server version:
+Number of the clients:
+Cluster size, i.e. the number of Hazelcast cluster members:
+OS version : Windows/Linux/OSX
+
+#### Expected behaviour
+
+
+#### Actual behaviour
+
+
+#### Steps to reproduce the behaviour


### PR DESCRIPTION
This pr adds `CONTRIBUTING.md` and `ISSUE_TEMPLATE.md`. They are added to `.github` folder. 
These files might be useful and make things easier for users when contributing or creating a new issue. With an issue template, issue creators will know what information to give.