### PR TITLE
remove dots from imports

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -17,7 +17,7 @@ package config
 
 import (
 	"github.com/hazelcast/hazelcast-go-client/core"
-	. "github.com/hazelcast/hazelcast-go-client/serialization"
+	"github.com/hazelcast/hazelcast-go-client/serialization"
 	"reflect"
 	"time"
 )
@@ -171,29 +171,29 @@ type SerializationConfig struct {
 	isBigEndian bool
 
 	// dataSerializableFactories is a map of factory IDs and corresponding IdentifiedDataSerializable factories.
-	dataSerializableFactories map[int32]IdentifiedDataSerializableFactory
+	dataSerializableFactories map[int32]serialization.IdentifiedDataSerializableFactory
 
 	// portableFactories is a map of factory IDs and corresponding Portable factories.
-	portableFactories map[int32]PortableFactory
+	portableFactories map[int32]serialization.PortableFactory
 
 	// Portable version will be used to differentiate two versions of the same struct that have changes on the struct,
 	// like adding/removing a field or changing a type of a field.
 	portableVersion int32
 
 	// customSerializers is a map of object types and corresponding custom serializers.
-	customSerializers map[reflect.Type]Serializer
+	customSerializers map[reflect.Type]serialization.Serializer
 
 	// globalSerializer is the serializer that will be used if no other serializer is applicable.
-	globalSerializer Serializer
+	globalSerializer serialization.Serializer
 
 	// classDefinitions contains ClassDefinitions for portable structs.
-	classDefinitions []ClassDefinition
+	classDefinitions []serialization.ClassDefinition
 }
 
 // NewSerializationConfig creates a SerializationConfig with default values.
 func NewSerializationConfig() *SerializationConfig {
-	return &SerializationConfig{isBigEndian: true, dataSerializableFactories: make(map[int32]IdentifiedDataSerializableFactory),
-		portableFactories: make(map[int32]PortableFactory), portableVersion: 0, customSerializers: make(map[reflect.Type]Serializer)}
+	return &SerializationConfig{isBigEndian: true, dataSerializableFactories: make(map[int32]serialization.IdentifiedDataSerializableFactory),
+		portableFactories: make(map[int32]serialization.PortableFactory), portableVersion: 0, customSerializers: make(map[reflect.Type]serialization.Serializer)}
 }
 
 // IsBigEndian returns isBigEndian bool value.
@@ -202,12 +202,12 @@ func (serializationConfig *SerializationConfig) IsBigEndian() bool {
 }
 
 // DataSerializableFactories returns a map of factory IDs and corresponding IdentifiedDataSerializable factories.
-func (serializationConfig *SerializationConfig) DataSerializableFactories() map[int32]IdentifiedDataSerializableFactory {
+func (serializationConfig *SerializationConfig) DataSerializableFactories() map[int32]serialization.IdentifiedDataSerializableFactory {
 	return serializationConfig.dataSerializableFactories
 }
 
 // PortableFactories returns a map of factory IDs and corresponding Portable factories.
-func (serializationConfig *SerializationConfig) PortableFactories() map[int32]PortableFactory {
+func (serializationConfig *SerializationConfig) PortableFactories() map[int32]serialization.PortableFactory {
 	return serializationConfig.portableFactories
 }
 
@@ -217,17 +217,17 @@ func (serializationConfig *SerializationConfig) PortableVersion() int32 {
 }
 
 // CustomSerializers returns a map of object types and corresponding custom serializers.
-func (serializationConfig *SerializationConfig) CustomSerializers() map[reflect.Type]Serializer {
+func (serializationConfig *SerializationConfig) CustomSerializers() map[reflect.Type]serialization.Serializer {
 	return serializationConfig.customSerializers
 }
 
 // GlobalSerializer returns the global serializer.
-func (serializationConfig *SerializationConfig) GlobalSerializer() Serializer {
+func (serializationConfig *SerializationConfig) GlobalSerializer() serialization.Serializer {
 	return serializationConfig.globalSerializer
 }
 
 // ClassDefinitions returns registered class definitions of portable structs.
-func (serializationConfig *SerializationConfig) ClassDefinitions() []ClassDefinition {
+func (serializationConfig *SerializationConfig) ClassDefinitions() []serialization.ClassDefinition {
 	return serializationConfig.classDefinitions
 }
 
@@ -237,17 +237,17 @@ func (serializationConfig *SerializationConfig) SetByteOrder(isBigEndian bool) {
 }
 
 // AddDataSerializableFactory adds a IdentifiedDataSerializableFactory for a given factory ID.
-func (serializationConfig *SerializationConfig) AddDataSerializableFactory(factoryId int32, f IdentifiedDataSerializableFactory) {
+func (serializationConfig *SerializationConfig) AddDataSerializableFactory(factoryId int32, f serialization.IdentifiedDataSerializableFactory) {
 	serializationConfig.dataSerializableFactories[factoryId] = f
 }
 
 // AddPortableFactory adds a PortableFactory for a given factory ID.
-func (serializationConfig *SerializationConfig) AddPortableFactory(factoryId int32, pf PortableFactory) {
+func (serializationConfig *SerializationConfig) AddPortableFactory(factoryId int32, pf serialization.PortableFactory) {
 	serializationConfig.portableFactories[factoryId] = pf
 }
 
 // AddClassDefinition registers class definitions explicitly.
-func (serializationConfig *SerializationConfig) AddClassDefinition(classDefinition ...ClassDefinition) {
+func (serializationConfig *SerializationConfig) AddClassDefinition(classDefinition ...serialization.ClassDefinition) {
 	serializationConfig.classDefinitions = append(serializationConfig.classDefinitions, classDefinition...)
 }
 
@@ -257,7 +257,7 @@ func (serializationConfig *SerializationConfig) SetPortableVersion(version int32
 }
 
 // AddCustomSerializer adds a custom serializer for a given type. It can be an interface type or a struct type.
-func (serializationConfig *SerializationConfig) AddCustomSerializer(typ reflect.Type, serializer Serializer) error {
+func (serializationConfig *SerializationConfig) AddCustomSerializer(typ reflect.Type, serializer serialization.Serializer) error {
 	if serializer.Id() > 0 {
 		serializationConfig.customSerializers[typ] = serializer
 	} else {
@@ -267,7 +267,7 @@ func (serializationConfig *SerializationConfig) AddCustomSerializer(typ reflect.
 }
 
 // SetGlobalSerializer sets the global serializer.
-func (serializationConfig *SerializationConfig) SetGlobalSerializer(serializer Serializer) error {
+func (serializationConfig *SerializationConfig) SetGlobalSerializer(serializer serialization.Serializer) error {
 	if serializer.Id() > 0 {
 		serializationConfig.globalSerializer = serializer
 	} else {

--- a/core/predicates/predicates.go
+++ b/core/predicates/predicates.go
@@ -15,95 +15,95 @@
 package predicates
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/predicates"
+	"github.com/hazelcast/hazelcast-go-client/internal/predicates"
 )
 
 // Sql is a helper function for creating SqlPredicate.
 func Sql(sql string) interface{} {
-	return NewSqlPredicate(sql)
+	return predicates.NewSqlPredicate(sql)
 }
 
 // And is a helper function for creating AndPredicate.
-func And(predicates ...interface{}) interface{} {
-	return NewAndPredicate(predicates)
+func And(predicate ...interface{}) interface{} {
+	return predicates.NewAndPredicate(predicate)
 }
 
 // Between is a helper function for creating BetweenPredicate.
 func Between(field string, from interface{}, to interface{}) interface{} {
-	return NewBetweenPredicate(field, from, to)
+	return predicates.NewBetweenPredicate(field, from, to)
 }
 
 // Equal is a helper function for creating EqualPredicate.
 func Equal(field string, value interface{}) interface{} {
-	return NewEqualPredicate(field, value)
+	return predicates.NewEqualPredicate(field, value)
 }
 
 // GreaterThan is a helper function for creating GreaterLessPredicate behaving like greater than.
 func GreaterThan(field string, value interface{}) interface{} {
-	return NewGreaterLessPredicate(field, value, false, false)
+	return predicates.NewGreaterLessPredicate(field, value, false, false)
 }
 
 // GreaterEqual is a helper function for creating GreaterLessPredicate behaving like greater equal.
 func GreaterEqual(field string, value interface{}) interface{} {
-	return NewGreaterLessPredicate(field, value, true, false)
+	return predicates.NewGreaterLessPredicate(field, value, true, false)
 }
 
 // LessThan is a helper function for creating GreaterLessPredicate behaving like less than.
 func LessThan(field string, value interface{}) interface{} {
-	return NewGreaterLessPredicate(field, value, false, true)
+	return predicates.NewGreaterLessPredicate(field, value, false, true)
 }
 
 // LessEqual is a helper function for creating GreaterLessPredicate behaving like less equal.
 func LessEqual(field string, value interface{}) interface{} {
-	return NewGreaterLessPredicate(field, value, true, true)
+	return predicates.NewGreaterLessPredicate(field, value, true, true)
 }
 
 // Like is a helper function for creating LikePredicate.
 func Like(field string, expr string) interface{} {
-	return NewLikePredicate(field, expr)
+	return predicates.NewLikePredicate(field, expr)
 }
 
 // ILike is a helper function for creating ILikePredicate.
 func ILike(field string, expr string) interface{} {
-	return NewILikePredicate(field, expr)
+	return predicates.NewILikePredicate(field, expr)
 }
 
 // In is a helper function for creating InPredicate.
 func In(field string, values ...interface{}) interface{} {
-	return NewInPredicate(field, values)
+	return predicates.NewInPredicate(field, values)
 }
 
 // InstanceOf is a helper function for creating InstanceOfPredicate.
 func InstanceOf(className string) interface{} {
-	return NewInstanceOfPredicate(className)
+	return predicates.NewInstanceOfPredicate(className)
 }
 
 // NotEqual is a helper function for creating NotEqualPredicate.
 func NotEqual(field string, value interface{}) interface{} {
-	return NewNotEqualPredicate(field, value)
+	return predicates.NewNotEqualPredicate(field, value)
 }
 
 // Not is a helper function for creating NotPredicate.
 func Not(predicate interface{}) interface{} {
-	return NewNotPredicate(predicate)
+	return predicates.NewNotPredicate(predicate)
 }
 
 // Or is a helper function for creating OrPredicate.
-func Or(predicates ...interface{}) interface{} {
-	return NewOrPredicate(predicates)
+func Or(predicate ...interface{}) interface{} {
+	return predicates.NewOrPredicate(predicate)
 }
 
 // Regex is a helper function for creating RegexPredicate.
 func Regex(field string, regex string) interface{} {
-	return NewRegexPredicate(field, regex)
+	return predicates.NewRegexPredicate(field, regex)
 }
 
 // True is a helper function for creating TruePredicate.
 func True() interface{} {
-	return NewTruePredicate()
+	return predicates.NewTruePredicate()
 }
 
 // False is a helper function for creating FalsePredicate.
 func False() interface{} {
-	return NewFalsePredicate()
+	return predicates.NewFalsePredicate()
 }

--- a/internal/client.go
+++ b/internal/client.go
@@ -15,17 +15,17 @@
 package internal
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/config"
+	"github.com/hazelcast/hazelcast-go-client/config"
 	"github.com/hazelcast/hazelcast-go-client/core"
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
 type HazelcastClient struct {
-	ClientConfig         *ClientConfig
+	ClientConfig         *config.ClientConfig
 	InvocationService    *invocationService
 	PartitionService     *partitionService
-	SerializationService *SerializationService
+	SerializationService *serialization.SerializationService
 	LifecycleService     *lifecycleService
 	ConnectionManager    *connectionManager
 	ListenerService      *listenerService
@@ -35,14 +35,14 @@ type HazelcastClient struct {
 	HeartBeatService     *heartBeatService
 }
 
-func NewHazelcastClient(config *ClientConfig) (*HazelcastClient, error) {
+func NewHazelcastClient(config *config.ClientConfig) (*HazelcastClient, error) {
 	client := HazelcastClient{ClientConfig: config}
 	err := client.init()
 	return &client, err
 }
 
 func (client *HazelcastClient) GetMap(name string) (core.IMap, error) {
-	mp, err := client.GetDistributedObject(ServiceNameMap, name)
+	mp, err := client.GetDistributedObject(common.ServiceNameMap, name)
 	if err != nil {
 		return nil, err
 	}
@@ -50,7 +50,7 @@ func (client *HazelcastClient) GetMap(name string) (core.IMap, error) {
 }
 
 func (client *HazelcastClient) GetList(name string) (core.IList, error) {
-	list, err := client.GetDistributedObject(ServiceNameList, name)
+	list, err := client.GetDistributedObject(common.ServiceNameList, name)
 	if err != nil {
 		return nil, err
 	}
@@ -58,14 +58,14 @@ func (client *HazelcastClient) GetList(name string) (core.IList, error) {
 }
 
 func (client *HazelcastClient) GetSet(name string) (core.ISet, error) {
-	set, err := client.GetDistributedObject(ServiceNameSet, name)
+	set, err := client.GetDistributedObject(common.ServiceNameSet, name)
 	if err != nil {
 		return nil, err
 	}
 	return set.(core.ISet), nil
 }
 func (client *HazelcastClient) GetReplicatedMap(name string) (core.ReplicatedMap, error) {
-	mp, err := client.GetDistributedObject(ServiceNameReplicatedMap, name)
+	mp, err := client.GetDistributedObject(common.ServiceNameReplicatedMap, name)
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +73,7 @@ func (client *HazelcastClient) GetReplicatedMap(name string) (core.ReplicatedMap
 }
 
 func (client *HazelcastClient) GetMultiMap(name string) (core.MultiMap, error) {
-	mmp, err := client.GetDistributedObject(ServiceNameMultiMap, name)
+	mmp, err := client.GetDistributedObject(common.ServiceNameMultiMap, name)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +81,7 @@ func (client *HazelcastClient) GetMultiMap(name string) (core.MultiMap, error) {
 }
 
 func (client *HazelcastClient) GetFlakeIdGenerator(name string) (core.FlakeIdGenerator, error) {
-	flakeIdGenerator, err := client.GetDistributedObject(ServiceNameIdGenerator, name)
+	flakeIdGenerator, err := client.GetDistributedObject(common.ServiceNameIdGenerator, name)
 	if err != nil {
 		return nil, err
 	}
@@ -89,7 +89,7 @@ func (client *HazelcastClient) GetFlakeIdGenerator(name string) (core.FlakeIdGen
 }
 
 func (client *HazelcastClient) GetTopic(name string) (core.ITopic, error) {
-	topic, err := client.GetDistributedObject(ServiceNameTopic, name)
+	topic, err := client.GetDistributedObject(common.ServiceNameTopic, name)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +97,7 @@ func (client *HazelcastClient) GetTopic(name string) (core.ITopic, error) {
 }
 
 func (client *HazelcastClient) GetQueue(name string) (core.IQueue, error) {
-	queue, err := client.GetDistributedObject(ServiceNameQueue, name)
+	queue, err := client.GetDistributedObject(common.ServiceNameQueue, name)
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +105,7 @@ func (client *HazelcastClient) GetQueue(name string) (core.IQueue, error) {
 }
 
 func (client *HazelcastClient) GetRingbuffer(name string) (core.Ringbuffer, error) {
-	rb, err := client.GetDistributedObject(ServiceNameRingbufferService, name)
+	rb, err := client.GetDistributedObject(common.ServiceNameRingbufferService, name)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +113,7 @@ func (client *HazelcastClient) GetRingbuffer(name string) (core.Ringbuffer, erro
 }
 
 func (client *HazelcastClient) GetPNCounter(name string) (core.PNCounter, error) {
-	counter, err := client.GetDistributedObject(ServiceNamePNCounter, name)
+	counter, err := client.GetDistributedObject(common.ServiceNamePNCounter, name)
 	if err != nil {
 		return nil, err
 	}
@@ -146,7 +146,7 @@ func (client *HazelcastClient) init() error {
 	client.PartitionService = newPartitionService(client)
 	client.ProxyManager = newProxyManager(client)
 	client.LoadBalancer = newRandomLoadBalancer(client.ClusterService)
-	client.SerializationService = NewSerializationService(client.ClientConfig.SerializationConfig())
+	client.SerializationService = serialization.NewSerializationService(client.ClientConfig.SerializationConfig())
 	err := client.ClusterService.start()
 	if err != nil {
 		return err

--- a/internal/common/collection/util.go
+++ b/internal/common/collection/util.go
@@ -17,15 +17,15 @@ package collection
 import (
 	"github.com/hazelcast/hazelcast-go-client/core"
 	"github.com/hazelcast/hazelcast-go-client/internal/common"
-	. "github.com/hazelcast/hazelcast-go-client/internal/protocol"
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
-func ObjectToDataCollection(objects []interface{}, service *SerializationService) ([]*Data, error) {
+func ObjectToDataCollection(objects []interface{}, service *serialization.SerializationService) ([]*serialization.Data, error) {
 	if objects == nil {
 		return nil, core.NewHazelcastNilPointerError(common.NilSliceIsNotAllowed, nil)
 	}
-	elementsData := make([]*Data, len(objects))
+	elementsData := make([]*serialization.Data, len(objects))
 	for index, element := range objects {
 		if element == nil {
 			return nil, core.NewHazelcastNilPointerError(common.NilArgIsNotAllowed, nil)
@@ -39,7 +39,7 @@ func ObjectToDataCollection(objects []interface{}, service *SerializationService
 	return elementsData, nil
 }
 
-func DataToObjectCollection(dataSlice []*Data, service *SerializationService) ([]interface{}, error) {
+func DataToObjectCollection(dataSlice []*serialization.Data, service *serialization.SerializationService) ([]interface{}, error) {
 	if dataSlice == nil {
 		return nil, core.NewHazelcastNilPointerError(common.NilSliceIsNotAllowed, nil)
 	}
@@ -54,18 +54,18 @@ func DataToObjectCollection(dataSlice []*Data, service *SerializationService) ([
 	return elements, nil
 }
 
-func DataToObjectPairCollection(dataSlice []*Pair, service *SerializationService) (pairSlice []core.IPair, err error) {
+func DataToObjectPairCollection(dataSlice []*protocol.Pair, service *serialization.SerializationService) (pairSlice []core.IPair, err error) {
 	pairSlice = make([]core.IPair, len(dataSlice))
 	for index, pairData := range dataSlice {
-		key, err := service.ToObject(pairData.Key().(*Data))
+		key, err := service.ToObject(pairData.Key().(*serialization.Data))
 		if err != nil {
 			return nil, err
 		}
-		value, err := service.ToObject(pairData.Value().(*Data))
+		value, err := service.ToObject(pairData.Value().(*serialization.Data))
 		if err != nil {
 			return nil, err
 		}
-		pairSlice[index] = core.IPair(NewPair(key, value))
+		pairSlice[index] = core.IPair(protocol.NewPair(key, value))
 	}
 	return
 }

--- a/internal/error.go
+++ b/internal/error.go
@@ -17,7 +17,7 @@ package internal
 import (
 	"fmt"
 	"github.com/hazelcast/hazelcast-go-client/core"
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 	"github.com/hazelcast/hazelcast-go-client/internal/protocol"
 )
 
@@ -28,20 +28,20 @@ func CreateHazelcastError(err *protocol.Error) core.HazelcastError {
 			trace.LineNumber())
 	}
 	message := fmt.Sprintf("got exception from server:\n %s: %s\n %s", err.ClassName(), err.Message(), stackTrace)
-	switch ErrorCode(err.ErrorCode()) {
-	case ErrorCodeAuthentication:
+	switch common.ErrorCode(err.ErrorCode()) {
+	case common.ErrorCodeAuthentication:
 		return core.NewHazelcastAuthenticationError(message, nil)
-	case ErrorCodeHazelcastInstanceNotActive:
+	case common.ErrorCodeHazelcastInstanceNotActive:
 		return core.NewHazelcastInstanceNotActiveError(message, nil)
-	case ErrorCodeHazelcastSerialization:
+	case common.ErrorCodeHazelcastSerialization:
 		return core.NewHazelcastSerializationError(message, nil)
-	case ErrorCodeTargetDisconnected:
+	case common.ErrorCodeTargetDisconnected:
 		return core.NewHazelcastTargetDisconnectedError(message, nil)
-	case ErrorCodeTargetNotMember:
+	case common.ErrorCodeTargetNotMember:
 		return core.NewHazelcastTargetNotMemberError(message, nil)
-	case ErrorCodeUnsupportedOperation:
+	case common.ErrorCodeUnsupportedOperation:
 		return core.NewHazelcastUnsupportedOperationError(message, nil)
-	case ErrorCodeConsistencyLostException:
+	case common.ErrorCodeConsistencyLostException:
 		return core.NewHazelcastConsistencyLostError(message, nil)
 	}
 

--- a/internal/flake_id_generator.go
+++ b/internal/flake_id_generator.go
@@ -15,33 +15,33 @@
 package internal
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/flake_id"
+	"github.com/hazelcast/hazelcast-go-client/internal/flake_id"
 	"github.com/hazelcast/hazelcast-go-client/internal/protocol"
 )
 
 type FlakeIdGeneratorProxy struct {
 	*proxy
-	batcher *AutoBatcher
+	batcher *flake_id.AutoBatcher
 }
 
 func (self *FlakeIdGeneratorProxy) NewId() (id int64, err error) {
 	return self.batcher.NewId()
 }
 
-func (self *FlakeIdGeneratorProxy) NewIdBatch(batchSize int32) (*IdBatch, error) {
+func (self *FlakeIdGeneratorProxy) NewIdBatch(batchSize int32) (*flake_id.IdBatch, error) {
 	request := protocol.FlakeIdGeneratorNewIdBatchEncodeRequest(self.name, batchSize)
 	responseMessage, err := self.invokeOnRandomTarget(request)
 	if err != nil {
 		return nil, err
 	}
 	base, increment, newBatchSize := protocol.FlakeIdGeneratorNewIdBatchDecodeResponse(responseMessage)()
-	return NewIdBatch(base, increment, newBatchSize), nil
+	return flake_id.NewIdBatch(base, increment, newBatchSize), nil
 }
 
 func newFlakeIdGenerator(client *HazelcastClient, serviceName *string, name *string) (*FlakeIdGeneratorProxy, error) {
 	config := client.ClientConfig.GetFlakeIdGeneratorConfig(*name)
 	flakeIdGenerator := &FlakeIdGeneratorProxy{}
 	flakeIdGenerator.proxy = &proxy{client: client, serviceName: serviceName, name: name}
-	flakeIdGenerator.batcher = NewAutoBatcher(config.PrefetchCount(), config.PrefetchValidityMillis(), flakeIdGenerator)
+	flakeIdGenerator.batcher = flake_id.NewAutoBatcher(config.PrefetchCount(), config.PrefetchValidityMillis(), flakeIdGenerator)
 	return flakeIdGenerator, nil
 }

--- a/internal/list.go
+++ b/internal/list.go
@@ -15,8 +15,8 @@
 package internal
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/protocol"
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
 type ListProxy struct {
@@ -36,9 +36,9 @@ func (list *ListProxy) Add(element interface{}) (changed bool, err error) {
 	if err != nil {
 		return false, err
 	}
-	request := ListAddEncodeRequest(list.name, elementData)
+	request := protocol.ListAddEncodeRequest(list.name, elementData)
 	responseMessage, err := list.invoke(request)
-	return list.decodeToBoolAndError(responseMessage, err, ListAddDecodeResponse)
+	return list.decodeToBoolAndError(responseMessage, err, protocol.ListAddDecodeResponse)
 }
 
 func (list *ListProxy) AddAt(index int32, element interface{}) (err error) {
@@ -46,7 +46,7 @@ func (list *ListProxy) AddAt(index int32, element interface{}) (err error) {
 	if err != nil {
 		return err
 	}
-	request := ListAddWithIndexEncodeRequest(list.name, index, elementData)
+	request := protocol.ListAddWithIndexEncodeRequest(list.name, index, elementData)
 	_, err = list.invoke(request)
 	return err
 }
@@ -56,9 +56,9 @@ func (list *ListProxy) AddAll(elements []interface{}) (changed bool, err error) 
 	if err != nil {
 		return false, err
 	}
-	request := ListAddAllEncodeRequest(list.name, elementsData)
+	request := protocol.ListAddAllEncodeRequest(list.name, elementsData)
 	responseMessage, err := list.invoke(request)
-	return list.decodeToBoolAndError(responseMessage, err, ListAddAllDecodeResponse)
+	return list.decodeToBoolAndError(responseMessage, err, protocol.ListAddAllDecodeResponse)
 
 }
 
@@ -67,24 +67,24 @@ func (list *ListProxy) AddAllAt(index int32, elements []interface{}) (changed bo
 	if err != nil {
 		return false, err
 	}
-	request := ListAddAllWithIndexEncodeRequest(list.name, index, elementsData)
+	request := protocol.ListAddAllWithIndexEncodeRequest(list.name, index, elementsData)
 	responseMessage, err := list.invoke(request)
-	return list.decodeToBoolAndError(responseMessage, err, ListAddAllWithIndexDecodeResponse)
+	return list.decodeToBoolAndError(responseMessage, err, protocol.ListAddAllWithIndexDecodeResponse)
 }
 
 func (list *ListProxy) AddItemListener(listener interface{}, includeValue bool) (registrationID *string, err error) {
-	request := ListAddListenerEncodeRequest(list.name, includeValue, false)
+	request := protocol.ListAddListenerEncodeRequest(list.name, includeValue, false)
 	eventHandler := list.createEventHandler(listener)
 	return list.client.ListenerService.registerListener(request, eventHandler,
-		func(registrationId *string) *ClientMessage {
-			return ListRemoveListenerEncodeRequest(list.name, registrationId)
-		}, func(clientMessage *ClientMessage) *string {
-			return ListAddListenerDecodeResponse(clientMessage)()
+		func(registrationId *string) *protocol.ClientMessage {
+			return protocol.ListRemoveListenerEncodeRequest(list.name, registrationId)
+		}, func(clientMessage *protocol.ClientMessage) *string {
+			return protocol.ListAddListenerDecodeResponse(clientMessage)()
 		})
 }
 
 func (list *ListProxy) Clear() (err error) {
-	request := ListClearEncodeRequest(list.name)
+	request := protocol.ListClearEncodeRequest(list.name)
 	_, err = list.invoke(request)
 	return err
 }
@@ -94,9 +94,9 @@ func (list *ListProxy) Contains(element interface{}) (found bool, err error) {
 	if err != nil {
 		return false, err
 	}
-	request := ListContainsEncodeRequest(list.name, elementData)
+	request := protocol.ListContainsEncodeRequest(list.name, elementData)
 	responseMessage, err := list.invoke(request)
-	return list.decodeToBoolAndError(responseMessage, err, ListContainsDecodeResponse)
+	return list.decodeToBoolAndError(responseMessage, err, protocol.ListContainsDecodeResponse)
 }
 
 func (list *ListProxy) ContainsAll(elements []interface{}) (foundAll bool, err error) {
@@ -104,15 +104,15 @@ func (list *ListProxy) ContainsAll(elements []interface{}) (foundAll bool, err e
 	if err != nil {
 		return false, err
 	}
-	request := ListContainsAllEncodeRequest(list.name, elementsData)
+	request := protocol.ListContainsAllEncodeRequest(list.name, elementsData)
 	responseMessage, err := list.invoke(request)
-	return list.decodeToBoolAndError(responseMessage, err, ListContainsAllDecodeResponse)
+	return list.decodeToBoolAndError(responseMessage, err, protocol.ListContainsAllDecodeResponse)
 }
 
 func (list *ListProxy) Get(index int32) (element interface{}, err error) {
-	request := ListGetEncodeRequest(list.name, index)
+	request := protocol.ListGetEncodeRequest(list.name, index)
 	responseMessage, err := list.invoke(request)
-	return list.decodeToObjectAndError(responseMessage, err, ListGetDecodeResponse)
+	return list.decodeToObjectAndError(responseMessage, err, protocol.ListGetDecodeResponse)
 }
 
 func (list *ListProxy) IndexOf(element interface{}) (index int32, err error) {
@@ -120,15 +120,15 @@ func (list *ListProxy) IndexOf(element interface{}) (index int32, err error) {
 	if err != nil {
 		return 0, err
 	}
-	request := ListIndexOfEncodeRequest(list.name, elementData)
+	request := protocol.ListIndexOfEncodeRequest(list.name, elementData)
 	responseMessage, err := list.invoke(request)
-	return list.decodeToInt32AndError(responseMessage, err, ListIndexOfDecodeResponse)
+	return list.decodeToInt32AndError(responseMessage, err, protocol.ListIndexOfDecodeResponse)
 }
 
 func (list *ListProxy) IsEmpty() (empty bool, err error) {
-	request := ListIsEmptyEncodeRequest(list.name)
+	request := protocol.ListIsEmptyEncodeRequest(list.name)
 	responseMessage, err := list.invoke(request)
-	return list.decodeToBoolAndError(responseMessage, err, ListIsEmptyDecodeResponse)
+	return list.decodeToBoolAndError(responseMessage, err, protocol.ListIsEmptyDecodeResponse)
 }
 
 func (list *ListProxy) LastIndexOf(element interface{}) (index int32, err error) {
@@ -136,9 +136,9 @@ func (list *ListProxy) LastIndexOf(element interface{}) (index int32, err error)
 	if err != nil {
 		return 0, err
 	}
-	request := ListLastIndexOfEncodeRequest(list.name, elementData)
+	request := protocol.ListLastIndexOfEncodeRequest(list.name, elementData)
 	responseMessage, err := list.invoke(request)
-	return list.decodeToInt32AndError(responseMessage, err, ListIndexOfDecodeResponse)
+	return list.decodeToInt32AndError(responseMessage, err, protocol.ListIndexOfDecodeResponse)
 }
 
 func (list *ListProxy) Remove(element interface{}) (changed bool, err error) {
@@ -146,15 +146,15 @@ func (list *ListProxy) Remove(element interface{}) (changed bool, err error) {
 	if err != nil {
 		return false, err
 	}
-	request := ListRemoveEncodeRequest(list.name, elementData)
+	request := protocol.ListRemoveEncodeRequest(list.name, elementData)
 	responseMessage, err := list.invoke(request)
-	return list.decodeToBoolAndError(responseMessage, err, ListRemoveDecodeResponse)
+	return list.decodeToBoolAndError(responseMessage, err, protocol.ListRemoveDecodeResponse)
 }
 
 func (list *ListProxy) RemoveAt(index int32) (previousElement interface{}, err error) {
-	request := ListRemoveWithIndexEncodeRequest(list.name, index)
+	request := protocol.ListRemoveWithIndexEncodeRequest(list.name, index)
 	responseMessage, err := list.invoke(request)
-	return list.decodeToObjectAndError(responseMessage, err, ListRemoveWithIndexDecodeResponse)
+	return list.decodeToObjectAndError(responseMessage, err, protocol.ListRemoveWithIndexDecodeResponse)
 }
 
 func (list *ListProxy) RemoveAll(elements []interface{}) (changed bool, err error) {
@@ -162,14 +162,14 @@ func (list *ListProxy) RemoveAll(elements []interface{}) (changed bool, err erro
 	if err != nil {
 		return false, err
 	}
-	request := ListCompareAndRemoveAllEncodeRequest(list.name, elementsData)
+	request := protocol.ListCompareAndRemoveAllEncodeRequest(list.name, elementsData)
 	responseMessage, err := list.invoke(request)
-	return list.decodeToBoolAndError(responseMessage, err, ListCompareAndRemoveAllDecodeResponse)
+	return list.decodeToBoolAndError(responseMessage, err, protocol.ListCompareAndRemoveAllDecodeResponse)
 }
 
 func (list *ListProxy) RemoveItemListener(registrationID *string) (removed bool, err error) {
-	return list.client.ListenerService.deregisterListener(*registrationID, func(registrationID *string) *ClientMessage {
-		return ListRemoveListenerEncodeRequest(list.name, registrationID)
+	return list.client.ListenerService.deregisterListener(*registrationID, func(registrationID *string) *protocol.ClientMessage {
+		return protocol.ListRemoveListenerEncodeRequest(list.name, registrationID)
 	})
 }
 
@@ -178,9 +178,9 @@ func (list *ListProxy) RetainAll(elements []interface{}) (changed bool, err erro
 	if err != nil {
 		return false, err
 	}
-	request := ListCompareAndRetainAllEncodeRequest(list.name, elementsData)
+	request := protocol.ListCompareAndRetainAllEncodeRequest(list.name, elementsData)
 	responseMessage, err := list.invoke(request)
-	return list.decodeToBoolAndError(responseMessage, err, ListCompareAndRetainAllDecodeResponse)
+	return list.decodeToBoolAndError(responseMessage, err, protocol.ListCompareAndRetainAllDecodeResponse)
 }
 
 func (list *ListProxy) Set(index int32, element interface{}) (previousElement interface{}, err error) {
@@ -188,32 +188,32 @@ func (list *ListProxy) Set(index int32, element interface{}) (previousElement in
 	if err != nil {
 		return nil, err
 	}
-	request := ListSetEncodeRequest(list.name, index, elementData)
+	request := protocol.ListSetEncodeRequest(list.name, index, elementData)
 	responseMessage, err := list.invoke(request)
-	return list.decodeToObjectAndError(responseMessage, err, ListSetDecodeResponse)
+	return list.decodeToObjectAndError(responseMessage, err, protocol.ListSetDecodeResponse)
 }
 
 func (list *ListProxy) Size() (size int32, err error) {
-	request := ListSizeEncodeRequest(list.name)
+	request := protocol.ListSizeEncodeRequest(list.name)
 	responseMessage, err := list.invoke(request)
-	return list.decodeToInt32AndError(responseMessage, err, ListSizeDecodeResponse)
+	return list.decodeToInt32AndError(responseMessage, err, protocol.ListSizeDecodeResponse)
 }
 
 func (list *ListProxy) SubList(start int32, end int32) (elements []interface{}, err error) {
-	request := ListSubEncodeRequest(list.name, start, end)
+	request := protocol.ListSubEncodeRequest(list.name, start, end)
 	responseMessage, err := list.invoke(request)
-	return list.decodeToInterfaceSliceAndError(responseMessage, err, ListSubDecodeResponse)
+	return list.decodeToInterfaceSliceAndError(responseMessage, err, protocol.ListSubDecodeResponse)
 }
 
 func (list *ListProxy) ToSlice() (elements []interface{}, err error) {
-	request := ListGetAllEncodeRequest(list.name)
+	request := protocol.ListGetAllEncodeRequest(list.name)
 	responseMessage, err := list.invoke(request)
-	return list.decodeToInterfaceSliceAndError(responseMessage, err, ListGetAllDecodeResponse)
+	return list.decodeToInterfaceSliceAndError(responseMessage, err, protocol.ListGetAllDecodeResponse)
 }
 
-func (list *ListProxy) createEventHandler(listener interface{}) func(clientMessage *ClientMessage) {
-	return func(clientMessage *ClientMessage) {
-		ListAddListenerHandle(clientMessage, func(itemData *Data, uuid *string, eventType int32) {
+func (list *ListProxy) createEventHandler(listener interface{}) func(clientMessage *protocol.ClientMessage) {
+	return func(clientMessage *protocol.ClientMessage) {
+		protocol.ListAddListenerHandle(clientMessage, func(itemData *serialization.Data, uuid *string, eventType int32) {
 			onItemEvent := list.createOnItemEvent(listener)
 			onItemEvent(itemData, uuid, eventType)
 		})

--- a/internal/loadbalancer.go
+++ b/internal/loadbalancer.go
@@ -15,7 +15,7 @@
 package internal
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/protocol"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol"
 	"math/rand"
 	"time"
 )
@@ -29,13 +29,13 @@ func newRandomLoadBalancer(clusterService *clusterService) *randomLoadBalancer {
 	return &randomLoadBalancer{clusterService: clusterService}
 }
 
-func (randomLoadBalancer *randomLoadBalancer) nextAddress() *Address {
+func (randomLoadBalancer *randomLoadBalancer) nextAddress() *protocol.Address {
 	membersList := randomLoadBalancer.clusterService.GetMemberList()
 	size := len(membersList)
 	if size > 0 {
 		randomIndex := rand.Intn(size)
 		member := membersList[randomIndex]
-		return member.Address().(*Address)
+		return member.Address().(*protocol.Address)
 	}
 	return nil
 }

--- a/internal/map.go
+++ b/internal/map.go
@@ -15,9 +15,9 @@
 package internal
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/core"
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
-	. "github.com/hazelcast/hazelcast-go-client/internal/protocol"
+	"github.com/hazelcast/hazelcast-go-client/core"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol"
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 	"time"
 )
@@ -35,26 +35,26 @@ func (imap *MapProxy) Put(key interface{}, value interface{}) (oldValue interfac
 	if err != nil {
 		return nil, err
 	}
-	request := MapPutEncodeRequest(imap.name, keyData, valueData, threadId, ttlUnlimited)
+	request := protocol.MapPutEncodeRequest(imap.name, keyData, valueData, threadId, ttlUnlimited)
 	responseMessage, err := imap.invokeOnKey(request, keyData)
-	return imap.decodeToObjectAndError(responseMessage, err, MapPutDecodeResponse)
+	return imap.decodeToObjectAndError(responseMessage, err, protocol.MapPutDecodeResponse)
 }
 func (imap *MapProxy) TryPut(key interface{}, value interface{}) (ok bool, err error) {
 	keyData, valueData, err := imap.validateAndSerialize2(key, value)
 	if err != nil {
 		return false, err
 	}
-	request := MapTryPutEncodeRequest(imap.name, keyData, valueData, threadId, ttlUnlimited)
+	request := protocol.MapTryPutEncodeRequest(imap.name, keyData, valueData, threadId, ttlUnlimited)
 	responseMessage, err := imap.invokeOnKey(request, keyData)
-	return imap.decodeToBoolAndError(responseMessage, err, MapTryPutDecodeResponse)
+	return imap.decodeToBoolAndError(responseMessage, err, protocol.MapTryPutDecodeResponse)
 }
 func (imap *MapProxy) PutTransient(key interface{}, value interface{}, ttl int64, ttlTimeUnit time.Duration) (err error) {
 	keyData, valueData, err := imap.validateAndSerialize2(key, value)
 	if err != nil {
 		return err
 	}
-	ttl = GetTimeInMilliSeconds(ttl, ttlTimeUnit)
-	request := MapPutTransientEncodeRequest(imap.name, keyData, valueData, threadId, ttl)
+	ttl = common.GetTimeInMilliSeconds(ttl, ttlTimeUnit)
+	request := protocol.MapPutTransientEncodeRequest(imap.name, keyData, valueData, threadId, ttl)
 	_, err = imap.invokeOnKey(request, keyData)
 	return err
 }
@@ -63,9 +63,9 @@ func (imap *MapProxy) Get(key interface{}) (value interface{}, err error) {
 	if err != nil {
 		return nil, err
 	}
-	request := MapGetEncodeRequest(imap.name, keyData, threadId)
+	request := protocol.MapGetEncodeRequest(imap.name, keyData, threadId)
 	responseMessage, err := imap.invokeOnKey(request, keyData)
-	return imap.decodeToObjectAndError(responseMessage, err, MapGetDecodeResponse)
+	return imap.decodeToObjectAndError(responseMessage, err, protocol.MapGetDecodeResponse)
 
 }
 func (imap *MapProxy) Remove(key interface{}) (value interface{}, err error) {
@@ -73,9 +73,9 @@ func (imap *MapProxy) Remove(key interface{}) (value interface{}, err error) {
 	if err != nil {
 		return nil, err
 	}
-	request := MapRemoveEncodeRequest(imap.name, keyData, threadId)
+	request := protocol.MapRemoveEncodeRequest(imap.name, keyData, threadId)
 	responseMessage, err := imap.invokeOnKey(request, keyData)
-	return imap.decodeToObjectAndError(responseMessage, err, MapRemoveDecodeResponse)
+	return imap.decodeToObjectAndError(responseMessage, err, protocol.MapRemoveDecodeResponse)
 
 }
 func (imap *MapProxy) RemoveIfSame(key interface{}, value interface{}) (ok bool, err error) {
@@ -83,9 +83,9 @@ func (imap *MapProxy) RemoveIfSame(key interface{}, value interface{}) (ok bool,
 	if err != nil {
 		return false, err
 	}
-	request := MapRemoveIfSameEncodeRequest(imap.name, keyData, valueData, threadId)
+	request := protocol.MapRemoveIfSameEncodeRequest(imap.name, keyData, valueData, threadId)
 	responseMessage, err := imap.invokeOnKey(request, keyData)
-	return imap.decodeToBoolAndError(responseMessage, err, MapRemoveIfSameDecodeResponse)
+	return imap.decodeToBoolAndError(responseMessage, err, protocol.MapRemoveIfSameDecodeResponse)
 
 }
 func (imap *MapProxy) RemoveAll(predicate interface{}) (err error) {
@@ -93,7 +93,7 @@ func (imap *MapProxy) RemoveAll(predicate interface{}) (err error) {
 	if err != nil {
 		return err
 	}
-	request := MapRemoveAllEncodeRequest(imap.name, predicateData)
+	request := protocol.MapRemoveAllEncodeRequest(imap.name, predicateData)
 	_, err = imap.invokeOnRandomTarget(request)
 	return err
 }
@@ -102,15 +102,15 @@ func (imap *MapProxy) TryRemove(key interface{}, timeout int64, timeoutTimeUnit 
 	if err != nil {
 		return false, err
 	}
-	timeout = GetTimeInMilliSeconds(timeout, timeoutTimeUnit)
-	request := MapTryRemoveEncodeRequest(imap.name, keyData, threadId, timeout)
+	timeout = common.GetTimeInMilliSeconds(timeout, timeoutTimeUnit)
+	request := protocol.MapTryRemoveEncodeRequest(imap.name, keyData, threadId, timeout)
 	responseMessage, err := imap.invokeOnKey(request, keyData)
-	return imap.decodeToBoolAndError(responseMessage, err, MapTryRemoveDecodeResponse)
+	return imap.decodeToBoolAndError(responseMessage, err, protocol.MapTryRemoveDecodeResponse)
 }
 func (imap *MapProxy) Size() (size int32, err error) {
-	request := MapSizeEncodeRequest(imap.name)
+	request := protocol.MapSizeEncodeRequest(imap.name)
 	responseMessage, err := imap.invokeOnRandomTarget(request)
-	return imap.decodeToInt32AndError(responseMessage, err, MapSizeDecodeResponse)
+	return imap.decodeToInt32AndError(responseMessage, err, protocol.MapSizeDecodeResponse)
 
 }
 func (imap *MapProxy) ContainsKey(key interface{}) (found bool, err error) {
@@ -118,9 +118,9 @@ func (imap *MapProxy) ContainsKey(key interface{}) (found bool, err error) {
 	if err != nil {
 		return false, err
 	}
-	request := MapContainsKeyEncodeRequest(imap.name, keyData, threadId)
+	request := protocol.MapContainsKeyEncodeRequest(imap.name, keyData, threadId)
 	responseMessage, err := imap.invokeOnKey(request, keyData)
-	return imap.decodeToBoolAndError(responseMessage, err, MapContainsKeyDecodeResponse)
+	return imap.decodeToBoolAndError(responseMessage, err, protocol.MapContainsKeyDecodeResponse)
 
 }
 func (imap *MapProxy) ContainsValue(value interface{}) (found bool, err error) {
@@ -128,13 +128,13 @@ func (imap *MapProxy) ContainsValue(value interface{}) (found bool, err error) {
 	if err != nil {
 		return false, err
 	}
-	request := MapContainsValueEncodeRequest(imap.name, valueData)
+	request := protocol.MapContainsValueEncodeRequest(imap.name, valueData)
 	responseMessage, err := imap.invokeOnRandomTarget(request)
-	return imap.decodeToBoolAndError(responseMessage, err, MapContainsValueDecodeResponse)
+	return imap.decodeToBoolAndError(responseMessage, err, protocol.MapContainsValueDecodeResponse)
 
 }
 func (imap *MapProxy) Clear() (err error) {
-	request := MapClearEncodeRequest(imap.name)
+	request := protocol.MapClearEncodeRequest(imap.name)
 	_, err = imap.invokeOnRandomTarget(request)
 	return
 }
@@ -143,18 +143,18 @@ func (imap *MapProxy) Delete(key interface{}) (err error) {
 	if err != nil {
 		return err
 	}
-	request := MapDeleteEncodeRequest(imap.name, keyData, threadId)
+	request := protocol.MapDeleteEncodeRequest(imap.name, keyData, threadId)
 	_, err = imap.invokeOnKey(request, keyData)
 	return
 }
 func (imap *MapProxy) IsEmpty() (empty bool, err error) {
-	request := MapIsEmptyEncodeRequest(imap.name)
+	request := protocol.MapIsEmptyEncodeRequest(imap.name)
 	responseMessage, err := imap.invokeOnRandomTarget(request)
-	return imap.decodeToBoolAndError(responseMessage, err, MapIsEmptyDecodeResponse)
+	return imap.decodeToBoolAndError(responseMessage, err, protocol.MapIsEmptyDecodeResponse)
 
 }
 func (imap *MapProxy) AddIndex(attribute string, ordered bool) (err error) {
-	request := MapAddIndexEncodeRequest(imap.name, &attribute, ordered)
+	request := protocol.MapAddIndexEncodeRequest(imap.name, &attribute, ordered)
 	_, err = imap.invokeOnRandomTarget(request)
 	return
 }
@@ -163,18 +163,18 @@ func (imap *MapProxy) Evict(key interface{}) (evicted bool, err error) {
 	if err != nil {
 		return false, err
 	}
-	request := MapEvictEncodeRequest(imap.name, keyData, threadId)
+	request := protocol.MapEvictEncodeRequest(imap.name, keyData, threadId)
 	responseMessage, err := imap.invokeOnKey(request, keyData)
-	return imap.decodeToBoolAndError(responseMessage, err, MapEvictDecodeResponse)
+	return imap.decodeToBoolAndError(responseMessage, err, protocol.MapEvictDecodeResponse)
 
 }
 func (imap *MapProxy) EvictAll() (err error) {
-	request := MapEvictAllEncodeRequest(imap.name)
+	request := protocol.MapEvictAllEncodeRequest(imap.name)
 	_, err = imap.invokeOnRandomTarget(request)
 	return
 }
 func (imap *MapProxy) Flush() (err error) {
-	request := MapFlushEncodeRequest(imap.name)
+	request := protocol.MapFlushEncodeRequest(imap.name)
 	_, err = imap.invokeOnRandomTarget(request)
 	return
 }
@@ -186,8 +186,8 @@ func (imap *MapProxy) LockWithLeaseTime(key interface{}, lease int64, leaseTimeU
 	if err != nil {
 		return err
 	}
-	lease = GetTimeInMilliSeconds(lease, leaseTimeUnit)
-	request := MapLockEncodeRequest(imap.name, keyData, threadId, lease, imap.client.ProxyManager.nextReferenceId())
+	lease = common.GetTimeInMilliSeconds(lease, leaseTimeUnit)
+	request := protocol.MapLockEncodeRequest(imap.name, keyData, threadId, lease, imap.client.ProxyManager.nextReferenceId())
 	_, err = imap.invokeOnKey(request, keyData)
 	return
 }
@@ -202,18 +202,18 @@ func (imap *MapProxy) TryLockWithTimeoutAndLease(key interface{}, timeout int64,
 	if err != nil {
 		return false, err
 	}
-	timeout = GetTimeInMilliSeconds(timeout, timeoutTimeUnit)
-	lease = GetTimeInMilliSeconds(lease, leaseTimeUnit)
-	request := MapTryLockEncodeRequest(imap.name, keyData, threadId, lease, timeout, imap.client.ProxyManager.nextReferenceId())
+	timeout = common.GetTimeInMilliSeconds(timeout, timeoutTimeUnit)
+	lease = common.GetTimeInMilliSeconds(lease, leaseTimeUnit)
+	request := protocol.MapTryLockEncodeRequest(imap.name, keyData, threadId, lease, timeout, imap.client.ProxyManager.nextReferenceId())
 	responseMessage, err := imap.invokeOnKey(request, keyData)
-	return imap.decodeToBoolAndError(responseMessage, err, MapTryLockDecodeResponse)
+	return imap.decodeToBoolAndError(responseMessage, err, protocol.MapTryLockDecodeResponse)
 }
 func (imap *MapProxy) Unlock(key interface{}) (err error) {
 	keyData, err := imap.validateAndSerialize(key)
 	if err != nil {
 		return err
 	}
-	request := MapUnlockEncodeRequest(imap.name, keyData, threadId, imap.client.ProxyManager.nextReferenceId())
+	request := protocol.MapUnlockEncodeRequest(imap.name, keyData, threadId, imap.client.ProxyManager.nextReferenceId())
 	_, err = imap.invokeOnKey(request, keyData)
 	return
 }
@@ -222,7 +222,7 @@ func (imap *MapProxy) ForceUnlock(key interface{}) (err error) {
 	if err != nil {
 		return err
 	}
-	request := MapForceUnlockEncodeRequest(imap.name, keyData, imap.client.ProxyManager.nextReferenceId())
+	request := protocol.MapForceUnlockEncodeRequest(imap.name, keyData, imap.client.ProxyManager.nextReferenceId())
 	_, err = imap.invokeOnKey(request, keyData)
 	return
 }
@@ -231,9 +231,9 @@ func (imap *MapProxy) IsLocked(key interface{}) (locked bool, err error) {
 	if err != nil {
 		return false, err
 	}
-	request := MapIsLockedEncodeRequest(imap.name, keyData)
+	request := protocol.MapIsLockedEncodeRequest(imap.name, keyData)
 	responseMessage, err := imap.invokeOnKey(request, keyData)
-	return imap.decodeToBoolAndError(responseMessage, err, MapIsLockedDecodeResponse)
+	return imap.decodeToBoolAndError(responseMessage, err, protocol.MapIsLockedDecodeResponse)
 
 }
 func (imap *MapProxy) Replace(key interface{}, value interface{}) (oldValue interface{}, err error) {
@@ -241,9 +241,9 @@ func (imap *MapProxy) Replace(key interface{}, value interface{}) (oldValue inte
 	if err != nil {
 		return nil, err
 	}
-	request := MapReplaceEncodeRequest(imap.name, keyData, valueData, threadId)
+	request := protocol.MapReplaceEncodeRequest(imap.name, keyData, valueData, threadId)
 	responseMessage, err := imap.invokeOnKey(request, keyData)
-	return imap.decodeToObjectAndError(responseMessage, err, MapReplaceDecodeResponse)
+	return imap.decodeToObjectAndError(responseMessage, err, protocol.MapReplaceDecodeResponse)
 
 }
 func (imap *MapProxy) ReplaceIfSame(key interface{}, oldValue interface{}, newValue interface{}) (replaced bool, err error) {
@@ -251,9 +251,9 @@ func (imap *MapProxy) ReplaceIfSame(key interface{}, oldValue interface{}, newVa
 	if err != nil {
 		return false, err
 	}
-	request := MapReplaceIfSameEncodeRequest(imap.name, keyData, oldValueData, newValueData, threadId)
+	request := protocol.MapReplaceIfSameEncodeRequest(imap.name, keyData, oldValueData, newValueData, threadId)
 	responseMessage, err := imap.invokeOnKey(request, keyData)
-	return imap.decodeToBoolAndError(responseMessage, err, MapReplaceIfSameDecodeResponse)
+	return imap.decodeToBoolAndError(responseMessage, err, protocol.MapReplaceIfSameDecodeResponse)
 
 }
 func (imap *MapProxy) Set(key interface{}, value interface{}) (err error) {
@@ -264,8 +264,8 @@ func (imap *MapProxy) SetWithTtl(key interface{}, value interface{}, ttl int64, 
 	if err != nil {
 		return err
 	}
-	ttl = GetTimeInMilliSeconds(ttl, ttlTimeUnit)
-	request := MapSetEncodeRequest(imap.name, keyData, valueData, threadId, ttl)
+	ttl = common.GetTimeInMilliSeconds(ttl, ttlTimeUnit)
+	request := protocol.MapSetEncodeRequest(imap.name, keyData, valueData, threadId, ttl)
 	_, err = imap.invokeOnKey(request, keyData)
 	return
 }
@@ -275,21 +275,21 @@ func (imap *MapProxy) PutIfAbsent(key interface{}, value interface{}) (oldValue 
 	if err != nil {
 		return nil, err
 	}
-	request := MapPutIfAbsentEncodeRequest(imap.name, keyData, valueData, threadId, ttlUnlimited)
+	request := protocol.MapPutIfAbsentEncodeRequest(imap.name, keyData, valueData, threadId, ttlUnlimited)
 	responseMessage, err := imap.invokeOnKey(request, keyData)
-	return imap.decodeToObjectAndError(responseMessage, err, MapPutIfAbsentDecodeResponse)
+	return imap.decodeToObjectAndError(responseMessage, err, protocol.MapPutIfAbsentDecodeResponse)
 
 }
 func (imap *MapProxy) PutAll(entries map[interface{}]interface{}) (err error) {
 	if entries == nil {
-		return NewHazelcastNilPointerError(NilMapIsNotAllowed, nil)
+		return core.NewHazelcastNilPointerError(common.NilMapIsNotAllowed, nil)
 	}
 	partitions, err := imap.validateAndSerializeMapAndGetPartitions(entries)
 	if err != nil {
 		return err
 	}
 	for partitionId, entryList := range partitions {
-		request := MapPutAllEncodeRequest(imap.name, entryList)
+		request := protocol.MapPutAllEncodeRequest(imap.name, entryList)
 		_, err = imap.invokeOnPartition(request, partitionId)
 		if err != nil {
 			return err
@@ -298,50 +298,50 @@ func (imap *MapProxy) PutAll(entries map[interface{}]interface{}) (err error) {
 	return nil
 }
 func (imap *MapProxy) KeySet() (keySet []interface{}, err error) {
-	request := MapKeySetEncodeRequest(imap.name)
+	request := protocol.MapKeySetEncodeRequest(imap.name)
 	responseMessage, err := imap.invokeOnRandomTarget(request)
-	return imap.decodeToInterfaceSliceAndError(responseMessage, err, MapKeySetDecodeResponse)
+	return imap.decodeToInterfaceSliceAndError(responseMessage, err, protocol.MapKeySetDecodeResponse)
 }
 func (imap *MapProxy) KeySetWithPredicate(predicate interface{}) (keySet []interface{}, err error) {
 	predicateData, err := imap.validateAndSerializePredicate(predicate)
 	if err != nil {
 		return nil, err
 	}
-	request := MapKeySetWithPredicateEncodeRequest(imap.name, predicateData)
+	request := protocol.MapKeySetWithPredicateEncodeRequest(imap.name, predicateData)
 	responseMessage, err := imap.invokeOnRandomTarget(request)
-	return imap.decodeToInterfaceSliceAndError(responseMessage, err, MapKeySetWithPredicateDecodeResponse)
+	return imap.decodeToInterfaceSliceAndError(responseMessage, err, protocol.MapKeySetWithPredicateDecodeResponse)
 }
 func (imap *MapProxy) Values() (values []interface{}, err error) {
-	request := MapValuesEncodeRequest(imap.name)
+	request := protocol.MapValuesEncodeRequest(imap.name)
 	responseMessage, err := imap.invokeOnRandomTarget(request)
-	return imap.decodeToInterfaceSliceAndError(responseMessage, err, MapValuesDecodeResponse)
+	return imap.decodeToInterfaceSliceAndError(responseMessage, err, protocol.MapValuesDecodeResponse)
 }
 func (imap *MapProxy) ValuesWithPredicate(predicate interface{}) (values []interface{}, err error) {
 	predicateData, err := imap.validateAndSerializePredicate(predicate)
 	if err != nil {
 		return nil, err
 	}
-	request := MapValuesWithPredicateEncodeRequest(imap.name, predicateData)
+	request := protocol.MapValuesWithPredicateEncodeRequest(imap.name, predicateData)
 	responseMessage, err := imap.invokeOnRandomTarget(request)
-	return imap.decodeToInterfaceSliceAndError(responseMessage, err, MapValuesWithPredicateDecodeResponse)
+	return imap.decodeToInterfaceSliceAndError(responseMessage, err, protocol.MapValuesWithPredicateDecodeResponse)
 }
-func (imap *MapProxy) EntrySet() (resultPairs []IPair, err error) {
-	request := MapEntrySetEncodeRequest(imap.name)
+func (imap *MapProxy) EntrySet() (resultPairs []core.IPair, err error) {
+	request := protocol.MapEntrySetEncodeRequest(imap.name)
 	responseMessage, err := imap.invokeOnRandomTarget(request)
-	return imap.decodeToPairSliceAndError(responseMessage, err, MapEntrySetDecodeResponse)
+	return imap.decodeToPairSliceAndError(responseMessage, err, protocol.MapEntrySetDecodeResponse)
 }
-func (imap *MapProxy) EntrySetWithPredicate(predicate interface{}) (resultPairs []IPair, err error) {
+func (imap *MapProxy) EntrySetWithPredicate(predicate interface{}) (resultPairs []core.IPair, err error) {
 	predicateData, err := imap.validateAndSerializePredicate(predicate)
 	if err != nil {
 		return nil, err
 	}
-	request := MapEntriesWithPredicateEncodeRequest(imap.name, predicateData)
+	request := protocol.MapEntriesWithPredicateEncodeRequest(imap.name, predicateData)
 	responseMessage, err := imap.invokeOnRandomTarget(request)
-	return imap.decodeToPairSliceAndError(responseMessage, err, MapEntriesWithPredicateDecodeResponse)
+	return imap.decodeToPairSliceAndError(responseMessage, err, protocol.MapEntriesWithPredicateDecodeResponse)
 }
 func (imap *MapProxy) GetAll(keys []interface{}) (entryMap map[interface{}]interface{}, err error) {
 	if keys == nil {
-		return nil, NewHazelcastNilPointerError(NilKeysAreNotAllowed, nil)
+		return nil, core.NewHazelcastNilPointerError(common.NilKeysAreNotAllowed, nil)
 	}
 	partitions := make(map[int32][]*serialization.Data)
 	entryMap = make(map[interface{}]interface{}, 0)
@@ -354,12 +354,12 @@ func (imap *MapProxy) GetAll(keys []interface{}) (entryMap map[interface{}]inter
 		partitions[partitionId] = append(partitions[partitionId], keyData)
 	}
 	for partitionId, keyList := range partitions {
-		request := MapGetAllEncodeRequest(imap.name, keyList)
+		request := protocol.MapGetAllEncodeRequest(imap.name, keyList)
 		responseMessage, err := imap.invokeOnPartition(request, partitionId)
 		if err != nil {
 			return nil, err
 		}
-		response := MapGetAllDecodeResponse(responseMessage)()
+		response := protocol.MapGetAllDecodeResponse(responseMessage)()
 		for _, pairData := range response {
 			key, err := imap.toObject(pairData.Key().(*serialization.Data))
 			if err != nil {
@@ -374,81 +374,81 @@ func (imap *MapProxy) GetAll(keys []interface{}) (entryMap map[interface{}]inter
 	}
 	return entryMap, nil
 }
-func (imap *MapProxy) GetEntryView(key interface{}) (entryView IEntryView, err error) {
+func (imap *MapProxy) GetEntryView(key interface{}) (entryView core.IEntryView, err error) {
 	keyData, err := imap.validateAndSerialize(key)
 	if err != nil {
 		return nil, err
 	}
-	request := MapGetEntryViewEncodeRequest(imap.name, keyData, threadId)
+	request := protocol.MapGetEntryViewEncodeRequest(imap.name, keyData, threadId)
 	responseMessage, err := imap.invokeOnKey(request, keyData)
 	if err != nil {
 		return nil, err
 	}
-	response := MapGetEntryViewDecodeResponse(responseMessage)()
+	response := protocol.MapGetEntryViewDecodeResponse(responseMessage)()
 	resultKey, _ := imap.toObject(response.KeyData())
 	resultValue, _ := imap.toObject(response.ValueData())
-	entryView = NewEntryView(resultKey, resultValue, response.Cost(),
+	entryView = protocol.NewEntryView(resultKey, resultValue, response.Cost(),
 		response.CreationTime(), response.ExpirationTime(), response.Hits(), response.LastAccessTime(), response.LastStoredTime(),
 		response.LastUpdateTime(), response.Version(), response.EvictionCriteriaNumber(), response.Ttl())
 	return entryView, nil
 }
 func (imap *MapProxy) AddEntryListener(listener interface{}, includeValue bool) (registrationID *string, err error) {
-	var request *ClientMessage
-	listenerFlags := GetEntryListenerFlags(listener)
-	request = MapAddEntryListenerEncodeRequest(imap.name, includeValue, listenerFlags, imap.isSmart())
-	eventHandler := func(clientMessage *ClientMessage) {
-		MapAddEntryListenerHandle(clientMessage, func(key *serialization.Data, oldValue *serialization.Data, value *serialization.Data, mergingValue *serialization.Data, eventType int32, Uuid *string, numberOfAffectedEntries int32) {
+	var request *protocol.ClientMessage
+	listenerFlags := protocol.GetEntryListenerFlags(listener)
+	request = protocol.MapAddEntryListenerEncodeRequest(imap.name, includeValue, listenerFlags, imap.isSmart())
+	eventHandler := func(clientMessage *protocol.ClientMessage) {
+		protocol.MapAddEntryListenerHandle(clientMessage, func(key *serialization.Data, oldValue *serialization.Data, value *serialization.Data, mergingValue *serialization.Data, eventType int32, Uuid *string, numberOfAffectedEntries int32) {
 			imap.onEntryEvent(key, oldValue, value, mergingValue, eventType, Uuid, numberOfAffectedEntries, includeValue, listener)
 		})
 	}
-	return imap.client.ListenerService.registerListener(request, eventHandler, func(registrationId *string) *ClientMessage {
-		return MapRemoveEntryListenerEncodeRequest(imap.name, registrationId)
-	}, func(clientMessage *ClientMessage) *string {
-		return MapAddEntryListenerDecodeResponse(clientMessage)()
+	return imap.client.ListenerService.registerListener(request, eventHandler, func(registrationId *string) *protocol.ClientMessage {
+		return protocol.MapRemoveEntryListenerEncodeRequest(imap.name, registrationId)
+	}, func(clientMessage *protocol.ClientMessage) *string {
+		return protocol.MapAddEntryListenerDecodeResponse(clientMessage)()
 	})
 }
 func (imap *MapProxy) AddEntryListenerWithPredicate(listener interface{}, predicate interface{}, includeValue bool) (*string, error) {
-	var request *ClientMessage
-	listenerFlags := GetEntryListenerFlags(listener)
+	var request *protocol.ClientMessage
+	listenerFlags := protocol.GetEntryListenerFlags(listener)
 	predicateData, err := imap.validateAndSerializePredicate(predicate)
 	if err != nil {
 		return nil, err
 	}
-	request = MapAddEntryListenerWithPredicateEncodeRequest(imap.name, predicateData, includeValue, listenerFlags, false)
-	eventHandler := func(clientMessage *ClientMessage) {
-		MapAddEntryListenerWithPredicateHandle(clientMessage, func(key *serialization.Data, oldValue *serialization.Data, value *serialization.Data, mergingValue *serialization.Data, eventType int32, Uuid *string, numberOfAffectedEntries int32) {
+	request = protocol.MapAddEntryListenerWithPredicateEncodeRequest(imap.name, predicateData, includeValue, listenerFlags, false)
+	eventHandler := func(clientMessage *protocol.ClientMessage) {
+		protocol.MapAddEntryListenerWithPredicateHandle(clientMessage, func(key *serialization.Data, oldValue *serialization.Data, value *serialization.Data, mergingValue *serialization.Data, eventType int32, Uuid *string, numberOfAffectedEntries int32) {
 			imap.onEntryEvent(key, oldValue, value, mergingValue, eventType, Uuid, numberOfAffectedEntries, includeValue, listener)
 		})
 	}
 	return imap.client.ListenerService.registerListener(request, eventHandler,
-		func(registrationId *string) *ClientMessage {
-			return MapRemoveEntryListenerEncodeRequest(imap.name, registrationId)
-		}, func(clientMessage *ClientMessage) *string {
-			return MapAddEntryListenerWithPredicateDecodeResponse(clientMessage)()
+		func(registrationId *string) *protocol.ClientMessage {
+			return protocol.MapRemoveEntryListenerEncodeRequest(imap.name, registrationId)
+		}, func(clientMessage *protocol.ClientMessage) *string {
+			return protocol.MapAddEntryListenerWithPredicateDecodeResponse(clientMessage)()
 		})
 }
 func (imap *MapProxy) AddEntryListenerToKey(listener interface{}, key interface{}, includeValue bool) (registrationID *string, err error) {
-	var request *ClientMessage
-	listenerFlags := GetEntryListenerFlags(listener)
+	var request *protocol.ClientMessage
+	listenerFlags := protocol.GetEntryListenerFlags(listener)
 	keyData, err := imap.validateAndSerialize(key)
 	if err != nil {
 		return nil, err
 	}
-	request = MapAddEntryListenerToKeyEncodeRequest(imap.name, keyData, includeValue, listenerFlags, imap.isSmart())
-	eventHandler := func(clientMessage *ClientMessage) {
-		MapAddEntryListenerToKeyHandle(clientMessage, func(key *serialization.Data, oldValue *serialization.Data, value *serialization.Data, mergingValue *serialization.Data, eventType int32, Uuid *string, numberOfAffectedEntries int32) {
+	request = protocol.MapAddEntryListenerToKeyEncodeRequest(imap.name, keyData, includeValue, listenerFlags, imap.isSmart())
+	eventHandler := func(clientMessage *protocol.ClientMessage) {
+		protocol.MapAddEntryListenerToKeyHandle(clientMessage, func(key *serialization.Data, oldValue *serialization.Data, value *serialization.Data, mergingValue *serialization.Data, eventType int32, Uuid *string, numberOfAffectedEntries int32) {
 			imap.onEntryEvent(key, oldValue, value, mergingValue, eventType, Uuid, numberOfAffectedEntries, includeValue, listener)
 		})
 	}
-	return imap.client.ListenerService.registerListener(request, eventHandler, func(registrationId *string) *ClientMessage {
-		return MapRemoveEntryListenerEncodeRequest(imap.name, registrationId)
-	}, func(clientMessage *ClientMessage) *string {
-		return MapAddEntryListenerToKeyDecodeResponse(clientMessage)()
+	return imap.client.ListenerService.registerListener(request, eventHandler, func(registrationId *string) *protocol.ClientMessage {
+		return protocol.MapRemoveEntryListenerEncodeRequest(imap.name, registrationId)
+	}, func(clientMessage *protocol.ClientMessage) *string {
+		return protocol.MapAddEntryListenerToKeyDecodeResponse(clientMessage)()
 	})
 }
 func (imap *MapProxy) AddEntryListenerToKeyWithPredicate(listener interface{}, predicate interface{}, key interface{}, includeValue bool) (*string, error) {
-	var request *ClientMessage
-	listenerFlags := GetEntryListenerFlags(listener)
+	var request *protocol.ClientMessage
+	listenerFlags := protocol.GetEntryListenerFlags(listener)
 	keyData, err := imap.validateAndSerialize(key)
 	if err != nil {
 		return nil, err
@@ -457,17 +457,17 @@ func (imap *MapProxy) AddEntryListenerToKeyWithPredicate(listener interface{}, p
 	if err != nil {
 		return nil, err
 	}
-	request = MapAddEntryListenerToKeyWithPredicateEncodeRequest(imap.name, keyData, predicateData, includeValue, listenerFlags, false)
-	eventHandler := func(clientMessage *ClientMessage) {
-		MapAddEntryListenerToKeyWithPredicateHandle(clientMessage, func(key *serialization.Data, oldValue *serialization.Data, value *serialization.Data, mergingValue *serialization.Data, eventType int32, Uuid *string, numberOfAffectedEntries int32) {
+	request = protocol.MapAddEntryListenerToKeyWithPredicateEncodeRequest(imap.name, keyData, predicateData, includeValue, listenerFlags, false)
+	eventHandler := func(clientMessage *protocol.ClientMessage) {
+		protocol.MapAddEntryListenerToKeyWithPredicateHandle(clientMessage, func(key *serialization.Data, oldValue *serialization.Data, value *serialization.Data, mergingValue *serialization.Data, eventType int32, Uuid *string, numberOfAffectedEntries int32) {
 			imap.onEntryEvent(key, oldValue, value, mergingValue, eventType, Uuid, numberOfAffectedEntries, includeValue, listener)
 		})
 	}
 	return imap.client.ListenerService.registerListener(request, eventHandler,
-		func(registrationId *string) *ClientMessage {
-			return MapRemoveEntryListenerEncodeRequest(imap.name, registrationId)
-		}, func(clientMessage *ClientMessage) *string {
-			return MapAddEntryListenerToKeyWithPredicateDecodeResponse(clientMessage)()
+		func(registrationId *string) *protocol.ClientMessage {
+			return protocol.MapRemoveEntryListenerEncodeRequest(imap.name, registrationId)
+		}, func(clientMessage *protocol.ClientMessage) *string {
+			return protocol.MapAddEntryListenerToKeyWithPredicateDecodeResponse(clientMessage)()
 		})
 }
 func (imap *MapProxy) onEntryEvent(keyData *serialization.Data, oldValueData *serialization.Data, valueData *serialization.Data, mergingValueData *serialization.Data, eventType int32, Uuid *string, numberOfAffectedEntries int32, includedValue bool, listener interface{}) {
@@ -475,31 +475,31 @@ func (imap *MapProxy) onEntryEvent(keyData *serialization.Data, oldValueData *se
 	oldValue, _ := imap.toObject(oldValueData)
 	value, _ := imap.toObject(valueData)
 	mergingValue, _ := imap.toObject(mergingValueData)
-	entryEvent := NewEntryEvent(key, oldValue, value, mergingValue, eventType, Uuid)
-	mapEvent := NewMapEvent(eventType, Uuid, numberOfAffectedEntries)
+	entryEvent := protocol.NewEntryEvent(key, oldValue, value, mergingValue, eventType, Uuid)
+	mapEvent := protocol.NewMapEvent(eventType, Uuid, numberOfAffectedEntries)
 	switch eventType {
-	case EntryEventAdded:
-		listener.(EntryAddedListener).EntryAdded(entryEvent)
-	case EntryEventRemoved:
-		listener.(EntryRemovedListener).EntryRemoved(entryEvent)
-	case EntryEventUpdated:
-		listener.(EntryUpdatedListener).EntryUpdated(entryEvent)
-	case EntryEventEvicted:
-		listener.(EntryEvictedListener).EntryEvicted(entryEvent)
-	case EntryEventEvictAll:
-		listener.(EntryEvictAllListener).EntryEvictAll(mapEvent)
-	case EntryEventClearAll:
-		listener.(EntryClearAllListener).EntryClearAll(mapEvent)
-	case EntryEventMerged:
-		listener.(EntryMergedListener).EntryMerged(entryEvent)
-	case EntryEventExpired:
-		listener.(EntryExpiredListener).EntryExpired(entryEvent)
+	case common.EntryEventAdded:
+		listener.(protocol.EntryAddedListener).EntryAdded(entryEvent)
+	case common.EntryEventRemoved:
+		listener.(protocol.EntryRemovedListener).EntryRemoved(entryEvent)
+	case common.EntryEventUpdated:
+		listener.(protocol.EntryUpdatedListener).EntryUpdated(entryEvent)
+	case common.EntryEventEvicted:
+		listener.(protocol.EntryEvictedListener).EntryEvicted(entryEvent)
+	case common.EntryEventEvictAll:
+		listener.(protocol.EntryEvictAllListener).EntryEvictAll(mapEvent)
+	case common.EntryEventClearAll:
+		listener.(protocol.EntryClearAllListener).EntryClearAll(mapEvent)
+	case common.EntryEventMerged:
+		listener.(protocol.EntryMergedListener).EntryMerged(entryEvent)
+	case common.EntryEventExpired:
+		listener.(protocol.EntryExpiredListener).EntryExpired(entryEvent)
 	}
 }
 
 func (imap *MapProxy) RemoveEntryListener(registrationId *string) (bool, error) {
-	return imap.client.ListenerService.deregisterListener(*registrationId, func(registrationId *string) *ClientMessage {
-		return MapRemoveEntryListenerEncodeRequest(imap.name, registrationId)
+	return imap.client.ListenerService.deregisterListener(*registrationId, func(registrationId *string) *protocol.ClientMessage {
+		return protocol.MapRemoveEntryListenerEncodeRequest(imap.name, registrationId)
 	})
 }
 
@@ -508,11 +508,11 @@ func (imap *MapProxy) ExecuteOnKey(key interface{}, entryProcessor interface{}) 
 	if err != nil {
 		return nil, err
 	}
-	request := MapExecuteOnKeyEncodeRequest(imap.name, entryProcessorData, keyData, threadId)
+	request := protocol.MapExecuteOnKeyEncodeRequest(imap.name, entryProcessorData, keyData, threadId)
 	responseMessage, err := imap.invokeOnKey(request, keyData)
-	return imap.decodeToObjectAndError(responseMessage, err, MapExecuteOnKeyDecodeResponse)
+	return imap.decodeToObjectAndError(responseMessage, err, protocol.MapExecuteOnKeyDecodeResponse)
 }
-func (imap *MapProxy) ExecuteOnKeys(keys []interface{}, entryProcessor interface{}) (keyToResultPairs []IPair, err error) {
+func (imap *MapProxy) ExecuteOnKeys(keys []interface{}, entryProcessor interface{}) (keyToResultPairs []core.IPair, err error) {
 	keysData := make([]*serialization.Data, len(keys))
 	for index, key := range keys {
 		keyData, err := imap.validateAndSerialize(key)
@@ -525,21 +525,21 @@ func (imap *MapProxy) ExecuteOnKeys(keys []interface{}, entryProcessor interface
 	if err != nil {
 		return nil, err
 	}
-	request := MapExecuteOnKeysEncodeRequest(imap.name, entryProcessorData, keysData)
+	request := protocol.MapExecuteOnKeysEncodeRequest(imap.name, entryProcessorData, keysData)
 	responseMessage, err := imap.invokeOnRandomTarget(request)
-	return imap.decodeToPairSliceAndError(responseMessage, err, MapExecuteOnKeysDecodeResponse)
+	return imap.decodeToPairSliceAndError(responseMessage, err, protocol.MapExecuteOnKeysDecodeResponse)
 }
-func (imap *MapProxy) ExecuteOnEntries(entryProcessor interface{}) (keyToResultPairs []IPair, err error) {
+func (imap *MapProxy) ExecuteOnEntries(entryProcessor interface{}) (keyToResultPairs []core.IPair, err error) {
 	entryProcessorData, err := imap.validateAndSerialize(entryProcessor)
 	if err != nil {
 		return nil, err
 	}
-	request := MapExecuteOnAllKeysEncodeRequest(imap.name, entryProcessorData)
+	request := protocol.MapExecuteOnAllKeysEncodeRequest(imap.name, entryProcessorData)
 	responseMessage, err := imap.invokeOnRandomTarget(request)
-	return imap.decodeToPairSliceAndError(responseMessage, err, MapExecuteOnAllKeysDecodeResponse)
+	return imap.decodeToPairSliceAndError(responseMessage, err, protocol.MapExecuteOnAllKeysDecodeResponse)
 }
 
-func (imap *MapProxy) ExecuteOnEntriesWithPredicate(entryProcessor interface{}, predicate interface{}) (keyToResultPairs []IPair, err error) {
+func (imap *MapProxy) ExecuteOnEntriesWithPredicate(entryProcessor interface{}, predicate interface{}) (keyToResultPairs []core.IPair, err error) {
 	predicateData, err := imap.validateAndSerializePredicate(predicate)
 	if err != nil {
 		return nil, err
@@ -548,7 +548,7 @@ func (imap *MapProxy) ExecuteOnEntriesWithPredicate(entryProcessor interface{}, 
 	if err != nil {
 		return nil, err
 	}
-	request := MapExecuteWithPredicateEncodeRequest(imap.name, entryProcessorData, predicateData)
+	request := protocol.MapExecuteWithPredicateEncodeRequest(imap.name, entryProcessorData, predicateData)
 	responseMessage, err := imap.invokeOnRandomTarget(request)
-	return imap.decodeToPairSliceAndError(responseMessage, err, MapExecuteWithPredicateDecodeResponse)
+	return imap.decodeToPairSliceAndError(responseMessage, err, protocol.MapExecuteWithPredicateDecodeResponse)
 }

--- a/internal/message_builder.go
+++ b/internal/message_builder.go
@@ -16,15 +16,15 @@ package internal
 
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/common"
-	. "github.com/hazelcast/hazelcast-go-client/internal/protocol"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol"
 )
 
 type clientMessageBuilder struct {
-	incompleteMessages map[int64]*ClientMessage
-	responseChannel    chan *ClientMessage
+	incompleteMessages map[int64]*protocol.ClientMessage
+	responseChannel    chan *protocol.ClientMessage
 }
 
-func (cmb *clientMessageBuilder) onMessage(msg *ClientMessage) {
+func (cmb *clientMessageBuilder) onMessage(msg *protocol.ClientMessage) {
 	if msg.HasFlags(common.BeginEndFlag) > 0 {
 		cmb.responseChannel <- msg
 	} else if msg.HasFlags(common.BeginFlag) > 0 {

--- a/internal/message_builder_test.go
+++ b/internal/message_builder_test.go
@@ -16,7 +16,7 @@ package internal
 
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/common"
-	. "github.com/hazelcast/hazelcast-go-client/internal/protocol"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol"
 	"reflect"
 	"sync"
 	"testing"
@@ -24,13 +24,13 @@ import (
 
 func TestClientMessageBuilder_OnMessage(t *testing.T) {
 	builder := &clientMessageBuilder{
-		incompleteMessages: make(map[int64]*ClientMessage),
+		incompleteMessages: make(map[int64]*protocol.ClientMessage),
 	}
 	var mu = sync.Mutex{}
 	// make this channel blocking to ensure that test wont continue until the builtClientMessage is received
-	ch := make(chan *ClientMessage, 0)
+	ch := make(chan *protocol.ClientMessage, 0)
 	builder.responseChannel = ch
-	var builtClientMessage *ClientMessage
+	var builtClientMessage *protocol.ClientMessage
 	go func() {
 		mu.Lock()
 		builtClientMessage = <-ch
@@ -39,7 +39,7 @@ func TestClientMessageBuilder_OnMessage(t *testing.T) {
 
 	testString := "testString"
 	serverVersion := "3.9"
-	expectedClientMessage := ClientAuthenticationEncodeRequest(&testString, &testString, &testString, &testString, false,
+	expectedClientMessage := protocol.ClientAuthenticationEncodeRequest(&testString, &testString, &testString, &testString, false,
 		&testString, 1, &serverVersion)
 	expectedClientMessage.SetFlags(common.BeginEndFlag)
 	expectedClientMessage.SetCorrelationId(1)
@@ -51,8 +51,8 @@ func TestClientMessageBuilder_OnMessage(t *testing.T) {
 	firstBuffer := append(buffer[0:expectedClientMessage.DataOffset()], buffer[expectedClientMessage.DataOffset():expectedClientMessage.DataOffset()+payloadSize/2]...)
 	secondBuffer := append(buffer[0:expectedClientMessage.DataOffset()], buffer[expectedClientMessage.DataOffset()+payloadSize/2:]...)
 
-	firstMessage := NewClientMessage(firstBuffer, 0)
-	secondMessage := NewClientMessage(secondBuffer, 0)
+	firstMessage := protocol.NewClientMessage(firstBuffer, 0)
+	secondMessage := protocol.NewClientMessage(secondBuffer, 0)
 
 	firstMessage.SetFrameLength(int32(len(firstMessage.Buffer)))
 	secondMessage.SetFrameLength(int32(len(secondMessage.Buffer)))
@@ -71,12 +71,12 @@ func TestClientMessageBuilder_OnMessage(t *testing.T) {
 
 func TestClientMessageBuilder_OnMessageWithNotFoundCorrelationId(t *testing.T) {
 	builder := &clientMessageBuilder{
-		incompleteMessages: make(map[int64]*ClientMessage),
+		incompleteMessages: make(map[int64]*protocol.ClientMessage),
 	}
 	// make this channel blocking to ensure that test wont continue until the builtClientMessage is received
-	ch := make(chan *ClientMessage, 0)
+	ch := make(chan *protocol.ClientMessage, 0)
 	builder.responseChannel = ch
-	msg := NewClientMessage(nil, 40)
+	msg := protocol.NewClientMessage(nil, 40)
 	msg.SetCorrelationId(2)
 	msg.SetFrameLength(int32(len(msg.Buffer)))
 	builder.onMessage(msg)

--- a/internal/multi_map.go
+++ b/internal/multi_map.go
@@ -15,9 +15,9 @@
 package internal
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/core"
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
-	. "github.com/hazelcast/hazelcast-go-client/internal/protocol"
+	"github.com/hazelcast/hazelcast-go-client/core"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol"
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 	"time"
 )
@@ -35,9 +35,9 @@ func (mmp *MultiMapProxy) Put(key interface{}, value interface{}) (increased boo
 	if err != nil {
 		return
 	}
-	request := MultiMapPutEncodeRequest(mmp.name, keyData, valueData, threadId)
+	request := protocol.MultiMapPutEncodeRequest(mmp.name, keyData, valueData, threadId)
 	responseMessage, err := mmp.invokeOnKey(request, keyData)
-	return mmp.decodeToBoolAndError(responseMessage, err, MultiMapPutDecodeResponse)
+	return mmp.decodeToBoolAndError(responseMessage, err, protocol.MultiMapPutDecodeResponse)
 }
 
 func (mmp *MultiMapProxy) Get(key interface{}) (values []interface{}, err error) {
@@ -45,9 +45,9 @@ func (mmp *MultiMapProxy) Get(key interface{}) (values []interface{}, err error)
 	if err != nil {
 		return
 	}
-	request := MultiMapGetEncodeRequest(mmp.name, keyData, threadId)
+	request := protocol.MultiMapGetEncodeRequest(mmp.name, keyData, threadId)
 	responseMessage, err := mmp.invokeOnKey(request, keyData)
-	return mmp.decodeToInterfaceSliceAndError(responseMessage, err, MultiMapGetDecodeResponse)
+	return mmp.decodeToInterfaceSliceAndError(responseMessage, err, protocol.MultiMapGetDecodeResponse)
 }
 
 func (mmp *MultiMapProxy) Remove(key interface{}, value interface{}) (removed bool, err error) {
@@ -55,9 +55,9 @@ func (mmp *MultiMapProxy) Remove(key interface{}, value interface{}) (removed bo
 	if err != nil {
 		return
 	}
-	request := MultiMapRemoveEntryEncodeRequest(mmp.name, keyData, valueData, threadId)
+	request := protocol.MultiMapRemoveEntryEncodeRequest(mmp.name, keyData, valueData, threadId)
 	responseMessage, err := mmp.invokeOnKey(request, keyData)
-	return mmp.decodeToBoolAndError(responseMessage, err, MultiMapRemoveEntryDecodeResponse)
+	return mmp.decodeToBoolAndError(responseMessage, err, protocol.MultiMapRemoveEntryDecodeResponse)
 
 }
 
@@ -66,9 +66,9 @@ func (mmp *MultiMapProxy) RemoveAll(key interface{}) (oldValues []interface{}, e
 	if err != nil {
 		return
 	}
-	request := MultiMapRemoveEncodeRequest(mmp.name, keyData, threadId)
+	request := protocol.MultiMapRemoveEncodeRequest(mmp.name, keyData, threadId)
 	responseMessage, err := mmp.invokeOnKey(request, keyData)
-	return mmp.decodeToInterfaceSliceAndError(responseMessage, err, MultiMapRemoveDecodeResponse)
+	return mmp.decodeToInterfaceSliceAndError(responseMessage, err, protocol.MultiMapRemoveDecodeResponse)
 }
 
 func (mmp *MultiMapProxy) ContainsKey(key interface{}) (found bool, err error) {
@@ -76,9 +76,9 @@ func (mmp *MultiMapProxy) ContainsKey(key interface{}) (found bool, err error) {
 	if err != nil {
 		return
 	}
-	request := MultiMapContainsKeyEncodeRequest(mmp.name, keyData, threadId)
+	request := protocol.MultiMapContainsKeyEncodeRequest(mmp.name, keyData, threadId)
 	responseMessage, err := mmp.invokeOnKey(request, keyData)
-	return mmp.decodeToBoolAndError(responseMessage, err, MultiMapContainsKeyDecodeResponse)
+	return mmp.decodeToBoolAndError(responseMessage, err, protocol.MultiMapContainsKeyDecodeResponse)
 }
 
 func (mmp *MultiMapProxy) ContainsValue(value interface{}) (found bool, err error) {
@@ -86,9 +86,9 @@ func (mmp *MultiMapProxy) ContainsValue(value interface{}) (found bool, err erro
 	if err != nil {
 		return
 	}
-	request := MultiMapContainsValueEncodeRequest(mmp.name, valueData)
+	request := protocol.MultiMapContainsValueEncodeRequest(mmp.name, valueData)
 	responseMessage, err := mmp.invokeOnRandomTarget(request)
-	return mmp.decodeToBoolAndError(responseMessage, err, MultiMapContainsValueDecodeResponse)
+	return mmp.decodeToBoolAndError(responseMessage, err, protocol.MultiMapContainsValueDecodeResponse)
 }
 
 func (mmp *MultiMapProxy) ContainsEntry(key interface{}, value interface{}) (found bool, err error) {
@@ -96,21 +96,21 @@ func (mmp *MultiMapProxy) ContainsEntry(key interface{}, value interface{}) (fou
 	if err != nil {
 		return
 	}
-	request := MultiMapContainsEntryEncodeRequest(mmp.name, keyData, valueData, threadId)
+	request := protocol.MultiMapContainsEntryEncodeRequest(mmp.name, keyData, valueData, threadId)
 	responseMessage, err := mmp.invokeOnKey(request, keyData)
-	return mmp.decodeToBoolAndError(responseMessage, err, MultiMapContainsEntryDecodeResponse)
+	return mmp.decodeToBoolAndError(responseMessage, err, protocol.MultiMapContainsEntryDecodeResponse)
 }
 
 func (mmp *MultiMapProxy) Clear() (err error) {
-	request := MultiMapClearEncodeRequest(mmp.name)
+	request := protocol.MultiMapClearEncodeRequest(mmp.name)
 	_, err = mmp.invokeOnRandomTarget(request)
 	return
 }
 
 func (mmp *MultiMapProxy) Size() (size int32, err error) {
-	request := MultiMapSizeEncodeRequest(mmp.name)
+	request := protocol.MultiMapSizeEncodeRequest(mmp.name)
 	responseMessage, err := mmp.invokeOnRandomTarget(request)
-	return mmp.decodeToInt32AndError(responseMessage, err, MultiMapSizeDecodeResponse)
+	return mmp.decodeToInt32AndError(responseMessage, err, protocol.MultiMapSizeDecodeResponse)
 }
 
 func (mmp *MultiMapProxy) ValueCount(key interface{}) (valueCount int32, err error) {
@@ -118,58 +118,58 @@ func (mmp *MultiMapProxy) ValueCount(key interface{}) (valueCount int32, err err
 	if err != nil {
 		return
 	}
-	request := MultiMapValueCountEncodeRequest(mmp.name, keyData, threadId)
+	request := protocol.MultiMapValueCountEncodeRequest(mmp.name, keyData, threadId)
 	responseMessage, err := mmp.invokeOnKey(request, keyData)
-	return mmp.decodeToInt32AndError(responseMessage, err, MultiMapValueCountDecodeResponse)
+	return mmp.decodeToInt32AndError(responseMessage, err, protocol.MultiMapValueCountDecodeResponse)
 }
 
 func (mmp *MultiMapProxy) Values() (values []interface{}, err error) {
-	request := MultiMapValuesEncodeRequest(mmp.name)
+	request := protocol.MultiMapValuesEncodeRequest(mmp.name)
 	responseMessage, err := mmp.invokeOnRandomTarget(request)
-	return mmp.decodeToInterfaceSliceAndError(responseMessage, err, MultiMapValuesDecodeResponse)
+	return mmp.decodeToInterfaceSliceAndError(responseMessage, err, protocol.MultiMapValuesDecodeResponse)
 }
 
 func (mmp *MultiMapProxy) KeySet() (keySet []interface{}, err error) {
-	request := MultiMapKeySetEncodeRequest(mmp.name)
+	request := protocol.MultiMapKeySetEncodeRequest(mmp.name)
 	responseMessage, err := mmp.invokeOnRandomTarget(request)
-	return mmp.decodeToInterfaceSliceAndError(responseMessage, err, MultiMapKeySetDecodeResponse)
+	return mmp.decodeToInterfaceSliceAndError(responseMessage, err, protocol.MultiMapKeySetDecodeResponse)
 }
 
-func (mmp *MultiMapProxy) EntrySet() (resultPairs []IPair, err error) {
-	request := MultiMapEntrySetEncodeRequest(mmp.name)
+func (mmp *MultiMapProxy) EntrySet() (resultPairs []core.IPair, err error) {
+	request := protocol.MultiMapEntrySetEncodeRequest(mmp.name)
 	responseMessage, err := mmp.invokeOnRandomTarget(request)
-	return mmp.decodeToPairSliceAndError(responseMessage, err, MultiMapEntrySetDecodeResponse)
+	return mmp.decodeToPairSliceAndError(responseMessage, err, protocol.MultiMapEntrySetDecodeResponse)
 }
 
 func (mmp *MultiMapProxy) AddEntryListener(listener interface{}, includeValue bool) (registrationID *string, err error) {
-	var request *ClientMessage
-	request = MultiMapAddEntryListenerEncodeRequest(mmp.name, includeValue, mmp.isSmart())
+	var request *protocol.ClientMessage
+	request = protocol.MultiMapAddEntryListenerEncodeRequest(mmp.name, includeValue, mmp.isSmart())
 	eventHandler := mmp.createEventHandler(listener)
-	return mmp.client.ListenerService.registerListener(request, eventHandler, func(registrationId *string) *ClientMessage {
-		return MultiMapRemoveEntryListenerEncodeRequest(mmp.name, registrationId)
-	}, func(clientMessage *ClientMessage) *string {
-		return MultiMapAddEntryListenerDecodeResponse(clientMessage)()
+	return mmp.client.ListenerService.registerListener(request, eventHandler, func(registrationId *string) *protocol.ClientMessage {
+		return protocol.MultiMapRemoveEntryListenerEncodeRequest(mmp.name, registrationId)
+	}, func(clientMessage *protocol.ClientMessage) *string {
+		return protocol.MultiMapAddEntryListenerDecodeResponse(clientMessage)()
 	})
 }
 
 func (mmp *MultiMapProxy) AddEntryListenerToKey(listener interface{}, key interface{}, includeValue bool) (registrationID *string, err error) {
-	var request *ClientMessage
+	var request *protocol.ClientMessage
 	keyData, err := mmp.validateAndSerialize(key)
 	if err != nil {
 		return nil, err
 	}
-	request = MultiMapAddEntryListenerToKeyEncodeRequest(mmp.name, keyData, includeValue, mmp.isSmart())
+	request = protocol.MultiMapAddEntryListenerToKeyEncodeRequest(mmp.name, keyData, includeValue, mmp.isSmart())
 	eventHandler := mmp.createEventHandlerToKey(listener)
-	return mmp.client.ListenerService.registerListener(request, eventHandler, func(registrationId *string) *ClientMessage {
-		return MultiMapRemoveEntryListenerEncodeRequest(mmp.name, registrationId)
-	}, func(clientMessage *ClientMessage) *string {
-		return MultiMapAddEntryListenerToKeyDecodeResponse(clientMessage)()
+	return mmp.client.ListenerService.registerListener(request, eventHandler, func(registrationId *string) *protocol.ClientMessage {
+		return protocol.MultiMapRemoveEntryListenerEncodeRequest(mmp.name, registrationId)
+	}, func(clientMessage *protocol.ClientMessage) *string {
+		return protocol.MultiMapAddEntryListenerToKeyDecodeResponse(clientMessage)()
 	})
 }
 
 func (mmp *MultiMapProxy) RemoveEntryListener(registrationId *string) (removed bool, err error) {
-	return mmp.client.ListenerService.deregisterListener(*registrationId, func(registrationId *string) *ClientMessage {
-		return MultiMapRemoveEntryListenerEncodeRequest(mmp.name, registrationId)
+	return mmp.client.ListenerService.deregisterListener(*registrationId, func(registrationId *string) *protocol.ClientMessage {
+		return protocol.MultiMapRemoveEntryListenerEncodeRequest(mmp.name, registrationId)
 	})
 }
 
@@ -182,8 +182,8 @@ func (mmp *MultiMapProxy) LockWithLeaseTime(key interface{}, lease int64, leaseT
 	if err != nil {
 		return err
 	}
-	lease = GetTimeInMilliSeconds(lease, leaseTimeUnit)
-	request := MultiMapLockEncodeRequest(mmp.name, keyData, threadId, lease, mmp.client.ProxyManager.nextReferenceId())
+	lease = common.GetTimeInMilliSeconds(lease, leaseTimeUnit)
+	request := protocol.MultiMapLockEncodeRequest(mmp.name, keyData, threadId, lease, mmp.client.ProxyManager.nextReferenceId())
 	_, err = mmp.invokeOnKey(request, keyData)
 	return
 }
@@ -193,9 +193,9 @@ func (mmp *MultiMapProxy) IsLocked(key interface{}) (locked bool, err error) {
 	if err != nil {
 		return false, err
 	}
-	request := MultiMapIsLockedEncodeRequest(mmp.name, keyData)
+	request := protocol.MultiMapIsLockedEncodeRequest(mmp.name, keyData)
 	responseMessage, err := mmp.invokeOnKey(request, keyData)
-	return mmp.decodeToBoolAndError(responseMessage, err, MultiMapIsLockedDecodeResponse)
+	return mmp.decodeToBoolAndError(responseMessage, err, protocol.MultiMapIsLockedDecodeResponse)
 }
 
 func (mmp *MultiMapProxy) TryLock(key interface{}) (locked bool, err error) {
@@ -211,11 +211,11 @@ func (mmp *MultiMapProxy) TryLockWithTimeoutAndLease(key interface{}, timeout in
 	if err != nil {
 		return false, err
 	}
-	timeout = GetTimeInMilliSeconds(timeout, timeoutTimeUnit)
-	lease = GetTimeInMilliSeconds(lease, leaseTimeUnit)
-	request := MultiMapTryLockEncodeRequest(mmp.name, keyData, threadId, lease, timeout, mmp.client.ProxyManager.nextReferenceId())
+	timeout = common.GetTimeInMilliSeconds(timeout, timeoutTimeUnit)
+	lease = common.GetTimeInMilliSeconds(lease, leaseTimeUnit)
+	request := protocol.MultiMapTryLockEncodeRequest(mmp.name, keyData, threadId, lease, timeout, mmp.client.ProxyManager.nextReferenceId())
 	responseMessage, err := mmp.invokeOnKey(request, keyData)
-	return mmp.decodeToBoolAndError(responseMessage, err, MultiMapTryLockDecodeResponse)
+	return mmp.decodeToBoolAndError(responseMessage, err, protocol.MultiMapTryLockDecodeResponse)
 }
 
 func (mmp *MultiMapProxy) Unlock(key interface{}) (err error) {
@@ -223,7 +223,7 @@ func (mmp *MultiMapProxy) Unlock(key interface{}) (err error) {
 	if err != nil {
 		return err
 	}
-	request := MultiMapUnlockEncodeRequest(mmp.name, keyData, threadId, mmp.client.ProxyManager.nextReferenceId())
+	request := protocol.MultiMapUnlockEncodeRequest(mmp.name, keyData, threadId, mmp.client.ProxyManager.nextReferenceId())
 	_, err = mmp.invokeOnKey(request, keyData)
 	return
 }
@@ -233,7 +233,7 @@ func (mmp *MultiMapProxy) ForceUnlock(key interface{}) (err error) {
 	if err != nil {
 		return err
 	}
-	request := MultiMapForceUnlockEncodeRequest(mmp.name, keyData, mmp.client.ProxyManager.nextReferenceId())
+	request := protocol.MultiMapForceUnlockEncodeRequest(mmp.name, keyData, mmp.client.ProxyManager.nextReferenceId())
 	_, err = mmp.invokeOnKey(request, keyData)
 	return
 }
@@ -243,30 +243,30 @@ func (mmp *MultiMapProxy) onEntryEvent(keyData *serialization.Data, oldValueData
 	oldValue, _ := mmp.toObject(oldValueData)
 	value, _ := mmp.toObject(valueData)
 	mergingValue, _ := mmp.toObject(mergingValueData)
-	entryEvent := NewEntryEvent(key, oldValue, value, mergingValue, eventType, Uuid)
-	mapEvent := NewMapEvent(eventType, Uuid, numberOfAffectedEntries)
+	entryEvent := protocol.NewEntryEvent(key, oldValue, value, mergingValue, eventType, Uuid)
+	mapEvent := protocol.NewMapEvent(eventType, Uuid, numberOfAffectedEntries)
 	switch eventType {
-	case EntryEventAdded:
-		listener.(EntryAddedListener).EntryAdded(entryEvent)
-	case EntryEventRemoved:
-		listener.(EntryRemovedListener).EntryRemoved(entryEvent)
-	case EntryEventClearAll:
-		listener.(EntryClearAllListener).EntryClearAll(mapEvent)
+	case common.EntryEventAdded:
+		listener.(protocol.EntryAddedListener).EntryAdded(entryEvent)
+	case common.EntryEventRemoved:
+		listener.(protocol.EntryRemovedListener).EntryRemoved(entryEvent)
+	case common.EntryEventClearAll:
+		listener.(protocol.EntryClearAllListener).EntryClearAll(mapEvent)
 	}
 }
 
-func (mmp *MultiMapProxy) createEventHandler(listener interface{}) func(clientMessage *ClientMessage) {
-	return func(clientMessage *ClientMessage) {
-		MultiMapAddEntryListenerHandle(clientMessage, func(key *serialization.Data, oldValue *serialization.Data,
+func (mmp *MultiMapProxy) createEventHandler(listener interface{}) func(clientMessage *protocol.ClientMessage) {
+	return func(clientMessage *protocol.ClientMessage) {
+		protocol.MultiMapAddEntryListenerHandle(clientMessage, func(key *serialization.Data, oldValue *serialization.Data,
 			value *serialization.Data, mergingValue *serialization.Data, eventType int32, Uuid *string, numberOfAffectedEntries int32) {
 			mmp.onEntryEvent(key, oldValue, value, mergingValue, eventType, Uuid, numberOfAffectedEntries, listener)
 		})
 	}
 }
 
-func (mmp *MultiMapProxy) createEventHandlerToKey(listener interface{}) func(clientMessage *ClientMessage) {
-	return func(clientMessage *ClientMessage) {
-		MultiMapAddEntryListenerToKeyHandle(clientMessage, func(key *serialization.Data, oldValue *serialization.Data,
+func (mmp *MultiMapProxy) createEventHandlerToKey(listener interface{}) func(clientMessage *protocol.ClientMessage) {
+	return func(clientMessage *protocol.ClientMessage) {
+		protocol.MultiMapAddEntryListenerToKeyHandle(clientMessage, func(key *serialization.Data, oldValue *serialization.Data,
 			value *serialization.Data, mergingValue *serialization.Data, eventType int32, Uuid *string, numberOfAffectedEntries int32) {
 			mmp.onEntryEvent(key, oldValue, value, mergingValue, eventType, Uuid, numberOfAffectedEntries, listener)
 		})

--- a/internal/partition.go
+++ b/internal/partition.go
@@ -16,7 +16,7 @@ package internal
 
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/common"
-	. "github.com/hazelcast/hazelcast-go-client/internal/protocol"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol"
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 	"log"
 	"sync/atomic"
@@ -56,11 +56,11 @@ func (partitionService *partitionService) start() {
 
 }
 func (partitionService *partitionService) getPartitionCount() int32 {
-	partitions := partitionService.mp.Load().(map[int32]*Address)
+	partitions := partitionService.mp.Load().(map[int32]*protocol.Address)
 	return int32(len(partitions))
 }
-func (partitionService *partitionService) partitionOwner(partitionId int32) (*Address, bool) {
-	partitions := partitionService.mp.Load().(map[int32]*Address)
+func (partitionService *partitionService) partitionOwner(partitionId int32) (*protocol.Address, bool) {
+	partitions := partitionService.mp.Load().(map[int32]*protocol.Address)
 	address, ok := partitions[partitionId]
 	return address, ok
 }
@@ -87,7 +87,7 @@ func (partitionService *partitionService) doRefresh() {
 		log.Println("error while fetching cluster partition table!")
 		return
 	}
-	request := ClientGetPartitionsEncodeRequest()
+	request := protocol.ClientGetPartitionsEncodeRequest()
 	result, err := partitionService.client.InvocationService.invokeOnConnection(request, connection).Result()
 	if err != nil {
 		log.Println("error while fetching cluster partition table! ", err)
@@ -96,11 +96,11 @@ func (partitionService *partitionService) doRefresh() {
 	partitionService.processPartitionResponse(result)
 }
 
-func (partitionService *partitionService) processPartitionResponse(result *ClientMessage) {
-	partitions /*partitionStateVersion*/, _ := ClientGetPartitionsDecodeResponse(result)()
-	newPartitions := make(map[int32]*Address, len(partitions))
+func (partitionService *partitionService) processPartitionResponse(result *protocol.ClientMessage) {
+	partitions /*partitionStateVersion*/, _ := protocol.ClientGetPartitionsDecodeResponse(result)()
+	newPartitions := make(map[int32]*protocol.Address, len(partitions))
 	for _, partitionList := range partitions {
-		addr := partitionList.Key().(*Address)
+		addr := partitionList.Key().(*protocol.Address)
 		for _, partition := range partitionList.Value().([]int32) {
 			newPartitions[int32(partition)] = addr
 		}

--- a/internal/predicates/predicate_factory.go
+++ b/internal/predicates/predicate_factory.go
@@ -15,7 +15,7 @@
 package predicates
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/serialization"
+	"github.com/hazelcast/hazelcast-go-client/serialization"
 )
 
 type PredicateFactory struct {
@@ -25,7 +25,7 @@ func NewPredicateFactory() *PredicateFactory {
 	return &PredicateFactory{}
 }
 
-func (pf *PredicateFactory) Create(id int32) IdentifiedDataSerializable {
+func (pf *PredicateFactory) Create(id int32) serialization.IdentifiedDataSerializable {
 	switch id {
 	case SqlPredicateId:
 		return &SqlPredicate{}

--- a/internal/predicates/predicates_impl.go
+++ b/internal/predicates/predicates_impl.go
@@ -15,7 +15,7 @@
 package predicates
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/serialization"
+	"github.com/hazelcast/hazelcast-go-client/serialization"
 )
 
 const PredicateFactoryId = -32
@@ -28,11 +28,11 @@ func newPredicate(id int32) *predicate {
 	return &predicate{id}
 }
 
-func (sp *predicate) ReadData(input DataInput) error {
+func (sp *predicate) ReadData(input serialization.DataInput) error {
 	return nil
 }
 
-func (sp *predicate) WriteData(output DataOutput) error {
+func (sp *predicate) WriteData(output serialization.DataOutput) error {
 	return nil
 }
 
@@ -53,14 +53,14 @@ func NewSqlPredicate(sql string) *SqlPredicate {
 	return &SqlPredicate{newPredicate(SqlPredicateId), sql}
 }
 
-func (sp *SqlPredicate) ReadData(input DataInput) error {
+func (sp *SqlPredicate) ReadData(input serialization.DataInput) error {
 	var err error
 	sp.predicate = newPredicate(SqlPredicateId)
 	sp.sql, err = input.ReadUTF()
 	return err
 }
 
-func (sp *SqlPredicate) WriteData(output DataOutput) error {
+func (sp *SqlPredicate) WriteData(output serialization.DataOutput) error {
 	output.WriteUTF(sp.sql)
 	return nil
 }
@@ -74,7 +74,7 @@ func NewAndPredicate(predicates []interface{}) *AndPredicate {
 	return &AndPredicate{newPredicate(AndPredicateId), predicates}
 }
 
-func (ap *AndPredicate) ReadData(input DataInput) error {
+func (ap *AndPredicate) ReadData(input serialization.DataInput) error {
 	ap.predicate = newPredicate(AndPredicateId)
 	length, err := input.ReadInt32()
 	if err != nil {
@@ -91,7 +91,7 @@ func (ap *AndPredicate) ReadData(input DataInput) error {
 	return nil
 }
 
-func (ap *AndPredicate) WriteData(output DataOutput) error {
+func (ap *AndPredicate) WriteData(output serialization.DataOutput) error {
 	output.WriteInt32(int32(len(ap.predicates)))
 	for _, pred := range ap.predicates {
 		err := output.WriteObject(pred)
@@ -113,7 +113,7 @@ func NewBetweenPredicate(field string, from interface{}, to interface{}) *Betwee
 	return &BetweenPredicate{newPredicate(BetweenPredicateId), field, from, to}
 }
 
-func (bp *BetweenPredicate) ReadData(input DataInput) error {
+func (bp *BetweenPredicate) ReadData(input serialization.DataInput) error {
 	var err error
 	bp.predicate = newPredicate(BetweenPredicateId)
 	bp.field, err = input.ReadUTF()
@@ -129,7 +129,7 @@ func (bp *BetweenPredicate) ReadData(input DataInput) error {
 	return err
 }
 
-func (bp *BetweenPredicate) WriteData(output DataOutput) error {
+func (bp *BetweenPredicate) WriteData(output serialization.DataOutput) error {
 	output.WriteUTF(bp.field)
 	err := output.WriteObject(bp.to)
 	if err != nil {
@@ -148,7 +148,7 @@ func NewEqualPredicate(field string, value interface{}) *EqualPredicate {
 	return &EqualPredicate{newPredicate(EqualPredicateId), field, value}
 }
 
-func (ep *EqualPredicate) ReadData(input DataInput) error {
+func (ep *EqualPredicate) ReadData(input serialization.DataInput) error {
 	var err error
 	ep.predicate = newPredicate(EqualPredicateId)
 	ep.field, err = input.ReadUTF()
@@ -160,7 +160,7 @@ func (ep *EqualPredicate) ReadData(input DataInput) error {
 	return err
 }
 
-func (ep *EqualPredicate) WriteData(output DataOutput) error {
+func (ep *EqualPredicate) WriteData(output serialization.DataOutput) error {
 	output.WriteUTF(ep.field)
 	return output.WriteObject(ep.value)
 }
@@ -177,7 +177,7 @@ func NewGreaterLessPredicate(field string, value interface{}, equal bool, less b
 	return &GreaterLessPredicate{newPredicate(GreaterlessPredicateId), field, value, equal, less}
 }
 
-func (glp *GreaterLessPredicate) ReadData(input DataInput) error {
+func (glp *GreaterLessPredicate) ReadData(input serialization.DataInput) error {
 	var err error
 	glp.predicate = newPredicate(GreaterlessPredicateId)
 	glp.field, err = input.ReadUTF()
@@ -196,7 +196,7 @@ func (glp *GreaterLessPredicate) ReadData(input DataInput) error {
 	return err
 }
 
-func (glp *GreaterLessPredicate) WriteData(output DataOutput) error {
+func (glp *GreaterLessPredicate) WriteData(output serialization.DataOutput) error {
 	output.WriteUTF(glp.field)
 	err := output.WriteObject(glp.value)
 	if err != nil {
@@ -217,7 +217,7 @@ func NewLikePredicate(field string, expr string) *LikePredicate {
 	return &LikePredicate{newPredicate(LikePredicateId), field, expr}
 }
 
-func (lp *LikePredicate) ReadData(input DataInput) error {
+func (lp *LikePredicate) ReadData(input serialization.DataInput) error {
 	var err error
 	lp.predicate = newPredicate(LikePredicateId)
 	lp.field, err = input.ReadUTF()
@@ -228,7 +228,7 @@ func (lp *LikePredicate) ReadData(input DataInput) error {
 	return err
 }
 
-func (lp *LikePredicate) WriteData(output DataOutput) error {
+func (lp *LikePredicate) WriteData(output serialization.DataOutput) error {
 	output.WriteUTF(lp.field)
 	output.WriteUTF(lp.expr)
 	return nil
@@ -242,7 +242,7 @@ func NewILikePredicate(field string, expr string) *ILikePredicate {
 	return &ILikePredicate{&LikePredicate{newPredicate(ILikePredicateId), field, expr}}
 }
 
-func (ilp *ILikePredicate) ReadData(input DataInput) error {
+func (ilp *ILikePredicate) ReadData(input serialization.DataInput) error {
 	var err error
 	ilp.LikePredicate = &LikePredicate{predicate: newPredicate(ILikePredicateId)}
 	ilp.field, err = input.ReadUTF()
@@ -263,7 +263,7 @@ func NewInPredicate(field string, values []interface{}) *InPredicate {
 	return &InPredicate{newPredicate(InPredicateId), field, values}
 }
 
-func (ip *InPredicate) ReadData(input DataInput) error {
+func (ip *InPredicate) ReadData(input serialization.DataInput) error {
 	var err error
 	ip.predicate = newPredicate(InPredicateId)
 	ip.field, err = input.ReadUTF()
@@ -284,7 +284,7 @@ func (ip *InPredicate) ReadData(input DataInput) error {
 	return nil
 }
 
-func (ip *InPredicate) WriteData(output DataOutput) error {
+func (ip *InPredicate) WriteData(output serialization.DataOutput) error {
 	output.WriteUTF(ip.field)
 	output.WriteInt32(int32(len(ip.values)))
 	for _, value := range ip.values {
@@ -305,14 +305,14 @@ func NewInstanceOfPredicate(className string) *InstanceOfPredicate {
 	return &InstanceOfPredicate{newPredicate(InstanceOfPredicateId), className}
 }
 
-func (iop *InstanceOfPredicate) ReadData(input DataInput) error {
+func (iop *InstanceOfPredicate) ReadData(input serialization.DataInput) error {
 	var err error
 	iop.predicate = newPredicate(InstanceOfPredicateId)
 	iop.className, err = input.ReadUTF()
 	return err
 }
 
-func (iop *InstanceOfPredicate) WriteData(output DataOutput) error {
+func (iop *InstanceOfPredicate) WriteData(output serialization.DataOutput) error {
 	output.WriteUTF(iop.className)
 	return nil
 }
@@ -325,7 +325,7 @@ func NewNotEqualPredicate(field string, value interface{}) *NotEqualPredicate {
 	return &NotEqualPredicate{&EqualPredicate{newPredicate(NotEqualPredicateId), field, value}}
 }
 
-func (nep *NotEqualPredicate) ReadData(input DataInput) error {
+func (nep *NotEqualPredicate) ReadData(input serialization.DataInput) error {
 	var err error
 	nep.EqualPredicate = &EqualPredicate{predicate: newPredicate(NotEqualPredicateId)}
 	nep.field, err = input.ReadUTF()
@@ -346,14 +346,14 @@ func NewNotPredicate(pred interface{}) *NotPredicate {
 	return &NotPredicate{newPredicate(NotPredicateId), pred}
 }
 
-func (np *NotPredicate) ReadData(input DataInput) error {
+func (np *NotPredicate) ReadData(input serialization.DataInput) error {
 	np.predicate = newPredicate(NotPredicateId)
 	i, err := input.ReadObject()
 	np.pred = i.(interface{})
 	return err
 }
 
-func (np *NotPredicate) WriteData(output DataOutput) error {
+func (np *NotPredicate) WriteData(output serialization.DataOutput) error {
 	return output.WriteObject(np.pred)
 }
 
@@ -366,7 +366,7 @@ func NewOrPredicate(predicates []interface{}) *OrPredicate {
 	return &OrPredicate{newPredicate(OrPredicateId), predicates}
 }
 
-func (or *OrPredicate) ReadData(input DataInput) error {
+func (or *OrPredicate) ReadData(input serialization.DataInput) error {
 	var err error
 	or.predicate = newPredicate(OrPredicateId)
 	length, err := input.ReadInt32()
@@ -384,7 +384,7 @@ func (or *OrPredicate) ReadData(input DataInput) error {
 	return err
 }
 
-func (or *OrPredicate) WriteData(output DataOutput) error {
+func (or *OrPredicate) WriteData(output serialization.DataOutput) error {
 	output.WriteInt32(int32(len(or.predicates)))
 	for _, pred := range or.predicates {
 		err := output.WriteObject(pred)
@@ -405,7 +405,7 @@ func NewRegexPredicate(field string, regex string) *RegexPredicate {
 	return &RegexPredicate{newPredicate(RegexPredicateId), field, regex}
 }
 
-func (rp *RegexPredicate) ReadData(input DataInput) error {
+func (rp *RegexPredicate) ReadData(input serialization.DataInput) error {
 	var err error
 	rp.predicate = newPredicate(RegexPredicateId)
 	rp.field, err = input.ReadUTF()
@@ -416,7 +416,7 @@ func (rp *RegexPredicate) ReadData(input DataInput) error {
 	return err
 }
 
-func (rp *RegexPredicate) WriteData(output DataOutput) error {
+func (rp *RegexPredicate) WriteData(output serialization.DataOutput) error {
 	output.WriteUTF(rp.field)
 	output.WriteUTF(rp.regex)
 	return nil
@@ -429,12 +429,12 @@ type FalsePredicate struct {
 func NewFalsePredicate() *FalsePredicate {
 	return &FalsePredicate{newPredicate(FalsePredicateId)}
 }
-func (fp *FalsePredicate) ReadData(input DataInput) error {
+func (fp *FalsePredicate) ReadData(input serialization.DataInput) error {
 	fp.predicate = newPredicate(FalsePredicateId)
 	return nil
 }
 
-func (fp *FalsePredicate) WriteData(output DataOutput) error {
+func (fp *FalsePredicate) WriteData(output serialization.DataOutput) error {
 	//Empty method
 	return nil
 }
@@ -446,12 +446,12 @@ type TruePredicate struct {
 func NewTruePredicate() *TruePredicate {
 	return &TruePredicate{newPredicate(TruePredicateId)}
 }
-func (tp *TruePredicate) ReadData(input DataInput) error {
+func (tp *TruePredicate) ReadData(input serialization.DataInput) error {
 	tp.predicate = newPredicate(TruePredicateId)
 	return nil
 }
 
-func (tp *TruePredicate) WriteData(output DataOutput) error {
+func (tp *TruePredicate) WriteData(output serialization.DataOutput) error {
 	//Empty method
 	return nil
 }

--- a/internal/protocol/client_addmembershiplistener.go
+++ b/internal/protocol/client_addmembershiplistener.go
@@ -15,13 +15,13 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
 func ClientAddMembershipListenerCalculateSize(localOnly bool) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += BoolSizeInBytes
+	dataSize += common.BoolSizeInBytes
 	return dataSize
 }
 
@@ -78,13 +78,13 @@ func ClientAddMembershipListenerHandle(clientMessage *ClientMessage,
 	handleEventMemberAttributeChange ClientAddMembershipListenerHandleEventMemberAttributeChangeFunc) {
 	// Event handler
 	messageType := clientMessage.MessageType()
-	if messageType == EventMember && handleEventMember != nil {
+	if messageType == common.EventMember && handleEventMember != nil {
 		handleEventMember(ClientAddMembershipListenerEventMemberDecode(clientMessage))
 	}
-	if messageType == EventMemberList && handleEventMemberList != nil {
+	if messageType == common.EventMemberList && handleEventMemberList != nil {
 		handleEventMemberList(ClientAddMembershipListenerEventMemberListDecode(clientMessage))
 	}
-	if messageType == EventMemberAttributeChange && handleEventMemberAttributeChange != nil {
+	if messageType == common.EventMemberAttributeChange && handleEventMemberAttributeChange != nil {
 		handleEventMemberAttributeChange(ClientAddMembershipListenerEventMemberAttributeChangeDecode(clientMessage))
 	}
 }

--- a/internal/protocol/client_authentication.go
+++ b/internal/protocol/client_authentication.go
@@ -15,7 +15,7 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
 func ClientAuthenticationCalculateSize(username *string, password *string, uuid *string, ownerUuid *string, isOwnerConnection bool, clientType *string, serializationVersion uint8, clientHazelcastVersion *string) int {
@@ -23,17 +23,17 @@ func ClientAuthenticationCalculateSize(username *string, password *string, uuid 
 	dataSize := 0
 	dataSize += StringCalculateSize(username)
 	dataSize += StringCalculateSize(password)
-	dataSize += BoolSizeInBytes
+	dataSize += common.BoolSizeInBytes
 	if uuid != nil {
 		dataSize += StringCalculateSize(uuid)
 	}
-	dataSize += BoolSizeInBytes
+	dataSize += common.BoolSizeInBytes
 	if ownerUuid != nil {
 		dataSize += StringCalculateSize(ownerUuid)
 	}
-	dataSize += BoolSizeInBytes
+	dataSize += common.BoolSizeInBytes
 	dataSize += StringCalculateSize(clientType)
-	dataSize += Uint8SizeInBytes
+	dataSize += common.Uint8SizeInBytes
 	dataSize += StringCalculateSize(clientHazelcastVersion)
 	return dataSize
 }

--- a/internal/protocol/consts.go
+++ b/internal/protocol/consts.go
@@ -15,27 +15,27 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
 const ClientType = "GOO"
 
-func DataCalculateSize(d *Data) int {
-	return len(d.Buffer()) + Int32SizeInBytes
+func DataCalculateSize(d *serialization.Data) int {
+	return len(d.Buffer()) + common.Int32SizeInBytes
 }
 
 func StringCalculateSize(str *string) int {
-	return len(*str) + Int32SizeInBytes
+	return len(*str) + common.Int32SizeInBytes
 }
 
 func Int64CalculateSize(v int64) int {
-	return Int64SizeInBytes
+	return common.Int64SizeInBytes
 }
 
 func AddressCalculateSize(a *Address) int {
 	dataSize := 0
 	dataSize += StringCalculateSize(&a.host)
-	dataSize += Int32SizeInBytes
+	dataSize += common.Int32SizeInBytes
 	return dataSize
 }

--- a/internal/protocol/core.go
+++ b/internal/protocol/core.go
@@ -18,8 +18,8 @@ import (
 	"bytes"
 	"fmt"
 	"github.com/hazelcast/hazelcast-go-client/core"
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 	"reflect"
 )
 
@@ -125,8 +125,8 @@ func (obj *DistributedObjectInfo) ServiceName() string {
 }
 
 type DataEntryView struct {
-	keyData                *Data
-	valueData              *Data
+	keyData                *serialization.Data
+	valueData              *serialization.Data
 	cost                   int64
 	creationTime           int64
 	expirationTime         int64
@@ -139,11 +139,11 @@ type DataEntryView struct {
 	ttl                    int64
 }
 
-func (ev1 *DataEntryView) KeyData() *Data {
+func (ev1 *DataEntryView) KeyData() *serialization.Data {
 	return ev1.keyData
 }
 
-func (ev1 *DataEntryView) ValueData() *Data {
+func (ev1 *DataEntryView) ValueData() *serialization.Data {
 	return ev1.valueData
 }
 
@@ -472,28 +472,28 @@ type MemberRemovedListener interface {
 func GetEntryListenerFlags(listener interface{}) int32 {
 	flags := int32(0)
 	if _, ok := listener.(EntryAddedListener); ok {
-		flags |= EntryEventAdded
+		flags |= common.EntryEventAdded
 	}
 	if _, ok := listener.(EntryRemovedListener); ok {
-		flags |= EntryEventRemoved
+		flags |= common.EntryEventRemoved
 	}
 	if _, ok := listener.(EntryUpdatedListener); ok {
-		flags |= EntryEventUpdated
+		flags |= common.EntryEventUpdated
 	}
 	if _, ok := listener.(EntryEvictedListener); ok {
-		flags |= EntryEventEvicted
+		flags |= common.EntryEventEvicted
 	}
 	if _, ok := listener.(EntryEvictAllListener); ok {
-		flags |= EntryEventEvictAll
+		flags |= common.EntryEventEvictAll
 	}
 	if _, ok := listener.(EntryClearAllListener); ok {
-		flags |= EntryEventClearAll
+		flags |= common.EntryEventClearAll
 	}
 	if _, ok := listener.(EntryExpiredListener); ok {
-		flags |= EntryEventExpired
+		flags |= common.EntryEventExpired
 	}
 	if _, ok := listener.(EntryMergedListener); ok {
-		flags |= EntryEventMerged
+		flags |= common.EntryEventMerged
 	}
 	return flags
 }

--- a/internal/protocol/custom_codec_test.go
+++ b/internal/protocol/custom_codec_test.go
@@ -15,8 +15,8 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 	"testing"
 )
 
@@ -70,8 +70,8 @@ func TestDataEntryViewCodecEncodeDecode(t *testing.T) {
 	key := "test-key"
 	value := "test-value"
 	entryView := DataEntryView{}
-	entryView.keyData = &Data{[]byte(key)}
-	entryView.valueData = &Data{[]byte(value)}
+	entryView.keyData = &serialization.Data{[]byte(key)}
+	entryView.valueData = &serialization.Data{[]byte(value)}
 	entryView.cost = 123123
 	entryView.creationTime = 1212
 	entryView.expirationTime = 12
@@ -119,7 +119,7 @@ func DataEntryViewCalculateSize(ev *DataEntryView) int {
 	dataSize := 0
 	dataSize += DataCalculateSize(ev.keyData)
 	dataSize += DataCalculateSize(ev.valueData)
-	dataSize += 10 * Int64SizeInBytes
+	dataSize += 10 * common.Int64SizeInBytes
 	return dataSize
 }
 
@@ -140,8 +140,8 @@ func MemberCalculateSize(member *Member) int {
 	dataSize := 0
 	dataSize += AddressCalculateSize(&member.address)
 	dataSize += StringCalculateSize(&member.uuid)
-	dataSize += BoolSizeInBytes
-	dataSize += Int32SizeInBytes //Size of the map(attributes)
+	dataSize += common.BoolSizeInBytes
+	dataSize += common.Int32SizeInBytes //Size of the map(attributes)
 	for key, value := range member.attributes {
 		dataSize += StringCalculateSize(&key)
 		dataSize += StringCalculateSize(&value)

--- a/internal/protocol/flakeidgenerator_newidbatch.go
+++ b/internal/protocol/flakeidgenerator_newidbatch.go
@@ -15,14 +15,14 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
 func FlakeIdGeneratorNewIdBatchCalculateSize(name *string, batchSize int32) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
-	dataSize += Int32SizeInBytes
+	dataSize += common.Int32SizeInBytes
 	return dataSize
 }
 

--- a/internal/protocol/list_add.go
+++ b/internal/protocol/list_add.go
@@ -15,10 +15,10 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
-func ListAddCalculateSize(name *string, value *Data) int {
+func ListAddCalculateSize(name *string, value *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
@@ -26,7 +26,7 @@ func ListAddCalculateSize(name *string, value *Data) int {
 	return dataSize
 }
 
-func ListAddEncodeRequest(name *string, value *Data) *ClientMessage {
+func ListAddEncodeRequest(name *string, value *serialization.Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ListAddCalculateSize(name, value))
 	clientMessage.SetMessageType(listAdd)

--- a/internal/protocol/list_addall.go
+++ b/internal/protocol/list_addall.go
@@ -15,23 +15,23 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func ListAddAllCalculateSize(name *string, valueList []*Data) int {
+func ListAddAllCalculateSize(name *string, valueList []*serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
-	dataSize += Int32SizeInBytes
+	dataSize += common.Int32SizeInBytes
 	for _, valueListItem := range valueList {
 		dataSize += DataCalculateSize(valueListItem)
 	}
 	return dataSize
 }
 
-func ListAddAllEncodeRequest(name *string, valueList []*Data) *ClientMessage {
+func ListAddAllEncodeRequest(name *string, valueList []*serialization.Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ListAddAllCalculateSize(name, valueList))
 	clientMessage.SetMessageType(listAddAll)

--- a/internal/protocol/list_addallwithindex.go
+++ b/internal/protocol/list_addallwithindex.go
@@ -15,24 +15,24 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func ListAddAllWithIndexCalculateSize(name *string, index int32, valueList []*Data) int {
+func ListAddAllWithIndexCalculateSize(name *string, index int32, valueList []*serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
-	dataSize += Int32SizeInBytes
-	dataSize += Int32SizeInBytes
+	dataSize += common.Int32SizeInBytes
+	dataSize += common.Int32SizeInBytes
 	for _, valueListItem := range valueList {
 		dataSize += DataCalculateSize(valueListItem)
 	}
 	return dataSize
 }
 
-func ListAddAllWithIndexEncodeRequest(name *string, index int32, valueList []*Data) *ClientMessage {
+func ListAddAllWithIndexEncodeRequest(name *string, index int32, valueList []*serialization.Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ListAddAllWithIndexCalculateSize(name, index, valueList))
 	clientMessage.SetMessageType(listAddAllWithIndex)

--- a/internal/protocol/list_addlistener.go
+++ b/internal/protocol/list_addlistener.go
@@ -15,17 +15,17 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
 func ListAddListenerCalculateSize(name *string, includeValue bool, localOnly bool) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
-	dataSize += BoolSizeInBytes
-	dataSize += BoolSizeInBytes
+	dataSize += common.BoolSizeInBytes
+	dataSize += common.BoolSizeInBytes
 	return dataSize
 }
 
@@ -49,9 +49,9 @@ func ListAddListenerDecodeResponse(clientMessage *ClientMessage) func() (respons
 	}
 }
 
-type ListAddListenerHandleEventItemFunc func(*Data, *string, int32)
+type ListAddListenerHandleEventItemFunc func(*serialization.Data, *string, int32)
 
-func ListAddListenerEventItemDecode(clientMessage *ClientMessage) (item *Data, uuid *string, eventType int32) {
+func ListAddListenerEventItemDecode(clientMessage *ClientMessage) (item *serialization.Data, uuid *string, eventType int32) {
 
 	if !clientMessage.ReadBool() {
 		item = clientMessage.ReadData()
@@ -65,7 +65,7 @@ func ListAddListenerHandle(clientMessage *ClientMessage,
 	handleEventItem ListAddListenerHandleEventItemFunc) {
 	// Event handler
 	messageType := clientMessage.MessageType()
-	if messageType == EventItem && handleEventItem != nil {
+	if messageType == common.EventItem && handleEventItem != nil {
 		handleEventItem(ListAddListenerEventItemDecode(clientMessage))
 	}
 }

--- a/internal/protocol/list_addwithindex.go
+++ b/internal/protocol/list_addwithindex.go
@@ -15,21 +15,21 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func ListAddWithIndexCalculateSize(name *string, index int32, value *Data) int {
+func ListAddWithIndexCalculateSize(name *string, index int32, value *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
-	dataSize += Int32SizeInBytes
+	dataSize += common.Int32SizeInBytes
 	dataSize += DataCalculateSize(value)
 	return dataSize
 }
 
-func ListAddWithIndexEncodeRequest(name *string, index int32, value *Data) *ClientMessage {
+func ListAddWithIndexEncodeRequest(name *string, index int32, value *serialization.Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ListAddWithIndexCalculateSize(name, index, value))
 	clientMessage.SetMessageType(listAddWithIndex)

--- a/internal/protocol/list_compareandremoveall.go
+++ b/internal/protocol/list_compareandremoveall.go
@@ -15,23 +15,23 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func ListCompareAndRemoveAllCalculateSize(name *string, values []*Data) int {
+func ListCompareAndRemoveAllCalculateSize(name *string, values []*serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
-	dataSize += Int32SizeInBytes
+	dataSize += common.Int32SizeInBytes
 	for _, valuesItem := range values {
 		dataSize += DataCalculateSize(valuesItem)
 	}
 	return dataSize
 }
 
-func ListCompareAndRemoveAllEncodeRequest(name *string, values []*Data) *ClientMessage {
+func ListCompareAndRemoveAllEncodeRequest(name *string, values []*serialization.Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ListCompareAndRemoveAllCalculateSize(name, values))
 	clientMessage.SetMessageType(listCompareAndRemoveAll)

--- a/internal/protocol/list_compareandretainall.go
+++ b/internal/protocol/list_compareandretainall.go
@@ -15,23 +15,23 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func ListCompareAndRetainAllCalculateSize(name *string, values []*Data) int {
+func ListCompareAndRetainAllCalculateSize(name *string, values []*serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
-	dataSize += Int32SizeInBytes
+	dataSize += common.Int32SizeInBytes
 	for _, valuesItem := range values {
 		dataSize += DataCalculateSize(valuesItem)
 	}
 	return dataSize
 }
 
-func ListCompareAndRetainAllEncodeRequest(name *string, values []*Data) *ClientMessage {
+func ListCompareAndRetainAllEncodeRequest(name *string, values []*serialization.Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ListCompareAndRetainAllCalculateSize(name, values))
 	clientMessage.SetMessageType(listCompareAndRetainAll)

--- a/internal/protocol/list_contains.go
+++ b/internal/protocol/list_contains.go
@@ -15,10 +15,10 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
-func ListContainsCalculateSize(name *string, value *Data) int {
+func ListContainsCalculateSize(name *string, value *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
@@ -26,7 +26,7 @@ func ListContainsCalculateSize(name *string, value *Data) int {
 	return dataSize
 }
 
-func ListContainsEncodeRequest(name *string, value *Data) *ClientMessage {
+func ListContainsEncodeRequest(name *string, value *serialization.Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ListContainsCalculateSize(name, value))
 	clientMessage.SetMessageType(listContains)

--- a/internal/protocol/list_containsall.go
+++ b/internal/protocol/list_containsall.go
@@ -15,23 +15,23 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func ListContainsAllCalculateSize(name *string, values []*Data) int {
+func ListContainsAllCalculateSize(name *string, values []*serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
-	dataSize += Int32SizeInBytes
+	dataSize += common.Int32SizeInBytes
 	for _, valuesItem := range values {
 		dataSize += DataCalculateSize(valuesItem)
 	}
 	return dataSize
 }
 
-func ListContainsAllEncodeRequest(name *string, values []*Data) *ClientMessage {
+func ListContainsAllEncodeRequest(name *string, values []*serialization.Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ListContainsAllCalculateSize(name, values))
 	clientMessage.SetMessageType(listContainsAll)

--- a/internal/protocol/list_get.go
+++ b/internal/protocol/list_get.go
@@ -15,15 +15,15 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
 func ListGetCalculateSize(name *string, index int32) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
-	dataSize += Int32SizeInBytes
+	dataSize += common.Int32SizeInBytes
 	return dataSize
 }
 
@@ -38,9 +38,9 @@ func ListGetEncodeRequest(name *string, index int32) *ClientMessage {
 	return clientMessage
 }
 
-func ListGetDecodeResponse(clientMessage *ClientMessage) func() (response *Data) {
+func ListGetDecodeResponse(clientMessage *ClientMessage) func() (response *serialization.Data) {
 	// Decode response from client message
-	return func() (response *Data) {
+	return func() (response *serialization.Data) {
 
 		if !clientMessage.ReadBool() {
 			response = clientMessage.ReadData()

--- a/internal/protocol/list_getall.go
+++ b/internal/protocol/list_getall.go
@@ -15,7 +15,7 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
 func ListGetAllCalculateSize(name *string) int {
@@ -35,11 +35,11 @@ func ListGetAllEncodeRequest(name *string) *ClientMessage {
 	return clientMessage
 }
 
-func ListGetAllDecodeResponse(clientMessage *ClientMessage) func() (response []*Data) {
+func ListGetAllDecodeResponse(clientMessage *ClientMessage) func() (response []*serialization.Data) {
 	// Decode response from client message
-	return func() (response []*Data) {
+	return func() (response []*serialization.Data) {
 		responseSize := clientMessage.ReadInt32()
-		response = make([]*Data, responseSize)
+		response = make([]*serialization.Data, responseSize)
 		for responseIndex := 0; responseIndex < int(responseSize); responseIndex++ {
 			responseItem := clientMessage.ReadData()
 			response[responseIndex] = responseItem

--- a/internal/protocol/list_indexof.go
+++ b/internal/protocol/list_indexof.go
@@ -15,10 +15,10 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
-func ListIndexOfCalculateSize(name *string, value *Data) int {
+func ListIndexOfCalculateSize(name *string, value *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
@@ -26,7 +26,7 @@ func ListIndexOfCalculateSize(name *string, value *Data) int {
 	return dataSize
 }
 
-func ListIndexOfEncodeRequest(name *string, value *Data) *ClientMessage {
+func ListIndexOfEncodeRequest(name *string, value *serialization.Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ListIndexOfCalculateSize(name, value))
 	clientMessage.SetMessageType(listIndexOf)

--- a/internal/protocol/list_lastindexof.go
+++ b/internal/protocol/list_lastindexof.go
@@ -15,10 +15,10 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
-func ListLastIndexOfCalculateSize(name *string, value *Data) int {
+func ListLastIndexOfCalculateSize(name *string, value *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
@@ -26,7 +26,7 @@ func ListLastIndexOfCalculateSize(name *string, value *Data) int {
 	return dataSize
 }
 
-func ListLastIndexOfEncodeRequest(name *string, value *Data) *ClientMessage {
+func ListLastIndexOfEncodeRequest(name *string, value *serialization.Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ListLastIndexOfCalculateSize(name, value))
 	clientMessage.SetMessageType(listLastIndexOf)

--- a/internal/protocol/list_remove.go
+++ b/internal/protocol/list_remove.go
@@ -15,10 +15,10 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
-func ListRemoveCalculateSize(name *string, value *Data) int {
+func ListRemoveCalculateSize(name *string, value *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
@@ -26,7 +26,7 @@ func ListRemoveCalculateSize(name *string, value *Data) int {
 	return dataSize
 }
 
-func ListRemoveEncodeRequest(name *string, value *Data) *ClientMessage {
+func ListRemoveEncodeRequest(name *string, value *serialization.Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ListRemoveCalculateSize(name, value))
 	clientMessage.SetMessageType(listRemove)

--- a/internal/protocol/list_removewithindex.go
+++ b/internal/protocol/list_removewithindex.go
@@ -15,15 +15,15 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
 func ListRemoveWithIndexCalculateSize(name *string, index int32) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
-	dataSize += Int32SizeInBytes
+	dataSize += common.Int32SizeInBytes
 	return dataSize
 }
 
@@ -38,9 +38,9 @@ func ListRemoveWithIndexEncodeRequest(name *string, index int32) *ClientMessage 
 	return clientMessage
 }
 
-func ListRemoveWithIndexDecodeResponse(clientMessage *ClientMessage) func() (response *Data) {
+func ListRemoveWithIndexDecodeResponse(clientMessage *ClientMessage) func() (response *serialization.Data) {
 	// Decode response from client message
-	return func() (response *Data) {
+	return func() (response *serialization.Data) {
 
 		if !clientMessage.ReadBool() {
 			response = clientMessage.ReadData()

--- a/internal/protocol/list_set.go
+++ b/internal/protocol/list_set.go
@@ -15,21 +15,21 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func ListSetCalculateSize(name *string, index int32, value *Data) int {
+func ListSetCalculateSize(name *string, index int32, value *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
-	dataSize += Int32SizeInBytes
+	dataSize += common.Int32SizeInBytes
 	dataSize += DataCalculateSize(value)
 	return dataSize
 }
 
-func ListSetEncodeRequest(name *string, index int32, value *Data) *ClientMessage {
+func ListSetEncodeRequest(name *string, index int32, value *serialization.Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ListSetCalculateSize(name, index, value))
 	clientMessage.SetMessageType(listSet)
@@ -41,9 +41,9 @@ func ListSetEncodeRequest(name *string, index int32, value *Data) *ClientMessage
 	return clientMessage
 }
 
-func ListSetDecodeResponse(clientMessage *ClientMessage) func() (response *Data) {
+func ListSetDecodeResponse(clientMessage *ClientMessage) func() (response *serialization.Data) {
 	// Decode response from client message
-	return func() (response *Data) {
+	return func() (response *serialization.Data) {
 
 		if !clientMessage.ReadBool() {
 			response = clientMessage.ReadData()

--- a/internal/protocol/list_sub.go
+++ b/internal/protocol/list_sub.go
@@ -15,16 +15,16 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
 func ListSubCalculateSize(name *string, from int32, to int32) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
-	dataSize += Int32SizeInBytes
-	dataSize += Int32SizeInBytes
+	dataSize += common.Int32SizeInBytes
+	dataSize += common.Int32SizeInBytes
 	return dataSize
 }
 
@@ -40,11 +40,11 @@ func ListSubEncodeRequest(name *string, from int32, to int32) *ClientMessage {
 	return clientMessage
 }
 
-func ListSubDecodeResponse(clientMessage *ClientMessage) func() (response []*Data) {
+func ListSubDecodeResponse(clientMessage *ClientMessage) func() (response []*serialization.Data) {
 	// Decode response from client message
-	return func() (response []*Data) {
+	return func() (response []*serialization.Data) {
 		responseSize := clientMessage.ReadInt32()
-		response = make([]*Data, responseSize)
+		response = make([]*serialization.Data, responseSize)
 		for responseIndex := 0; responseIndex < int(responseSize); responseIndex++ {
 			responseItem := clientMessage.ReadData()
 			response[responseIndex] = responseItem

--- a/internal/protocol/map_addentrylistener.go
+++ b/internal/protocol/map_addentrylistener.go
@@ -15,18 +15,18 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
 func MapAddEntryListenerCalculateSize(name *string, includeValue bool, listenerFlags int32, localOnly bool) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
-	dataSize += BoolSizeInBytes
-	dataSize += Int32SizeInBytes
-	dataSize += BoolSizeInBytes
+	dataSize += common.BoolSizeInBytes
+	dataSize += common.Int32SizeInBytes
+	dataSize += common.BoolSizeInBytes
 	return dataSize
 }
 
@@ -51,9 +51,9 @@ func MapAddEntryListenerDecodeResponse(clientMessage *ClientMessage) func() (res
 	}
 }
 
-type MapAddEntryListenerHandleEventEntryFunc func(*Data, *Data, *Data, *Data, int32, *string, int32)
+type MapAddEntryListenerHandleEventEntryFunc func(*serialization.Data, *serialization.Data, *serialization.Data, *serialization.Data, int32, *string, int32)
 
-func MapAddEntryListenerEventEntryDecode(clientMessage *ClientMessage) (key *Data, value *Data, oldValue *Data, mergingValue *Data, eventType int32, uuid *string, numberOfAffectedEntries int32) {
+func MapAddEntryListenerEventEntryDecode(clientMessage *ClientMessage) (key *serialization.Data, value *serialization.Data, oldValue *serialization.Data, mergingValue *serialization.Data, eventType int32, uuid *string, numberOfAffectedEntries int32) {
 
 	if !clientMessage.ReadBool() {
 		key = clientMessage.ReadData()
@@ -80,7 +80,7 @@ func MapAddEntryListenerHandle(clientMessage *ClientMessage,
 	handleEventEntry MapAddEntryListenerHandleEventEntryFunc) {
 	// Event handler
 	messageType := clientMessage.MessageType()
-	if messageType == EventEntry && handleEventEntry != nil {
+	if messageType == common.EventEntry && handleEventEntry != nil {
 		handleEventEntry(MapAddEntryListenerEventEntryDecode(clientMessage))
 	}
 }

--- a/internal/protocol/map_addentrylistenertokey.go
+++ b/internal/protocol/map_addentrylistenertokey.go
@@ -15,23 +15,23 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func MapAddEntryListenerToKeyCalculateSize(name *string, key *Data, includeValue bool, listenerFlags int32, localOnly bool) int {
+func MapAddEntryListenerToKeyCalculateSize(name *string, key *serialization.Data, includeValue bool, listenerFlags int32, localOnly bool) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
 	dataSize += DataCalculateSize(key)
-	dataSize += BoolSizeInBytes
-	dataSize += Int32SizeInBytes
-	dataSize += BoolSizeInBytes
+	dataSize += common.BoolSizeInBytes
+	dataSize += common.Int32SizeInBytes
+	dataSize += common.BoolSizeInBytes
 	return dataSize
 }
 
-func MapAddEntryListenerToKeyEncodeRequest(name *string, key *Data, includeValue bool, listenerFlags int32, localOnly bool) *ClientMessage {
+func MapAddEntryListenerToKeyEncodeRequest(name *string, key *serialization.Data, includeValue bool, listenerFlags int32, localOnly bool) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapAddEntryListenerToKeyCalculateSize(name, key, includeValue, listenerFlags, localOnly))
 	clientMessage.SetMessageType(mapAddEntryListenerToKey)
@@ -53,9 +53,9 @@ func MapAddEntryListenerToKeyDecodeResponse(clientMessage *ClientMessage) func()
 	}
 }
 
-type MapAddEntryListenerToKeyHandleEventEntryFunc func(*Data, *Data, *Data, *Data, int32, *string, int32)
+type MapAddEntryListenerToKeyHandleEventEntryFunc func(*serialization.Data, *serialization.Data, *serialization.Data, *serialization.Data, int32, *string, int32)
 
-func MapAddEntryListenerToKeyEventEntryDecode(clientMessage *ClientMessage) (key *Data, value *Data, oldValue *Data, mergingValue *Data, eventType int32, uuid *string, numberOfAffectedEntries int32) {
+func MapAddEntryListenerToKeyEventEntryDecode(clientMessage *ClientMessage) (key *serialization.Data, value *serialization.Data, oldValue *serialization.Data, mergingValue *serialization.Data, eventType int32, uuid *string, numberOfAffectedEntries int32) {
 
 	if !clientMessage.ReadBool() {
 		key = clientMessage.ReadData()
@@ -82,7 +82,7 @@ func MapAddEntryListenerToKeyHandle(clientMessage *ClientMessage,
 	handleEventEntry MapAddEntryListenerToKeyHandleEventEntryFunc) {
 	// Event handler
 	messageType := clientMessage.MessageType()
-	if messageType == EventEntry && handleEventEntry != nil {
+	if messageType == common.EventEntry && handleEventEntry != nil {
 		handleEventEntry(MapAddEntryListenerToKeyEventEntryDecode(clientMessage))
 	}
 }

--- a/internal/protocol/map_addentrylistenertokeywithpredicate.go
+++ b/internal/protocol/map_addentrylistenertokeywithpredicate.go
@@ -15,24 +15,24 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func MapAddEntryListenerToKeyWithPredicateCalculateSize(name *string, key *Data, predicate *Data, includeValue bool, listenerFlags int32, localOnly bool) int {
+func MapAddEntryListenerToKeyWithPredicateCalculateSize(name *string, key *serialization.Data, predicate *serialization.Data, includeValue bool, listenerFlags int32, localOnly bool) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
 	dataSize += DataCalculateSize(key)
 	dataSize += DataCalculateSize(predicate)
-	dataSize += BoolSizeInBytes
-	dataSize += Int32SizeInBytes
-	dataSize += BoolSizeInBytes
+	dataSize += common.BoolSizeInBytes
+	dataSize += common.Int32SizeInBytes
+	dataSize += common.BoolSizeInBytes
 	return dataSize
 }
 
-func MapAddEntryListenerToKeyWithPredicateEncodeRequest(name *string, key *Data, predicate *Data, includeValue bool, listenerFlags int32, localOnly bool) *ClientMessage {
+func MapAddEntryListenerToKeyWithPredicateEncodeRequest(name *string, key *serialization.Data, predicate *serialization.Data, includeValue bool, listenerFlags int32, localOnly bool) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapAddEntryListenerToKeyWithPredicateCalculateSize(name, key, predicate, includeValue, listenerFlags, localOnly))
 	clientMessage.SetMessageType(mapAddEntryListenerToKeyWithPredicate)
@@ -55,9 +55,9 @@ func MapAddEntryListenerToKeyWithPredicateDecodeResponse(clientMessage *ClientMe
 	}
 }
 
-type MapAddEntryListenerToKeyWithPredicateHandleEventEntryFunc func(*Data, *Data, *Data, *Data, int32, *string, int32)
+type MapAddEntryListenerToKeyWithPredicateHandleEventEntryFunc func(*serialization.Data, *serialization.Data, *serialization.Data, *serialization.Data, int32, *string, int32)
 
-func MapAddEntryListenerToKeyWithPredicateEventEntryDecode(clientMessage *ClientMessage) (key *Data, value *Data, oldValue *Data, mergingValue *Data, eventType int32, uuid *string, numberOfAffectedEntries int32) {
+func MapAddEntryListenerToKeyWithPredicateEventEntryDecode(clientMessage *ClientMessage) (key *serialization.Data, value *serialization.Data, oldValue *serialization.Data, mergingValue *serialization.Data, eventType int32, uuid *string, numberOfAffectedEntries int32) {
 
 	if !clientMessage.ReadBool() {
 		key = clientMessage.ReadData()
@@ -84,7 +84,7 @@ func MapAddEntryListenerToKeyWithPredicateHandle(clientMessage *ClientMessage,
 	handleEventEntry MapAddEntryListenerToKeyWithPredicateHandleEventEntryFunc) {
 	// Event handler
 	messageType := clientMessage.MessageType()
-	if messageType == EventEntry && handleEventEntry != nil {
+	if messageType == common.EventEntry && handleEventEntry != nil {
 		handleEventEntry(MapAddEntryListenerToKeyWithPredicateEventEntryDecode(clientMessage))
 	}
 }

--- a/internal/protocol/map_addentrylistenerwithpredicate.go
+++ b/internal/protocol/map_addentrylistenerwithpredicate.go
@@ -15,23 +15,23 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func MapAddEntryListenerWithPredicateCalculateSize(name *string, predicate *Data, includeValue bool, listenerFlags int32, localOnly bool) int {
+func MapAddEntryListenerWithPredicateCalculateSize(name *string, predicate *serialization.Data, includeValue bool, listenerFlags int32, localOnly bool) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
 	dataSize += DataCalculateSize(predicate)
-	dataSize += BoolSizeInBytes
-	dataSize += Int32SizeInBytes
-	dataSize += BoolSizeInBytes
+	dataSize += common.BoolSizeInBytes
+	dataSize += common.Int32SizeInBytes
+	dataSize += common.BoolSizeInBytes
 	return dataSize
 }
 
-func MapAddEntryListenerWithPredicateEncodeRequest(name *string, predicate *Data, includeValue bool, listenerFlags int32, localOnly bool) *ClientMessage {
+func MapAddEntryListenerWithPredicateEncodeRequest(name *string, predicate *serialization.Data, includeValue bool, listenerFlags int32, localOnly bool) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapAddEntryListenerWithPredicateCalculateSize(name, predicate, includeValue, listenerFlags, localOnly))
 	clientMessage.SetMessageType(mapAddEntryListenerWithPredicate)
@@ -53,9 +53,9 @@ func MapAddEntryListenerWithPredicateDecodeResponse(clientMessage *ClientMessage
 	}
 }
 
-type MapAddEntryListenerWithPredicateHandleEventEntryFunc func(*Data, *Data, *Data, *Data, int32, *string, int32)
+type MapAddEntryListenerWithPredicateHandleEventEntryFunc func(*serialization.Data, *serialization.Data, *serialization.Data, *serialization.Data, int32, *string, int32)
 
-func MapAddEntryListenerWithPredicateEventEntryDecode(clientMessage *ClientMessage) (key *Data, value *Data, oldValue *Data, mergingValue *Data, eventType int32, uuid *string, numberOfAffectedEntries int32) {
+func MapAddEntryListenerWithPredicateEventEntryDecode(clientMessage *ClientMessage) (key *serialization.Data, value *serialization.Data, oldValue *serialization.Data, mergingValue *serialization.Data, eventType int32, uuid *string, numberOfAffectedEntries int32) {
 
 	if !clientMessage.ReadBool() {
 		key = clientMessage.ReadData()
@@ -82,7 +82,7 @@ func MapAddEntryListenerWithPredicateHandle(clientMessage *ClientMessage,
 	handleEventEntry MapAddEntryListenerWithPredicateHandleEventEntryFunc) {
 	// Event handler
 	messageType := clientMessage.MessageType()
-	if messageType == EventEntry && handleEventEntry != nil {
+	if messageType == common.EventEntry && handleEventEntry != nil {
 		handleEventEntry(MapAddEntryListenerWithPredicateEventEntryDecode(clientMessage))
 	}
 }

--- a/internal/protocol/map_addindex.go
+++ b/internal/protocol/map_addindex.go
@@ -15,7 +15,7 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
 func MapAddIndexCalculateSize(name *string, attribute *string, ordered bool) int {
@@ -23,7 +23,7 @@ func MapAddIndexCalculateSize(name *string, attribute *string, ordered bool) int
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
 	dataSize += StringCalculateSize(attribute)
-	dataSize += BoolSizeInBytes
+	dataSize += common.BoolSizeInBytes
 	return dataSize
 }
 

--- a/internal/protocol/map_containskey.go
+++ b/internal/protocol/map_containskey.go
@@ -15,21 +15,21 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func MapContainsKeyCalculateSize(name *string, key *Data, threadId int64) int {
+func MapContainsKeyCalculateSize(name *string, key *serialization.Data, threadId int64) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
 	dataSize += DataCalculateSize(key)
-	dataSize += Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
 	return dataSize
 }
 
-func MapContainsKeyEncodeRequest(name *string, key *Data, threadId int64) *ClientMessage {
+func MapContainsKeyEncodeRequest(name *string, key *serialization.Data, threadId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapContainsKeyCalculateSize(name, key, threadId))
 	clientMessage.SetMessageType(mapContainsKey)

--- a/internal/protocol/map_containsvalue.go
+++ b/internal/protocol/map_containsvalue.go
@@ -15,10 +15,10 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
-func MapContainsValueCalculateSize(name *string, value *Data) int {
+func MapContainsValueCalculateSize(name *string, value *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
@@ -26,7 +26,7 @@ func MapContainsValueCalculateSize(name *string, value *Data) int {
 	return dataSize
 }
 
-func MapContainsValueEncodeRequest(name *string, value *Data) *ClientMessage {
+func MapContainsValueEncodeRequest(name *string, value *serialization.Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapContainsValueCalculateSize(name, value))
 	clientMessage.SetMessageType(mapContainsValue)

--- a/internal/protocol/map_delete.go
+++ b/internal/protocol/map_delete.go
@@ -15,21 +15,21 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func MapDeleteCalculateSize(name *string, key *Data, threadId int64) int {
+func MapDeleteCalculateSize(name *string, key *serialization.Data, threadId int64) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
 	dataSize += DataCalculateSize(key)
-	dataSize += Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
 	return dataSize
 }
 
-func MapDeleteEncodeRequest(name *string, key *Data, threadId int64) *ClientMessage {
+func MapDeleteEncodeRequest(name *string, key *serialization.Data, threadId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapDeleteCalculateSize(name, key, threadId))
 	clientMessage.SetMessageType(mapDelete)

--- a/internal/protocol/map_entrieswithpredicate.go
+++ b/internal/protocol/map_entrieswithpredicate.go
@@ -15,10 +15,10 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
-func MapEntriesWithPredicateCalculateSize(name *string, predicate *Data) int {
+func MapEntriesWithPredicateCalculateSize(name *string, predicate *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
@@ -26,7 +26,7 @@ func MapEntriesWithPredicateCalculateSize(name *string, predicate *Data) int {
 	return dataSize
 }
 
-func MapEntriesWithPredicateEncodeRequest(name *string, predicate *Data) *ClientMessage {
+func MapEntriesWithPredicateEncodeRequest(name *string, predicate *serialization.Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapEntriesWithPredicateCalculateSize(name, predicate))
 	clientMessage.SetMessageType(mapEntriesWithPredicate)

--- a/internal/protocol/map_evict.go
+++ b/internal/protocol/map_evict.go
@@ -15,21 +15,21 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func MapEvictCalculateSize(name *string, key *Data, threadId int64) int {
+func MapEvictCalculateSize(name *string, key *serialization.Data, threadId int64) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
 	dataSize += DataCalculateSize(key)
-	dataSize += Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
 	return dataSize
 }
 
-func MapEvictEncodeRequest(name *string, key *Data, threadId int64) *ClientMessage {
+func MapEvictEncodeRequest(name *string, key *serialization.Data, threadId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapEvictCalculateSize(name, key, threadId))
 	clientMessage.SetMessageType(mapEvict)

--- a/internal/protocol/map_executeonallkeys.go
+++ b/internal/protocol/map_executeonallkeys.go
@@ -15,10 +15,10 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
-func MapExecuteOnAllKeysCalculateSize(name *string, entryProcessor *Data) int {
+func MapExecuteOnAllKeysCalculateSize(name *string, entryProcessor *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
@@ -26,7 +26,7 @@ func MapExecuteOnAllKeysCalculateSize(name *string, entryProcessor *Data) int {
 	return dataSize
 }
 
-func MapExecuteOnAllKeysEncodeRequest(name *string, entryProcessor *Data) *ClientMessage {
+func MapExecuteOnAllKeysEncodeRequest(name *string, entryProcessor *serialization.Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapExecuteOnAllKeysCalculateSize(name, entryProcessor))
 	clientMessage.SetMessageType(mapExecuteOnAllKeys)

--- a/internal/protocol/map_executeonkey.go
+++ b/internal/protocol/map_executeonkey.go
@@ -15,22 +15,22 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func MapExecuteOnKeyCalculateSize(name *string, entryProcessor *Data, key *Data, threadId int64) int {
+func MapExecuteOnKeyCalculateSize(name *string, entryProcessor *serialization.Data, key *serialization.Data, threadId int64) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
 	dataSize += DataCalculateSize(entryProcessor)
 	dataSize += DataCalculateSize(key)
-	dataSize += Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
 	return dataSize
 }
 
-func MapExecuteOnKeyEncodeRequest(name *string, entryProcessor *Data, key *Data, threadId int64) *ClientMessage {
+func MapExecuteOnKeyEncodeRequest(name *string, entryProcessor *serialization.Data, key *serialization.Data, threadId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapExecuteOnKeyCalculateSize(name, entryProcessor, key, threadId))
 	clientMessage.SetMessageType(mapExecuteOnKey)
@@ -43,9 +43,9 @@ func MapExecuteOnKeyEncodeRequest(name *string, entryProcessor *Data, key *Data,
 	return clientMessage
 }
 
-func MapExecuteOnKeyDecodeResponse(clientMessage *ClientMessage) func() (response *Data) {
+func MapExecuteOnKeyDecodeResponse(clientMessage *ClientMessage) func() (response *serialization.Data) {
 	// Decode response from client message
-	return func() (response *Data) {
+	return func() (response *serialization.Data) {
 
 		if !clientMessage.ReadBool() {
 			response = clientMessage.ReadData()

--- a/internal/protocol/map_executeonkeys.go
+++ b/internal/protocol/map_executeonkeys.go
@@ -15,24 +15,24 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func MapExecuteOnKeysCalculateSize(name *string, entryProcessor *Data, keys []*Data) int {
+func MapExecuteOnKeysCalculateSize(name *string, entryProcessor *serialization.Data, keys []*serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
 	dataSize += DataCalculateSize(entryProcessor)
-	dataSize += Int32SizeInBytes
+	dataSize += common.Int32SizeInBytes
 	for _, keysItem := range keys {
 		dataSize += DataCalculateSize(keysItem)
 	}
 	return dataSize
 }
 
-func MapExecuteOnKeysEncodeRequest(name *string, entryProcessor *Data, keys []*Data) *ClientMessage {
+func MapExecuteOnKeysEncodeRequest(name *string, entryProcessor *serialization.Data, keys []*serialization.Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapExecuteOnKeysCalculateSize(name, entryProcessor, keys))
 	clientMessage.SetMessageType(mapExecuteOnKeys)

--- a/internal/protocol/map_executewithpredicate.go
+++ b/internal/protocol/map_executewithpredicate.go
@@ -15,10 +15,10 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
-func MapExecuteWithPredicateCalculateSize(name *string, entryProcessor *Data, predicate *Data) int {
+func MapExecuteWithPredicateCalculateSize(name *string, entryProcessor *serialization.Data, predicate *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
@@ -27,7 +27,7 @@ func MapExecuteWithPredicateCalculateSize(name *string, entryProcessor *Data, pr
 	return dataSize
 }
 
-func MapExecuteWithPredicateEncodeRequest(name *string, entryProcessor *Data, predicate *Data) *ClientMessage {
+func MapExecuteWithPredicateEncodeRequest(name *string, entryProcessor *serialization.Data, predicate *serialization.Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapExecuteWithPredicateCalculateSize(name, entryProcessor, predicate))
 	clientMessage.SetMessageType(mapExecuteWithPredicate)

--- a/internal/protocol/map_forceunlock.go
+++ b/internal/protocol/map_forceunlock.go
@@ -15,21 +15,21 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func MapForceUnlockCalculateSize(name *string, key *Data, referenceId int64) int {
+func MapForceUnlockCalculateSize(name *string, key *serialization.Data, referenceId int64) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
 	dataSize += DataCalculateSize(key)
-	dataSize += Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
 	return dataSize
 }
 
-func MapForceUnlockEncodeRequest(name *string, key *Data, referenceId int64) *ClientMessage {
+func MapForceUnlockEncodeRequest(name *string, key *serialization.Data, referenceId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapForceUnlockCalculateSize(name, key, referenceId))
 	clientMessage.SetMessageType(mapForceUnlock)

--- a/internal/protocol/map_get.go
+++ b/internal/protocol/map_get.go
@@ -15,21 +15,21 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func MapGetCalculateSize(name *string, key *Data, threadId int64) int {
+func MapGetCalculateSize(name *string, key *serialization.Data, threadId int64) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
 	dataSize += DataCalculateSize(key)
-	dataSize += Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
 	return dataSize
 }
 
-func MapGetEncodeRequest(name *string, key *Data, threadId int64) *ClientMessage {
+func MapGetEncodeRequest(name *string, key *serialization.Data, threadId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapGetCalculateSize(name, key, threadId))
 	clientMessage.SetMessageType(mapGet)
@@ -41,9 +41,9 @@ func MapGetEncodeRequest(name *string, key *Data, threadId int64) *ClientMessage
 	return clientMessage
 }
 
-func MapGetDecodeResponse(clientMessage *ClientMessage) func() (response *Data) {
+func MapGetDecodeResponse(clientMessage *ClientMessage) func() (response *serialization.Data) {
 	// Decode response from client message
-	return func() (response *Data) {
+	return func() (response *serialization.Data) {
 
 		if !clientMessage.ReadBool() {
 			response = clientMessage.ReadData()

--- a/internal/protocol/map_getall.go
+++ b/internal/protocol/map_getall.go
@@ -15,23 +15,23 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func MapGetAllCalculateSize(name *string, keys []*Data) int {
+func MapGetAllCalculateSize(name *string, keys []*serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
-	dataSize += Int32SizeInBytes
+	dataSize += common.Int32SizeInBytes
 	for _, keysItem := range keys {
 		dataSize += DataCalculateSize(keysItem)
 	}
 	return dataSize
 }
 
-func MapGetAllEncodeRequest(name *string, keys []*Data) *ClientMessage {
+func MapGetAllEncodeRequest(name *string, keys []*serialization.Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapGetAllCalculateSize(name, keys))
 	clientMessage.SetMessageType(mapGetAll)

--- a/internal/protocol/map_getentryview.go
+++ b/internal/protocol/map_getentryview.go
@@ -15,21 +15,21 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func MapGetEntryViewCalculateSize(name *string, key *Data, threadId int64) int {
+func MapGetEntryViewCalculateSize(name *string, key *serialization.Data, threadId int64) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
 	dataSize += DataCalculateSize(key)
-	dataSize += Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
 	return dataSize
 }
 
-func MapGetEntryViewEncodeRequest(name *string, key *Data, threadId int64) *ClientMessage {
+func MapGetEntryViewEncodeRequest(name *string, key *serialization.Data, threadId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapGetEntryViewCalculateSize(name, key, threadId))
 	clientMessage.SetMessageType(mapGetEntryView)

--- a/internal/protocol/map_islocked.go
+++ b/internal/protocol/map_islocked.go
@@ -15,10 +15,10 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
-func MapIsLockedCalculateSize(name *string, key *Data) int {
+func MapIsLockedCalculateSize(name *string, key *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
@@ -26,7 +26,7 @@ func MapIsLockedCalculateSize(name *string, key *Data) int {
 	return dataSize
 }
 
-func MapIsLockedEncodeRequest(name *string, key *Data) *ClientMessage {
+func MapIsLockedEncodeRequest(name *string, key *serialization.Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapIsLockedCalculateSize(name, key))
 	clientMessage.SetMessageType(mapIsLocked)

--- a/internal/protocol/map_keyset.go
+++ b/internal/protocol/map_keyset.go
@@ -15,7 +15,7 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
 func MapKeySetCalculateSize(name *string) int {
@@ -35,11 +35,11 @@ func MapKeySetEncodeRequest(name *string) *ClientMessage {
 	return clientMessage
 }
 
-func MapKeySetDecodeResponse(clientMessage *ClientMessage) func() (response []*Data) {
+func MapKeySetDecodeResponse(clientMessage *ClientMessage) func() (response []*serialization.Data) {
 	// Decode response from client message
-	return func() (response []*Data) {
+	return func() (response []*serialization.Data) {
 		responseSize := clientMessage.ReadInt32()
-		response = make([]*Data, responseSize)
+		response = make([]*serialization.Data, responseSize)
 		for responseIndex := 0; responseIndex < int(responseSize); responseIndex++ {
 			responseItem := clientMessage.ReadData()
 			response[responseIndex] = responseItem

--- a/internal/protocol/map_keysetwithpredicate.go
+++ b/internal/protocol/map_keysetwithpredicate.go
@@ -15,10 +15,10 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
-func MapKeySetWithPredicateCalculateSize(name *string, predicate *Data) int {
+func MapKeySetWithPredicateCalculateSize(name *string, predicate *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
@@ -26,7 +26,7 @@ func MapKeySetWithPredicateCalculateSize(name *string, predicate *Data) int {
 	return dataSize
 }
 
-func MapKeySetWithPredicateEncodeRequest(name *string, predicate *Data) *ClientMessage {
+func MapKeySetWithPredicateEncodeRequest(name *string, predicate *serialization.Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapKeySetWithPredicateCalculateSize(name, predicate))
 	clientMessage.SetMessageType(mapKeySetWithPredicate)
@@ -37,11 +37,11 @@ func MapKeySetWithPredicateEncodeRequest(name *string, predicate *Data) *ClientM
 	return clientMessage
 }
 
-func MapKeySetWithPredicateDecodeResponse(clientMessage *ClientMessage) func() (response []*Data) {
+func MapKeySetWithPredicateDecodeResponse(clientMessage *ClientMessage) func() (response []*serialization.Data) {
 	// Decode response from client message
-	return func() (response []*Data) {
+	return func() (response []*serialization.Data) {
 		responseSize := clientMessage.ReadInt32()
-		response = make([]*Data, responseSize)
+		response = make([]*serialization.Data, responseSize)
 		for responseIndex := 0; responseIndex < int(responseSize); responseIndex++ {
 			responseItem := clientMessage.ReadData()
 			response[responseIndex] = responseItem

--- a/internal/protocol/map_lock.go
+++ b/internal/protocol/map_lock.go
@@ -15,23 +15,23 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func MapLockCalculateSize(name *string, key *Data, threadId int64, ttl int64, referenceId int64) int {
+func MapLockCalculateSize(name *string, key *serialization.Data, threadId int64, ttl int64, referenceId int64) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
 	dataSize += DataCalculateSize(key)
-	dataSize += Int64SizeInBytes
-	dataSize += Int64SizeInBytes
-	dataSize += Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
 	return dataSize
 }
 
-func MapLockEncodeRequest(name *string, key *Data, threadId int64, ttl int64, referenceId int64) *ClientMessage {
+func MapLockEncodeRequest(name *string, key *serialization.Data, threadId int64, ttl int64, referenceId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapLockCalculateSize(name, key, threadId, ttl, referenceId))
 	clientMessage.SetMessageType(mapLock)

--- a/internal/protocol/map_put.go
+++ b/internal/protocol/map_put.go
@@ -15,23 +15,23 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func MapPutCalculateSize(name *string, key *Data, value *Data, threadId int64, ttl int64) int {
+func MapPutCalculateSize(name *string, key *serialization.Data, value *serialization.Data, threadId int64, ttl int64) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
 	dataSize += DataCalculateSize(key)
 	dataSize += DataCalculateSize(value)
-	dataSize += Int64SizeInBytes
-	dataSize += Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
 	return dataSize
 }
 
-func MapPutEncodeRequest(name *string, key *Data, value *Data, threadId int64, ttl int64) *ClientMessage {
+func MapPutEncodeRequest(name *string, key *serialization.Data, value *serialization.Data, threadId int64, ttl int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapPutCalculateSize(name, key, value, threadId, ttl))
 	clientMessage.SetMessageType(mapPut)
@@ -45,9 +45,9 @@ func MapPutEncodeRequest(name *string, key *Data, value *Data, threadId int64, t
 	return clientMessage
 }
 
-func MapPutDecodeResponse(clientMessage *ClientMessage) func() (response *Data) {
+func MapPutDecodeResponse(clientMessage *ClientMessage) func() (response *serialization.Data) {
 	// Decode response from client message
-	return func() (response *Data) {
+	return func() (response *serialization.Data) {
 
 		if !clientMessage.ReadBool() {
 			response = clientMessage.ReadData()

--- a/internal/protocol/map_putall.go
+++ b/internal/protocol/map_putall.go
@@ -15,19 +15,19 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
 func MapPutAllCalculateSize(name *string, entries []*Pair) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
-	dataSize += Int32SizeInBytes
+	dataSize += common.Int32SizeInBytes
 	for _, entriesItem := range entries {
-		key := entriesItem.key.(*Data)
-		val := entriesItem.value.(*Data)
+		key := entriesItem.key.(*serialization.Data)
+		val := entriesItem.value.(*serialization.Data)
 		dataSize += DataCalculateSize(key)
 		dataSize += DataCalculateSize(val)
 	}
@@ -42,8 +42,8 @@ func MapPutAllEncodeRequest(name *string, entries []*Pair) *ClientMessage {
 	clientMessage.AppendString(name)
 	clientMessage.AppendInt32(int32(len(entries)))
 	for _, entriesItem := range entries {
-		key := entriesItem.key.(*Data)
-		val := entriesItem.value.(*Data)
+		key := entriesItem.key.(*serialization.Data)
+		val := entriesItem.value.(*serialization.Data)
 		clientMessage.AppendData(key)
 		clientMessage.AppendData(val)
 	}

--- a/internal/protocol/map_putifabsent.go
+++ b/internal/protocol/map_putifabsent.go
@@ -15,23 +15,23 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func MapPutIfAbsentCalculateSize(name *string, key *Data, value *Data, threadId int64, ttl int64) int {
+func MapPutIfAbsentCalculateSize(name *string, key *serialization.Data, value *serialization.Data, threadId int64, ttl int64) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
 	dataSize += DataCalculateSize(key)
 	dataSize += DataCalculateSize(value)
-	dataSize += Int64SizeInBytes
-	dataSize += Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
 	return dataSize
 }
 
-func MapPutIfAbsentEncodeRequest(name *string, key *Data, value *Data, threadId int64, ttl int64) *ClientMessage {
+func MapPutIfAbsentEncodeRequest(name *string, key *serialization.Data, value *serialization.Data, threadId int64, ttl int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapPutIfAbsentCalculateSize(name, key, value, threadId, ttl))
 	clientMessage.SetMessageType(mapPutIfAbsent)
@@ -45,9 +45,9 @@ func MapPutIfAbsentEncodeRequest(name *string, key *Data, value *Data, threadId 
 	return clientMessage
 }
 
-func MapPutIfAbsentDecodeResponse(clientMessage *ClientMessage) func() (response *Data) {
+func MapPutIfAbsentDecodeResponse(clientMessage *ClientMessage) func() (response *serialization.Data) {
 	// Decode response from client message
-	return func() (response *Data) {
+	return func() (response *serialization.Data) {
 
 		if !clientMessage.ReadBool() {
 			response = clientMessage.ReadData()

--- a/internal/protocol/map_puttransient.go
+++ b/internal/protocol/map_puttransient.go
@@ -15,23 +15,23 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func MapPutTransientCalculateSize(name *string, key *Data, value *Data, threadId int64, ttl int64) int {
+func MapPutTransientCalculateSize(name *string, key *serialization.Data, value *serialization.Data, threadId int64, ttl int64) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
 	dataSize += DataCalculateSize(key)
 	dataSize += DataCalculateSize(value)
-	dataSize += Int64SizeInBytes
-	dataSize += Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
 	return dataSize
 }
 
-func MapPutTransientEncodeRequest(name *string, key *Data, value *Data, threadId int64, ttl int64) *ClientMessage {
+func MapPutTransientEncodeRequest(name *string, key *serialization.Data, value *serialization.Data, threadId int64, ttl int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapPutTransientCalculateSize(name, key, value, threadId, ttl))
 	clientMessage.SetMessageType(mapPutTransient)

--- a/internal/protocol/map_remove.go
+++ b/internal/protocol/map_remove.go
@@ -15,21 +15,21 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func MapRemoveCalculateSize(name *string, key *Data, threadId int64) int {
+func MapRemoveCalculateSize(name *string, key *serialization.Data, threadId int64) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
 	dataSize += DataCalculateSize(key)
-	dataSize += Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
 	return dataSize
 }
 
-func MapRemoveEncodeRequest(name *string, key *Data, threadId int64) *ClientMessage {
+func MapRemoveEncodeRequest(name *string, key *serialization.Data, threadId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapRemoveCalculateSize(name, key, threadId))
 	clientMessage.SetMessageType(mapRemove)
@@ -41,9 +41,9 @@ func MapRemoveEncodeRequest(name *string, key *Data, threadId int64) *ClientMess
 	return clientMessage
 }
 
-func MapRemoveDecodeResponse(clientMessage *ClientMessage) func() (response *Data) {
+func MapRemoveDecodeResponse(clientMessage *ClientMessage) func() (response *serialization.Data) {
 	// Decode response from client message
-	return func() (response *Data) {
+	return func() (response *serialization.Data) {
 
 		if !clientMessage.ReadBool() {
 			response = clientMessage.ReadData()

--- a/internal/protocol/map_removeall.go
+++ b/internal/protocol/map_removeall.go
@@ -15,10 +15,10 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
-func MapRemoveAllCalculateSize(name *string, predicate *Data) int {
+func MapRemoveAllCalculateSize(name *string, predicate *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
@@ -26,7 +26,7 @@ func MapRemoveAllCalculateSize(name *string, predicate *Data) int {
 	return dataSize
 }
 
-func MapRemoveAllEncodeRequest(name *string, predicate *Data) *ClientMessage {
+func MapRemoveAllEncodeRequest(name *string, predicate *serialization.Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapRemoveAllCalculateSize(name, predicate))
 	clientMessage.SetMessageType(mapRemoveAll)

--- a/internal/protocol/map_removeifsame.go
+++ b/internal/protocol/map_removeifsame.go
@@ -15,22 +15,22 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func MapRemoveIfSameCalculateSize(name *string, key *Data, value *Data, threadId int64) int {
+func MapRemoveIfSameCalculateSize(name *string, key *serialization.Data, value *serialization.Data, threadId int64) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
 	dataSize += DataCalculateSize(key)
 	dataSize += DataCalculateSize(value)
-	dataSize += Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
 	return dataSize
 }
 
-func MapRemoveIfSameEncodeRequest(name *string, key *Data, value *Data, threadId int64) *ClientMessage {
+func MapRemoveIfSameEncodeRequest(name *string, key *serialization.Data, value *serialization.Data, threadId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapRemoveIfSameCalculateSize(name, key, value, threadId))
 	clientMessage.SetMessageType(mapRemoveIfSame)

--- a/internal/protocol/map_replace.go
+++ b/internal/protocol/map_replace.go
@@ -15,22 +15,22 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func MapReplaceCalculateSize(name *string, key *Data, value *Data, threadId int64) int {
+func MapReplaceCalculateSize(name *string, key *serialization.Data, value *serialization.Data, threadId int64) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
 	dataSize += DataCalculateSize(key)
 	dataSize += DataCalculateSize(value)
-	dataSize += Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
 	return dataSize
 }
 
-func MapReplaceEncodeRequest(name *string, key *Data, value *Data, threadId int64) *ClientMessage {
+func MapReplaceEncodeRequest(name *string, key *serialization.Data, value *serialization.Data, threadId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapReplaceCalculateSize(name, key, value, threadId))
 	clientMessage.SetMessageType(mapReplace)
@@ -43,9 +43,9 @@ func MapReplaceEncodeRequest(name *string, key *Data, value *Data, threadId int6
 	return clientMessage
 }
 
-func MapReplaceDecodeResponse(clientMessage *ClientMessage) func() (response *Data) {
+func MapReplaceDecodeResponse(clientMessage *ClientMessage) func() (response *serialization.Data) {
 	// Decode response from client message
-	return func() (response *Data) {
+	return func() (response *serialization.Data) {
 
 		if !clientMessage.ReadBool() {
 			response = clientMessage.ReadData()

--- a/internal/protocol/map_replaceifsame.go
+++ b/internal/protocol/map_replaceifsame.go
@@ -15,23 +15,23 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func MapReplaceIfSameCalculateSize(name *string, key *Data, testValue *Data, value *Data, threadId int64) int {
+func MapReplaceIfSameCalculateSize(name *string, key *serialization.Data, testValue *serialization.Data, value *serialization.Data, threadId int64) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
 	dataSize += DataCalculateSize(key)
 	dataSize += DataCalculateSize(testValue)
 	dataSize += DataCalculateSize(value)
-	dataSize += Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
 	return dataSize
 }
 
-func MapReplaceIfSameEncodeRequest(name *string, key *Data, testValue *Data, value *Data, threadId int64) *ClientMessage {
+func MapReplaceIfSameEncodeRequest(name *string, key *serialization.Data, testValue *serialization.Data, value *serialization.Data, threadId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapReplaceIfSameCalculateSize(name, key, testValue, value, threadId))
 	clientMessage.SetMessageType(mapReplaceIfSame)

--- a/internal/protocol/map_set.go
+++ b/internal/protocol/map_set.go
@@ -15,23 +15,23 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func MapSetCalculateSize(name *string, key *Data, value *Data, threadId int64, ttl int64) int {
+func MapSetCalculateSize(name *string, key *serialization.Data, value *serialization.Data, threadId int64, ttl int64) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
 	dataSize += DataCalculateSize(key)
 	dataSize += DataCalculateSize(value)
-	dataSize += Int64SizeInBytes
-	dataSize += Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
 	return dataSize
 }
 
-func MapSetEncodeRequest(name *string, key *Data, value *Data, threadId int64, ttl int64) *ClientMessage {
+func MapSetEncodeRequest(name *string, key *serialization.Data, value *serialization.Data, threadId int64, ttl int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapSetCalculateSize(name, key, value, threadId, ttl))
 	clientMessage.SetMessageType(mapSet)

--- a/internal/protocol/map_trylock.go
+++ b/internal/protocol/map_trylock.go
@@ -15,24 +15,24 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func MapTryLockCalculateSize(name *string, key *Data, threadId int64, lease int64, timeout int64, referenceId int64) int {
+func MapTryLockCalculateSize(name *string, key *serialization.Data, threadId int64, lease int64, timeout int64, referenceId int64) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
 	dataSize += DataCalculateSize(key)
-	dataSize += Int64SizeInBytes
-	dataSize += Int64SizeInBytes
-	dataSize += Int64SizeInBytes
-	dataSize += Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
 	return dataSize
 }
 
-func MapTryLockEncodeRequest(name *string, key *Data, threadId int64, lease int64, timeout int64, referenceId int64) *ClientMessage {
+func MapTryLockEncodeRequest(name *string, key *serialization.Data, threadId int64, lease int64, timeout int64, referenceId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapTryLockCalculateSize(name, key, threadId, lease, timeout, referenceId))
 	clientMessage.SetMessageType(mapTryLock)

--- a/internal/protocol/map_tryput.go
+++ b/internal/protocol/map_tryput.go
@@ -15,23 +15,23 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func MapTryPutCalculateSize(name *string, key *Data, value *Data, threadId int64, timeout int64) int {
+func MapTryPutCalculateSize(name *string, key *serialization.Data, value *serialization.Data, threadId int64, timeout int64) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
 	dataSize += DataCalculateSize(key)
 	dataSize += DataCalculateSize(value)
-	dataSize += Int64SizeInBytes
-	dataSize += Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
 	return dataSize
 }
 
-func MapTryPutEncodeRequest(name *string, key *Data, value *Data, threadId int64, timeout int64) *ClientMessage {
+func MapTryPutEncodeRequest(name *string, key *serialization.Data, value *serialization.Data, threadId int64, timeout int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapTryPutCalculateSize(name, key, value, threadId, timeout))
 	clientMessage.SetMessageType(mapTryPut)

--- a/internal/protocol/map_tryremove.go
+++ b/internal/protocol/map_tryremove.go
@@ -15,22 +15,22 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func MapTryRemoveCalculateSize(name *string, key *Data, threadId int64, timeout int64) int {
+func MapTryRemoveCalculateSize(name *string, key *serialization.Data, threadId int64, timeout int64) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
 	dataSize += DataCalculateSize(key)
-	dataSize += Int64SizeInBytes
-	dataSize += Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
 	return dataSize
 }
 
-func MapTryRemoveEncodeRequest(name *string, key *Data, threadId int64, timeout int64) *ClientMessage {
+func MapTryRemoveEncodeRequest(name *string, key *serialization.Data, threadId int64, timeout int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapTryRemoveCalculateSize(name, key, threadId, timeout))
 	clientMessage.SetMessageType(mapTryRemove)

--- a/internal/protocol/map_unlock.go
+++ b/internal/protocol/map_unlock.go
@@ -15,22 +15,22 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func MapUnlockCalculateSize(name *string, key *Data, threadId int64, referenceId int64) int {
+func MapUnlockCalculateSize(name *string, key *serialization.Data, threadId int64, referenceId int64) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
 	dataSize += DataCalculateSize(key)
-	dataSize += Int64SizeInBytes
-	dataSize += Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
 	return dataSize
 }
 
-func MapUnlockEncodeRequest(name *string, key *Data, threadId int64, referenceId int64) *ClientMessage {
+func MapUnlockEncodeRequest(name *string, key *serialization.Data, threadId int64, referenceId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapUnlockCalculateSize(name, key, threadId, referenceId))
 	clientMessage.SetMessageType(mapUnlock)

--- a/internal/protocol/map_values.go
+++ b/internal/protocol/map_values.go
@@ -15,7 +15,7 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
 func MapValuesCalculateSize(name *string) int {
@@ -35,11 +35,11 @@ func MapValuesEncodeRequest(name *string) *ClientMessage {
 	return clientMessage
 }
 
-func MapValuesDecodeResponse(clientMessage *ClientMessage) func() (response []*Data) {
+func MapValuesDecodeResponse(clientMessage *ClientMessage) func() (response []*serialization.Data) {
 	// Decode response from client message
-	return func() (response []*Data) {
+	return func() (response []*serialization.Data) {
 		responseSize := clientMessage.ReadInt32()
-		response = make([]*Data, responseSize)
+		response = make([]*serialization.Data, responseSize)
 		for responseIndex := 0; responseIndex < int(responseSize); responseIndex++ {
 			responseItem := clientMessage.ReadData()
 			response[responseIndex] = responseItem

--- a/internal/protocol/map_valueswithpredicate.go
+++ b/internal/protocol/map_valueswithpredicate.go
@@ -15,10 +15,10 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
-func MapValuesWithPredicateCalculateSize(name *string, predicate *Data) int {
+func MapValuesWithPredicateCalculateSize(name *string, predicate *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
@@ -26,7 +26,7 @@ func MapValuesWithPredicateCalculateSize(name *string, predicate *Data) int {
 	return dataSize
 }
 
-func MapValuesWithPredicateEncodeRequest(name *string, predicate *Data) *ClientMessage {
+func MapValuesWithPredicateEncodeRequest(name *string, predicate *serialization.Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MapValuesWithPredicateCalculateSize(name, predicate))
 	clientMessage.SetMessageType(mapValuesWithPredicate)
@@ -37,11 +37,11 @@ func MapValuesWithPredicateEncodeRequest(name *string, predicate *Data) *ClientM
 	return clientMessage
 }
 
-func MapValuesWithPredicateDecodeResponse(clientMessage *ClientMessage) func() (response []*Data) {
+func MapValuesWithPredicateDecodeResponse(clientMessage *ClientMessage) func() (response []*serialization.Data) {
 	// Decode response from client message
-	return func() (response []*Data) {
+	return func() (response []*serialization.Data) {
 		responseSize := clientMessage.ReadInt32()
-		response = make([]*Data, responseSize)
+		response = make([]*serialization.Data, responseSize)
 		for responseIndex := 0; responseIndex < int(responseSize); responseIndex++ {
 			responseItem := clientMessage.ReadData()
 			response[responseIndex] = responseItem

--- a/internal/protocol/message.go
+++ b/internal/protocol/message.go
@@ -18,8 +18,8 @@ import (
 	"encoding/binary"
 	"unicode/utf8"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
 // ClientMessage is the carrier framed data as defined below.
@@ -59,38 +59,38 @@ func NewClientMessage(buffer []byte, payloadSize int) *ClientMessage {
 	if buffer != nil {
 		//Message has a buffer so it will be decoded.
 		clientMessage.Buffer = buffer
-		clientMessage.readIndex = HeaderSize
+		clientMessage.readIndex = common.HeaderSize
 	} else {
 		//Client message that will be encoded.
-		clientMessage.Buffer = make([]byte, HeaderSize+payloadSize)
-		clientMessage.SetDataOffset(HeaderSize)
-		clientMessage.writeIndex = HeaderSize
+		clientMessage.Buffer = make([]byte, common.HeaderSize+payloadSize)
+		clientMessage.SetDataOffset(common.HeaderSize)
+		clientMessage.writeIndex = common.HeaderSize
 	}
 	clientMessage.IsRetryable = false
 	return clientMessage
 }
 
 func (msg *ClientMessage) FrameLength() int32 {
-	return int32(binary.LittleEndian.Uint32(msg.Buffer[FrameLengthFieldOffset:VersionFieldOffset]))
+	return int32(binary.LittleEndian.Uint32(msg.Buffer[common.FrameLengthFieldOffset:common.VersionFieldOffset]))
 }
 
 func (msg *ClientMessage) SetFrameLength(v int32) {
-	binary.LittleEndian.PutUint32(msg.Buffer[FrameLengthFieldOffset:VersionFieldOffset], uint32(v))
+	binary.LittleEndian.PutUint32(msg.Buffer[common.FrameLengthFieldOffset:common.VersionFieldOffset], uint32(v))
 }
 
 func (msg *ClientMessage) SetVersion(v uint8) {
-	msg.Buffer[VersionFieldOffset] = byte(v)
+	msg.Buffer[common.VersionFieldOffset] = byte(v)
 }
 
 func (msg *ClientMessage) Flags() uint8 {
-	return msg.Buffer[FlagsFieldOffset]
+	return msg.Buffer[common.FlagsFieldOffset]
 }
 
 func (msg *ClientMessage) SetFlags(v uint8) {
-	msg.Buffer[FlagsFieldOffset] = byte(v)
+	msg.Buffer[common.FlagsFieldOffset] = byte(v)
 }
 func (msg *ClientMessage) AddFlags(v uint8) {
-	msg.Buffer[FlagsFieldOffset] = msg.Buffer[FlagsFieldOffset] | byte(v)
+	msg.Buffer[common.FlagsFieldOffset] = msg.Buffer[common.FlagsFieldOffset] | byte(v)
 }
 
 func (msg *ClientMessage) HasFlags(flags uint8) uint8 {
@@ -101,36 +101,36 @@ func (msg *ClientMessage) HasFlags(flags uint8) uint8 {
 	return 0
 }
 
-func (msg *ClientMessage) MessageType() MessageType {
-	return MessageType(binary.LittleEndian.Uint16(msg.Buffer[TypeFieldOffset:CorrelationIdFieldOffset]))
+func (msg *ClientMessage) MessageType() common.MessageType {
+	return common.MessageType(binary.LittleEndian.Uint16(msg.Buffer[common.TypeFieldOffset:common.CorrelationIdFieldOffset]))
 }
 
-func (msg *ClientMessage) SetMessageType(v MessageType) {
-	binary.LittleEndian.PutUint16(msg.Buffer[TypeFieldOffset:CorrelationIdFieldOffset], uint16(v))
+func (msg *ClientMessage) SetMessageType(v common.MessageType) {
+	binary.LittleEndian.PutUint16(msg.Buffer[common.TypeFieldOffset:common.CorrelationIdFieldOffset], uint16(v))
 }
 
 func (msg *ClientMessage) CorrelationId() int64 {
-	return int64(binary.LittleEndian.Uint64(msg.Buffer[CorrelationIdFieldOffset:PartitionIdFieldOffset]))
+	return int64(binary.LittleEndian.Uint64(msg.Buffer[common.CorrelationIdFieldOffset:common.PartitionIdFieldOffset]))
 }
 
 func (msg *ClientMessage) SetCorrelationId(val int64) {
-	binary.LittleEndian.PutUint64(msg.Buffer[CorrelationIdFieldOffset:PartitionIdFieldOffset], uint64(val))
+	binary.LittleEndian.PutUint64(msg.Buffer[common.CorrelationIdFieldOffset:common.PartitionIdFieldOffset], uint64(val))
 }
 
 func (msg *ClientMessage) PartitionId() int32 {
-	return int32(binary.LittleEndian.Uint32(msg.Buffer[PartitionIdFieldOffset:DataOffsetFieldOffset]))
+	return int32(binary.LittleEndian.Uint32(msg.Buffer[common.PartitionIdFieldOffset:common.DataOffsetFieldOffset]))
 }
 
 func (msg *ClientMessage) SetPartitionId(val int32) {
-	binary.LittleEndian.PutUint32(msg.Buffer[PartitionIdFieldOffset:DataOffsetFieldOffset], uint32(val))
+	binary.LittleEndian.PutUint32(msg.Buffer[common.PartitionIdFieldOffset:common.DataOffsetFieldOffset], uint32(val))
 }
 
 func (msg *ClientMessage) DataOffset() uint16 {
-	return binary.LittleEndian.Uint16(msg.Buffer[DataOffsetFieldOffset:HeaderSize])
+	return binary.LittleEndian.Uint16(msg.Buffer[common.DataOffsetFieldOffset:common.HeaderSize])
 }
 
 func (msg *ClientMessage) SetDataOffset(v uint16) {
-	binary.LittleEndian.PutUint16(msg.Buffer[DataOffsetFieldOffset:HeaderSize], v)
+	binary.LittleEndian.PutUint16(msg.Buffer[common.DataOffsetFieldOffset:common.HeaderSize], v)
 }
 
 func (msg *ClientMessage) writeOffset() int32 {
@@ -147,17 +147,17 @@ func (msg *ClientMessage) readOffset() int32 {
 
 func (msg *ClientMessage) AppendByte(v uint8) {
 	msg.Buffer[msg.writeIndex] = byte(v)
-	msg.writeIndex += ByteSizeInBytes
+	msg.writeIndex += common.ByteSizeInBytes
 }
 func (msg *ClientMessage) AppendUint8(v uint8) {
 	msg.Buffer[msg.writeIndex] = byte(v)
-	msg.writeIndex += ByteSizeInBytes
+	msg.writeIndex += common.ByteSizeInBytes
 }
 func (msg *ClientMessage) AppendInt32(v int32) {
-	binary.LittleEndian.PutUint32(msg.Buffer[msg.writeIndex:msg.writeIndex+Int32SizeInBytes], uint32(v))
-	msg.writeIndex += Int32SizeInBytes
+	binary.LittleEndian.PutUint32(msg.Buffer[msg.writeIndex:msg.writeIndex+common.Int32SizeInBytes], uint32(v))
+	msg.writeIndex += common.Int32SizeInBytes
 }
-func (msg *ClientMessage) AppendData(v *Data) {
+func (msg *ClientMessage) AppendData(v *serialization.Data) {
 	msg.AppendByteArray(v.Buffer())
 }
 
@@ -170,8 +170,8 @@ func (msg *ClientMessage) AppendByteArray(arr []byte) {
 	msg.writeIndex += length
 }
 func (msg *ClientMessage) AppendInt64(v int64) {
-	binary.LittleEndian.PutUint64(msg.Buffer[msg.writeIndex:msg.writeIndex+Int64SizeInBytes], uint64(v))
-	msg.writeIndex += Int64SizeInBytes
+	binary.LittleEndian.PutUint64(msg.Buffer[msg.writeIndex:msg.writeIndex+common.Int64SizeInBytes], uint64(v))
+	msg.writeIndex += common.Int64SizeInBytes
 }
 
 func (msg *ClientMessage) AppendString(str *string) {
@@ -201,18 +201,18 @@ func (msg *ClientMessage) AppendBool(v bool) {
 */
 
 func (msg *ClientMessage) ReadInt32() int32 {
-	int := int32(binary.LittleEndian.Uint32(msg.Buffer[msg.readOffset() : msg.readOffset()+Int32SizeInBytes]))
-	msg.readIndex += Int32SizeInBytes
+	int := int32(binary.LittleEndian.Uint32(msg.Buffer[msg.readOffset() : msg.readOffset()+common.Int32SizeInBytes]))
+	msg.readIndex += common.Int32SizeInBytes
 	return int
 }
 func (msg *ClientMessage) ReadInt64() int64 {
-	int64 := int64(binary.LittleEndian.Uint64(msg.Buffer[msg.readOffset() : msg.readOffset()+Int64SizeInBytes]))
-	msg.readIndex += Int64SizeInBytes
+	int64 := int64(binary.LittleEndian.Uint64(msg.Buffer[msg.readOffset() : msg.readOffset()+common.Int64SizeInBytes]))
+	msg.readIndex += common.Int64SizeInBytes
 	return int64
 }
 func (msg *ClientMessage) ReadUint8() uint8 {
 	byte := byte(msg.Buffer[msg.readOffset()])
-	msg.readIndex += ByteSizeInBytes
+	msg.readIndex += common.ByteSizeInBytes
 	return byte
 }
 
@@ -227,8 +227,8 @@ func (msg *ClientMessage) ReadString() *string {
 	str := string(msg.ReadByteArray())
 	return &str
 }
-func (msg *ClientMessage) ReadData() *Data {
-	return &Data{msg.ReadByteArray()}
+func (msg *ClientMessage) ReadData() *serialization.Data {
+	return &serialization.Data{msg.ReadByteArray()}
 }
 func (msg *ClientMessage) ReadByteArray() []byte {
 	length := msg.ReadInt32()
@@ -251,5 +251,5 @@ func (msg *ClientMessage) Accumulate(newMsg *ClientMessage) {
 }
 
 func (msg *ClientMessage) IsComplete() bool {
-	return (msg.readOffset() >= HeaderSize) && (msg.readOffset() == msg.FrameLength())
+	return (msg.readOffset() >= common.HeaderSize) && (msg.readOffset() == msg.FrameLength())
 }

--- a/internal/protocol/message_test.go
+++ b/internal/protocol/message_test.go
@@ -18,7 +18,7 @@ import (
 	"encoding/hex"
 	"testing"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
 var READ_HEADER = []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 16, 0}
@@ -26,7 +26,7 @@ var READ_HEADER = []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 func TestHeaderFields(t *testing.T) {
 	message := NewClientMessage(nil, 30)
 	var correlationId int64 = 6474838
-	var messageType MessageType = 987
+	var messageType common.MessageType = 987
 	var flags uint8 = 5
 	var partitionId int32 = 27
 	var frameLength int32 = 100
@@ -174,62 +174,62 @@ func TestClientMessage_ReadString(t *testing.T) {
 func TestNoFlag(t *testing.T) {
 	message := NewClientMessage(nil, 30)
 	message.SetFlags(0)
-	if result := message.HasFlags(BeginFlag); result != 0 {
+	if result := message.HasFlags(common.BeginFlag); result != 0 {
 		t.Errorf("HasFlag returned %d expected 0", result)
 	}
-	if result := message.HasFlags(EndFlag); result != 0 {
+	if result := message.HasFlags(common.EndFlag); result != 0 {
 		t.Errorf("HasFlag returned %d expected 0", result)
 	}
-	if result := message.HasFlags(ListenerFlag); result != 0 {
+	if result := message.HasFlags(common.ListenerFlag); result != 0 {
 		t.Errorf("HasFlag returned %d expected 0", result)
 	}
 }
 func TestSetFlagBegin(t *testing.T) {
 	message := NewClientMessage(nil, 30)
 	message.SetFlags(0)
-	message.AddFlags(BeginFlag)
-	if result := message.HasFlags(BeginFlag); result == 0 {
+	message.AddFlags(common.BeginFlag)
+	if result := message.HasFlags(common.BeginFlag); result == 0 {
 		t.Errorf("HasFlag returned %d expected 128", result)
 	}
-	if result := message.HasFlags(EndFlag); result != 0 {
+	if result := message.HasFlags(common.EndFlag); result != 0 {
 		t.Errorf("HasFlag returned %d expected 0", result)
 	}
-	if result := message.HasFlags(ListenerFlag); result != 0 {
+	if result := message.HasFlags(common.ListenerFlag); result != 0 {
 		t.Errorf("HasFlag returned %d expected 0", result)
 	}
 }
 func TestSetFlagEnd(t *testing.T) {
 	message := NewClientMessage(nil, 30)
 	message.SetFlags(0)
-	message.AddFlags(EndFlag)
-	if result := message.HasFlags(BeginFlag); result != 0 {
+	message.AddFlags(common.EndFlag)
+	if result := message.HasFlags(common.BeginFlag); result != 0 {
 		t.Errorf("HasFlag returned %d expected 0", result)
 	}
-	if result := message.HasFlags(EndFlag); result == 0 {
+	if result := message.HasFlags(common.EndFlag); result == 0 {
 		t.Errorf("HasFlag returned %d expected 64", result)
 	}
-	if result := message.HasFlags(ListenerFlag); result != 0 {
+	if result := message.HasFlags(common.ListenerFlag); result != 0 {
 		t.Errorf("HasFlag returned %d expected 0", result)
 	}
 }
 func TestSetListenerFlag(t *testing.T) {
 	message := NewClientMessage(nil, 30)
 	message.SetFlags(0)
-	message.AddFlags(ListenerFlag)
-	if result := message.HasFlags(BeginFlag); result != 0 {
+	message.AddFlags(common.ListenerFlag)
+	if result := message.HasFlags(common.BeginFlag); result != 0 {
 		t.Errorf("HasFlag returned %d expected 0", result)
 	}
-	if result := message.HasFlags(EndFlag); result != 0 {
+	if result := message.HasFlags(common.EndFlag); result != 0 {
 		t.Errorf("HasFlag returned %d expected 0", result)
 	}
-	if result := message.HasFlags(ListenerFlag); result == 0 {
+	if result := message.HasFlags(common.ListenerFlag); result == 0 {
 		t.Errorf("HasFlag returned %d expected 1", result)
 	}
 }
 func TestCalculateSizeStr(t *testing.T) {
 	testString := "abc"
-	if result := StringCalculateSize(&testString); result != len(testString)+Int32SizeInBytes {
-		t.Errorf("StringCalculateSize returned %d expected %d", result, len(testString)+Int32SizeInBytes)
+	if result := StringCalculateSize(&testString); result != len(testString)+common.Int32SizeInBytes {
+		t.Errorf("StringCalculateSize returned %d expected %d", result, len(testString)+common.Int32SizeInBytes)
 	}
 }
 func TestClientMessage_UpdateFrameLength(t *testing.T) {

--- a/internal/protocol/multimap_addentrylistener.go
+++ b/internal/protocol/multimap_addentrylistener.go
@@ -15,17 +15,17 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
 func MultiMapAddEntryListenerCalculateSize(name *string, includeValue bool, localOnly bool) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
-	dataSize += BoolSizeInBytes
-	dataSize += BoolSizeInBytes
+	dataSize += common.BoolSizeInBytes
+	dataSize += common.BoolSizeInBytes
 	return dataSize
 }
 
@@ -49,9 +49,9 @@ func MultiMapAddEntryListenerDecodeResponse(clientMessage *ClientMessage) func()
 	}
 }
 
-type MultiMapAddEntryListenerHandleEventEntryFunc func(*Data, *Data, *Data, *Data, int32, *string, int32)
+type MultiMapAddEntryListenerHandleEventEntryFunc func(*serialization.Data, *serialization.Data, *serialization.Data, *serialization.Data, int32, *string, int32)
 
-func MultiMapAddEntryListenerEventEntryDecode(clientMessage *ClientMessage) (key *Data, value *Data, oldValue *Data, mergingValue *Data, eventType int32, uuid *string, numberOfAffectedEntries int32) {
+func MultiMapAddEntryListenerEventEntryDecode(clientMessage *ClientMessage) (key *serialization.Data, value *serialization.Data, oldValue *serialization.Data, mergingValue *serialization.Data, eventType int32, uuid *string, numberOfAffectedEntries int32) {
 
 	if !clientMessage.ReadBool() {
 		key = clientMessage.ReadData()
@@ -78,7 +78,7 @@ func MultiMapAddEntryListenerHandle(clientMessage *ClientMessage,
 	handleEventEntry MultiMapAddEntryListenerHandleEventEntryFunc) {
 	// Event handler
 	messageType := clientMessage.MessageType()
-	if messageType == EventEntry && handleEventEntry != nil {
+	if messageType == common.EventEntry && handleEventEntry != nil {
 		handleEventEntry(MultiMapAddEntryListenerEventEntryDecode(clientMessage))
 	}
 }

--- a/internal/protocol/multimap_addentrylistenertokey.go
+++ b/internal/protocol/multimap_addentrylistenertokey.go
@@ -15,22 +15,22 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func MultiMapAddEntryListenerToKeyCalculateSize(name *string, key *Data, includeValue bool, localOnly bool) int {
+func MultiMapAddEntryListenerToKeyCalculateSize(name *string, key *serialization.Data, includeValue bool, localOnly bool) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
 	dataSize += DataCalculateSize(key)
-	dataSize += BoolSizeInBytes
-	dataSize += BoolSizeInBytes
+	dataSize += common.BoolSizeInBytes
+	dataSize += common.BoolSizeInBytes
 	return dataSize
 }
 
-func MultiMapAddEntryListenerToKeyEncodeRequest(name *string, key *Data, includeValue bool, localOnly bool) *ClientMessage {
+func MultiMapAddEntryListenerToKeyEncodeRequest(name *string, key *serialization.Data, includeValue bool, localOnly bool) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MultiMapAddEntryListenerToKeyCalculateSize(name, key, includeValue, localOnly))
 	clientMessage.SetMessageType(multimapAddEntryListenerToKey)
@@ -51,9 +51,9 @@ func MultiMapAddEntryListenerToKeyDecodeResponse(clientMessage *ClientMessage) f
 	}
 }
 
-type MultiMapAddEntryListenerToKeyHandleEventEntryFunc func(*Data, *Data, *Data, *Data, int32, *string, int32)
+type MultiMapAddEntryListenerToKeyHandleEventEntryFunc func(*serialization.Data, *serialization.Data, *serialization.Data, *serialization.Data, int32, *string, int32)
 
-func MultiMapAddEntryListenerToKeyEventEntryDecode(clientMessage *ClientMessage) (key *Data, value *Data, oldValue *Data, mergingValue *Data, eventType int32, uuid *string, numberOfAffectedEntries int32) {
+func MultiMapAddEntryListenerToKeyEventEntryDecode(clientMessage *ClientMessage) (key *serialization.Data, value *serialization.Data, oldValue *serialization.Data, mergingValue *serialization.Data, eventType int32, uuid *string, numberOfAffectedEntries int32) {
 
 	if !clientMessage.ReadBool() {
 		key = clientMessage.ReadData()
@@ -80,7 +80,7 @@ func MultiMapAddEntryListenerToKeyHandle(clientMessage *ClientMessage,
 	handleEventEntry MultiMapAddEntryListenerToKeyHandleEventEntryFunc) {
 	// Event handler
 	messageType := clientMessage.MessageType()
-	if messageType == EventEntry && handleEventEntry != nil {
+	if messageType == common.EventEntry && handleEventEntry != nil {
 		handleEventEntry(MultiMapAddEntryListenerToKeyEventEntryDecode(clientMessage))
 	}
 }

--- a/internal/protocol/multimap_containsentry.go
+++ b/internal/protocol/multimap_containsentry.go
@@ -15,22 +15,22 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func MultiMapContainsEntryCalculateSize(name *string, key *Data, value *Data, threadId int64) int {
+func MultiMapContainsEntryCalculateSize(name *string, key *serialization.Data, value *serialization.Data, threadId int64) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
 	dataSize += DataCalculateSize(key)
 	dataSize += DataCalculateSize(value)
-	dataSize += Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
 	return dataSize
 }
 
-func MultiMapContainsEntryEncodeRequest(name *string, key *Data, value *Data, threadId int64) *ClientMessage {
+func MultiMapContainsEntryEncodeRequest(name *string, key *serialization.Data, value *serialization.Data, threadId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MultiMapContainsEntryCalculateSize(name, key, value, threadId))
 	clientMessage.SetMessageType(multimapContainsEntry)

--- a/internal/protocol/multimap_containskey.go
+++ b/internal/protocol/multimap_containskey.go
@@ -15,21 +15,21 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func MultiMapContainsKeyCalculateSize(name *string, key *Data, threadId int64) int {
+func MultiMapContainsKeyCalculateSize(name *string, key *serialization.Data, threadId int64) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
 	dataSize += DataCalculateSize(key)
-	dataSize += Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
 	return dataSize
 }
 
-func MultiMapContainsKeyEncodeRequest(name *string, key *Data, threadId int64) *ClientMessage {
+func MultiMapContainsKeyEncodeRequest(name *string, key *serialization.Data, threadId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MultiMapContainsKeyCalculateSize(name, key, threadId))
 	clientMessage.SetMessageType(multimapContainsKey)

--- a/internal/protocol/multimap_containsvalue.go
+++ b/internal/protocol/multimap_containsvalue.go
@@ -15,10 +15,10 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
-func MultiMapContainsValueCalculateSize(name *string, value *Data) int {
+func MultiMapContainsValueCalculateSize(name *string, value *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
@@ -26,7 +26,7 @@ func MultiMapContainsValueCalculateSize(name *string, value *Data) int {
 	return dataSize
 }
 
-func MultiMapContainsValueEncodeRequest(name *string, value *Data) *ClientMessage {
+func MultiMapContainsValueEncodeRequest(name *string, value *serialization.Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MultiMapContainsValueCalculateSize(name, value))
 	clientMessage.SetMessageType(multimapContainsValue)

--- a/internal/protocol/multimap_delete.go
+++ b/internal/protocol/multimap_delete.go
@@ -15,21 +15,21 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func MultiMapDeleteCalculateSize(name *string, key *Data, threadId int64) int {
+func MultiMapDeleteCalculateSize(name *string, key *serialization.Data, threadId int64) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
 	dataSize += DataCalculateSize(key)
-	dataSize += Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
 	return dataSize
 }
 
-func MultiMapDeleteEncodeRequest(name *string, key *Data, threadId int64) *ClientMessage {
+func MultiMapDeleteEncodeRequest(name *string, key *serialization.Data, threadId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MultiMapDeleteCalculateSize(name, key, threadId))
 	clientMessage.SetMessageType(multimapDelete)

--- a/internal/protocol/multimap_forceunlock.go
+++ b/internal/protocol/multimap_forceunlock.go
@@ -15,21 +15,21 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func MultiMapForceUnlockCalculateSize(name *string, key *Data, referenceId int64) int {
+func MultiMapForceUnlockCalculateSize(name *string, key *serialization.Data, referenceId int64) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
 	dataSize += DataCalculateSize(key)
-	dataSize += Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
 	return dataSize
 }
 
-func MultiMapForceUnlockEncodeRequest(name *string, key *Data, referenceId int64) *ClientMessage {
+func MultiMapForceUnlockEncodeRequest(name *string, key *serialization.Data, referenceId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MultiMapForceUnlockCalculateSize(name, key, referenceId))
 	clientMessage.SetMessageType(multimapForceUnlock)

--- a/internal/protocol/multimap_get.go
+++ b/internal/protocol/multimap_get.go
@@ -15,21 +15,21 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func MultiMapGetCalculateSize(name *string, key *Data, threadId int64) int {
+func MultiMapGetCalculateSize(name *string, key *serialization.Data, threadId int64) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
 	dataSize += DataCalculateSize(key)
-	dataSize += Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
 	return dataSize
 }
 
-func MultiMapGetEncodeRequest(name *string, key *Data, threadId int64) *ClientMessage {
+func MultiMapGetEncodeRequest(name *string, key *serialization.Data, threadId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MultiMapGetCalculateSize(name, key, threadId))
 	clientMessage.SetMessageType(multimapGet)
@@ -41,11 +41,11 @@ func MultiMapGetEncodeRequest(name *string, key *Data, threadId int64) *ClientMe
 	return clientMessage
 }
 
-func MultiMapGetDecodeResponse(clientMessage *ClientMessage) func() (response []*Data) {
+func MultiMapGetDecodeResponse(clientMessage *ClientMessage) func() (response []*serialization.Data) {
 	// Decode response from client message
-	return func() (response []*Data) {
+	return func() (response []*serialization.Data) {
 		responseSize := clientMessage.ReadInt32()
-		response = make([]*Data, responseSize)
+		response = make([]*serialization.Data, responseSize)
 		for responseIndex := 0; responseIndex < int(responseSize); responseIndex++ {
 			responseItem := clientMessage.ReadData()
 			response[responseIndex] = responseItem

--- a/internal/protocol/multimap_islocked.go
+++ b/internal/protocol/multimap_islocked.go
@@ -15,10 +15,10 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
-func MultiMapIsLockedCalculateSize(name *string, key *Data) int {
+func MultiMapIsLockedCalculateSize(name *string, key *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
@@ -26,7 +26,7 @@ func MultiMapIsLockedCalculateSize(name *string, key *Data) int {
 	return dataSize
 }
 
-func MultiMapIsLockedEncodeRequest(name *string, key *Data) *ClientMessage {
+func MultiMapIsLockedEncodeRequest(name *string, key *serialization.Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MultiMapIsLockedCalculateSize(name, key))
 	clientMessage.SetMessageType(multimapIsLocked)

--- a/internal/protocol/multimap_keyset.go
+++ b/internal/protocol/multimap_keyset.go
@@ -15,7 +15,7 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
 func MultiMapKeySetCalculateSize(name *string) int {
@@ -35,11 +35,11 @@ func MultiMapKeySetEncodeRequest(name *string) *ClientMessage {
 	return clientMessage
 }
 
-func MultiMapKeySetDecodeResponse(clientMessage *ClientMessage) func() (response []*Data) {
+func MultiMapKeySetDecodeResponse(clientMessage *ClientMessage) func() (response []*serialization.Data) {
 	// Decode response from client message
-	return func() (response []*Data) {
+	return func() (response []*serialization.Data) {
 		responseSize := clientMessage.ReadInt32()
-		response = make([]*Data, responseSize)
+		response = make([]*serialization.Data, responseSize)
 		for responseIndex := 0; responseIndex < int(responseSize); responseIndex++ {
 			responseItem := clientMessage.ReadData()
 			response[responseIndex] = responseItem

--- a/internal/protocol/multimap_lock.go
+++ b/internal/protocol/multimap_lock.go
@@ -15,23 +15,23 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func MultiMapLockCalculateSize(name *string, key *Data, threadId int64, ttl int64, referenceId int64) int {
+func MultiMapLockCalculateSize(name *string, key *serialization.Data, threadId int64, ttl int64, referenceId int64) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
 	dataSize += DataCalculateSize(key)
-	dataSize += Int64SizeInBytes
-	dataSize += Int64SizeInBytes
-	dataSize += Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
 	return dataSize
 }
 
-func MultiMapLockEncodeRequest(name *string, key *Data, threadId int64, ttl int64, referenceId int64) *ClientMessage {
+func MultiMapLockEncodeRequest(name *string, key *serialization.Data, threadId int64, ttl int64, referenceId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MultiMapLockCalculateSize(name, key, threadId, ttl, referenceId))
 	clientMessage.SetMessageType(multimapLock)

--- a/internal/protocol/multimap_put.go
+++ b/internal/protocol/multimap_put.go
@@ -15,22 +15,22 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func MultiMapPutCalculateSize(name *string, key *Data, value *Data, threadId int64) int {
+func MultiMapPutCalculateSize(name *string, key *serialization.Data, value *serialization.Data, threadId int64) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
 	dataSize += DataCalculateSize(key)
 	dataSize += DataCalculateSize(value)
-	dataSize += Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
 	return dataSize
 }
 
-func MultiMapPutEncodeRequest(name *string, key *Data, value *Data, threadId int64) *ClientMessage {
+func MultiMapPutEncodeRequest(name *string, key *serialization.Data, value *serialization.Data, threadId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MultiMapPutCalculateSize(name, key, value, threadId))
 	clientMessage.SetMessageType(multimapPut)

--- a/internal/protocol/multimap_remove.go
+++ b/internal/protocol/multimap_remove.go
@@ -15,21 +15,21 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func MultiMapRemoveCalculateSize(name *string, key *Data, threadId int64) int {
+func MultiMapRemoveCalculateSize(name *string, key *serialization.Data, threadId int64) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
 	dataSize += DataCalculateSize(key)
-	dataSize += Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
 	return dataSize
 }
 
-func MultiMapRemoveEncodeRequest(name *string, key *Data, threadId int64) *ClientMessage {
+func MultiMapRemoveEncodeRequest(name *string, key *serialization.Data, threadId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MultiMapRemoveCalculateSize(name, key, threadId))
 	clientMessage.SetMessageType(multimapRemove)
@@ -41,11 +41,11 @@ func MultiMapRemoveEncodeRequest(name *string, key *Data, threadId int64) *Clien
 	return clientMessage
 }
 
-func MultiMapRemoveDecodeResponse(clientMessage *ClientMessage) func() (response []*Data) {
+func MultiMapRemoveDecodeResponse(clientMessage *ClientMessage) func() (response []*serialization.Data) {
 	// Decode response from client message
-	return func() (response []*Data) {
+	return func() (response []*serialization.Data) {
 		responseSize := clientMessage.ReadInt32()
-		response = make([]*Data, responseSize)
+		response = make([]*serialization.Data, responseSize)
 		for responseIndex := 0; responseIndex < int(responseSize); responseIndex++ {
 			responseItem := clientMessage.ReadData()
 			response[responseIndex] = responseItem

--- a/internal/protocol/multimap_removeentry.go
+++ b/internal/protocol/multimap_removeentry.go
@@ -15,22 +15,22 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func MultiMapRemoveEntryCalculateSize(name *string, key *Data, value *Data, threadId int64) int {
+func MultiMapRemoveEntryCalculateSize(name *string, key *serialization.Data, value *serialization.Data, threadId int64) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
 	dataSize += DataCalculateSize(key)
 	dataSize += DataCalculateSize(value)
-	dataSize += Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
 	return dataSize
 }
 
-func MultiMapRemoveEntryEncodeRequest(name *string, key *Data, value *Data, threadId int64) *ClientMessage {
+func MultiMapRemoveEntryEncodeRequest(name *string, key *serialization.Data, value *serialization.Data, threadId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MultiMapRemoveEntryCalculateSize(name, key, value, threadId))
 	clientMessage.SetMessageType(multimapRemoveEntry)

--- a/internal/protocol/multimap_trylock.go
+++ b/internal/protocol/multimap_trylock.go
@@ -15,24 +15,24 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func MultiMapTryLockCalculateSize(name *string, key *Data, threadId int64, lease int64, timeout int64, referenceId int64) int {
+func MultiMapTryLockCalculateSize(name *string, key *serialization.Data, threadId int64, lease int64, timeout int64, referenceId int64) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
 	dataSize += DataCalculateSize(key)
-	dataSize += Int64SizeInBytes
-	dataSize += Int64SizeInBytes
-	dataSize += Int64SizeInBytes
-	dataSize += Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
 	return dataSize
 }
 
-func MultiMapTryLockEncodeRequest(name *string, key *Data, threadId int64, lease int64, timeout int64, referenceId int64) *ClientMessage {
+func MultiMapTryLockEncodeRequest(name *string, key *serialization.Data, threadId int64, lease int64, timeout int64, referenceId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MultiMapTryLockCalculateSize(name, key, threadId, lease, timeout, referenceId))
 	clientMessage.SetMessageType(multimapTryLock)

--- a/internal/protocol/multimap_unlock.go
+++ b/internal/protocol/multimap_unlock.go
@@ -15,22 +15,22 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func MultiMapUnlockCalculateSize(name *string, key *Data, threadId int64, referenceId int64) int {
+func MultiMapUnlockCalculateSize(name *string, key *serialization.Data, threadId int64, referenceId int64) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
 	dataSize += DataCalculateSize(key)
-	dataSize += Int64SizeInBytes
-	dataSize += Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
 	return dataSize
 }
 
-func MultiMapUnlockEncodeRequest(name *string, key *Data, threadId int64, referenceId int64) *ClientMessage {
+func MultiMapUnlockEncodeRequest(name *string, key *serialization.Data, threadId int64, referenceId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MultiMapUnlockCalculateSize(name, key, threadId, referenceId))
 	clientMessage.SetMessageType(multimapUnlock)

--- a/internal/protocol/multimap_valuecount.go
+++ b/internal/protocol/multimap_valuecount.go
@@ -15,21 +15,21 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func MultiMapValueCountCalculateSize(name *string, key *Data, threadId int64) int {
+func MultiMapValueCountCalculateSize(name *string, key *serialization.Data, threadId int64) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
 	dataSize += DataCalculateSize(key)
-	dataSize += Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
 	return dataSize
 }
 
-func MultiMapValueCountEncodeRequest(name *string, key *Data, threadId int64) *ClientMessage {
+func MultiMapValueCountEncodeRequest(name *string, key *serialization.Data, threadId int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, MultiMapValueCountCalculateSize(name, key, threadId))
 	clientMessage.SetMessageType(multimapValueCount)

--- a/internal/protocol/multimap_values.go
+++ b/internal/protocol/multimap_values.go
@@ -15,7 +15,7 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
 func MultiMapValuesCalculateSize(name *string) int {
@@ -35,11 +35,11 @@ func MultiMapValuesEncodeRequest(name *string) *ClientMessage {
 	return clientMessage
 }
 
-func MultiMapValuesDecodeResponse(clientMessage *ClientMessage) func() (response []*Data) {
+func MultiMapValuesDecodeResponse(clientMessage *ClientMessage) func() (response []*serialization.Data) {
 	// Decode response from client message
-	return func() (response []*Data) {
+	return func() (response []*serialization.Data) {
 		responseSize := clientMessage.ReadInt32()
-		response = make([]*Data, responseSize)
+		response = make([]*serialization.Data, responseSize)
 		for responseIndex := 0; responseIndex < int(responseSize); responseIndex++ {
 			responseItem := clientMessage.ReadData()
 			response[responseIndex] = responseItem

--- a/internal/protocol/pncounter_add.go
+++ b/internal/protocol/pncounter_add.go
@@ -15,16 +15,16 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
 func PNCounterAddCalculateSize(name *string, delta int64, getBeforeUpdate bool, replicaTimestamps []*Pair, targetReplica *Address) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
-	dataSize += Int64SizeInBytes
-	dataSize += BoolSizeInBytes
-	dataSize += Int32SizeInBytes
+	dataSize += common.Int64SizeInBytes
+	dataSize += common.BoolSizeInBytes
+	dataSize += common.Int32SizeInBytes
 	for _, replicaTimestampsItem := range replicaTimestamps {
 		key := replicaTimestampsItem.key.(*string)
 		val := replicaTimestampsItem.value.(int64)

--- a/internal/protocol/pncounter_get.go
+++ b/internal/protocol/pncounter_get.go
@@ -15,14 +15,14 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
 func PNCounterGetCalculateSize(name *string, replicaTimestamps []*Pair, targetReplica *Address) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
-	dataSize += Int32SizeInBytes
+	dataSize += common.Int32SizeInBytes
 	for _, replicaTimestampsItem := range replicaTimestamps {
 		key := replicaTimestampsItem.key.(*string)
 		val := replicaTimestampsItem.value.(int64)

--- a/internal/protocol/queue_addall.go
+++ b/internal/protocol/queue_addall.go
@@ -15,23 +15,23 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func QueueAddAllCalculateSize(name *string, dataList []*Data) int {
+func QueueAddAllCalculateSize(name *string, dataList []*serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
-	dataSize += Int32SizeInBytes
+	dataSize += common.Int32SizeInBytes
 	for _, dataListItem := range dataList {
 		dataSize += DataCalculateSize(dataListItem)
 	}
 	return dataSize
 }
 
-func QueueAddAllEncodeRequest(name *string, dataList []*Data) *ClientMessage {
+func QueueAddAllEncodeRequest(name *string, dataList []*serialization.Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, QueueAddAllCalculateSize(name, dataList))
 	clientMessage.SetMessageType(queueAddAll)

--- a/internal/protocol/queue_addlistener.go
+++ b/internal/protocol/queue_addlistener.go
@@ -15,17 +15,17 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
 func QueueAddListenerCalculateSize(name *string, includeValue bool, localOnly bool) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
-	dataSize += BoolSizeInBytes
-	dataSize += BoolSizeInBytes
+	dataSize += common.BoolSizeInBytes
+	dataSize += common.BoolSizeInBytes
 	return dataSize
 }
 
@@ -49,9 +49,9 @@ func QueueAddListenerDecodeResponse(clientMessage *ClientMessage) func() (respon
 	}
 }
 
-type QueueAddListenerHandleEventItemFunc func(*Data, *string, int32)
+type QueueAddListenerHandleEventItemFunc func(*serialization.Data, *string, int32)
 
-func QueueAddListenerEventItemDecode(clientMessage *ClientMessage) (item *Data, uuid *string, eventType int32) {
+func QueueAddListenerEventItemDecode(clientMessage *ClientMessage) (item *serialization.Data, uuid *string, eventType int32) {
 
 	if !clientMessage.ReadBool() {
 		item = clientMessage.ReadData()
@@ -65,7 +65,7 @@ func QueueAddListenerHandle(clientMessage *ClientMessage,
 	handleEventItem QueueAddListenerHandleEventItemFunc) {
 	// Event handler
 	messageType := clientMessage.MessageType()
-	if messageType == EventItem && handleEventItem != nil {
+	if messageType == common.EventItem && handleEventItem != nil {
 		handleEventItem(QueueAddListenerEventItemDecode(clientMessage))
 	}
 }

--- a/internal/protocol/queue_compareandremoveall.go
+++ b/internal/protocol/queue_compareandremoveall.go
@@ -15,23 +15,23 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func QueueCompareAndRemoveAllCalculateSize(name *string, dataList []*Data) int {
+func QueueCompareAndRemoveAllCalculateSize(name *string, dataList []*serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
-	dataSize += Int32SizeInBytes
+	dataSize += common.Int32SizeInBytes
 	for _, dataListItem := range dataList {
 		dataSize += DataCalculateSize(dataListItem)
 	}
 	return dataSize
 }
 
-func QueueCompareAndRemoveAllEncodeRequest(name *string, dataList []*Data) *ClientMessage {
+func QueueCompareAndRemoveAllEncodeRequest(name *string, dataList []*serialization.Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, QueueCompareAndRemoveAllCalculateSize(name, dataList))
 	clientMessage.SetMessageType(queueCompareAndRemoveAll)

--- a/internal/protocol/queue_compareandretainall.go
+++ b/internal/protocol/queue_compareandretainall.go
@@ -15,23 +15,23 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func QueueCompareAndRetainAllCalculateSize(name *string, dataList []*Data) int {
+func QueueCompareAndRetainAllCalculateSize(name *string, dataList []*serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
-	dataSize += Int32SizeInBytes
+	dataSize += common.Int32SizeInBytes
 	for _, dataListItem := range dataList {
 		dataSize += DataCalculateSize(dataListItem)
 	}
 	return dataSize
 }
 
-func QueueCompareAndRetainAllEncodeRequest(name *string, dataList []*Data) *ClientMessage {
+func QueueCompareAndRetainAllEncodeRequest(name *string, dataList []*serialization.Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, QueueCompareAndRetainAllCalculateSize(name, dataList))
 	clientMessage.SetMessageType(queueCompareAndRetainAll)

--- a/internal/protocol/queue_contains.go
+++ b/internal/protocol/queue_contains.go
@@ -15,10 +15,10 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
-func QueueContainsCalculateSize(name *string, value *Data) int {
+func QueueContainsCalculateSize(name *string, value *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
@@ -26,7 +26,7 @@ func QueueContainsCalculateSize(name *string, value *Data) int {
 	return dataSize
 }
 
-func QueueContainsEncodeRequest(name *string, value *Data) *ClientMessage {
+func QueueContainsEncodeRequest(name *string, value *serialization.Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, QueueContainsCalculateSize(name, value))
 	clientMessage.SetMessageType(queueContains)

--- a/internal/protocol/queue_containsall.go
+++ b/internal/protocol/queue_containsall.go
@@ -15,23 +15,23 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func QueueContainsAllCalculateSize(name *string, dataList []*Data) int {
+func QueueContainsAllCalculateSize(name *string, dataList []*serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
-	dataSize += Int32SizeInBytes
+	dataSize += common.Int32SizeInBytes
 	for _, dataListItem := range dataList {
 		dataSize += DataCalculateSize(dataListItem)
 	}
 	return dataSize
 }
 
-func QueueContainsAllEncodeRequest(name *string, dataList []*Data) *ClientMessage {
+func QueueContainsAllEncodeRequest(name *string, dataList []*serialization.Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, QueueContainsAllCalculateSize(name, dataList))
 	clientMessage.SetMessageType(queueContainsAll)

--- a/internal/protocol/queue_drainto.go
+++ b/internal/protocol/queue_drainto.go
@@ -15,7 +15,7 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
 func QueueDrainToCalculateSize(name *string) int {
@@ -35,11 +35,11 @@ func QueueDrainToEncodeRequest(name *string) *ClientMessage {
 	return clientMessage
 }
 
-func QueueDrainToDecodeResponse(clientMessage *ClientMessage) func() (response []*Data) {
+func QueueDrainToDecodeResponse(clientMessage *ClientMessage) func() (response []*serialization.Data) {
 	// Decode response from client message
-	return func() (response []*Data) {
+	return func() (response []*serialization.Data) {
 		responseSize := clientMessage.ReadInt32()
-		response = make([]*Data, responseSize)
+		response = make([]*serialization.Data, responseSize)
 		for responseIndex := 0; responseIndex < int(responseSize); responseIndex++ {
 			responseItem := clientMessage.ReadData()
 			response[responseIndex] = responseItem

--- a/internal/protocol/queue_draintomaxsize.go
+++ b/internal/protocol/queue_draintomaxsize.go
@@ -15,15 +15,15 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
 func QueueDrainToMaxSizeCalculateSize(name *string, maxSize int32) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
-	dataSize += Int32SizeInBytes
+	dataSize += common.Int32SizeInBytes
 	return dataSize
 }
 
@@ -38,11 +38,11 @@ func QueueDrainToMaxSizeEncodeRequest(name *string, maxSize int32) *ClientMessag
 	return clientMessage
 }
 
-func QueueDrainToMaxSizeDecodeResponse(clientMessage *ClientMessage) func() (response []*Data) {
+func QueueDrainToMaxSizeDecodeResponse(clientMessage *ClientMessage) func() (response []*serialization.Data) {
 	// Decode response from client message
-	return func() (response []*Data) {
+	return func() (response []*serialization.Data) {
 		responseSize := clientMessage.ReadInt32()
-		response = make([]*Data, responseSize)
+		response = make([]*serialization.Data, responseSize)
 		for responseIndex := 0; responseIndex < int(responseSize); responseIndex++ {
 			responseItem := clientMessage.ReadData()
 			response[responseIndex] = responseItem

--- a/internal/protocol/queue_iterator.go
+++ b/internal/protocol/queue_iterator.go
@@ -15,7 +15,7 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
 func QueueIteratorCalculateSize(name *string) int {
@@ -35,11 +35,11 @@ func QueueIteratorEncodeRequest(name *string) *ClientMessage {
 	return clientMessage
 }
 
-func QueueIteratorDecodeResponse(clientMessage *ClientMessage) func() (response []*Data) {
+func QueueIteratorDecodeResponse(clientMessage *ClientMessage) func() (response []*serialization.Data) {
 	// Decode response from client message
-	return func() (response []*Data) {
+	return func() (response []*serialization.Data) {
 		responseSize := clientMessage.ReadInt32()
-		response = make([]*Data, responseSize)
+		response = make([]*serialization.Data, responseSize)
 		for responseIndex := 0; responseIndex < int(responseSize); responseIndex++ {
 			responseItem := clientMessage.ReadData()
 			response[responseIndex] = responseItem

--- a/internal/protocol/queue_offer.go
+++ b/internal/protocol/queue_offer.go
@@ -15,21 +15,21 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func QueueOfferCalculateSize(name *string, value *Data, timeoutMillis int64) int {
+func QueueOfferCalculateSize(name *string, value *serialization.Data, timeoutMillis int64) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
 	dataSize += DataCalculateSize(value)
-	dataSize += Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
 	return dataSize
 }
 
-func QueueOfferEncodeRequest(name *string, value *Data, timeoutMillis int64) *ClientMessage {
+func QueueOfferEncodeRequest(name *string, value *serialization.Data, timeoutMillis int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, QueueOfferCalculateSize(name, value, timeoutMillis))
 	clientMessage.SetMessageType(queueOffer)

--- a/internal/protocol/queue_peek.go
+++ b/internal/protocol/queue_peek.go
@@ -15,7 +15,7 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
 func QueuePeekCalculateSize(name *string) int {
@@ -35,9 +35,9 @@ func QueuePeekEncodeRequest(name *string) *ClientMessage {
 	return clientMessage
 }
 
-func QueuePeekDecodeResponse(clientMessage *ClientMessage) func() (response *Data) {
+func QueuePeekDecodeResponse(clientMessage *ClientMessage) func() (response *serialization.Data) {
 	// Decode response from client message
-	return func() (response *Data) {
+	return func() (response *serialization.Data) {
 
 		if !clientMessage.ReadBool() {
 			response = clientMessage.ReadData()

--- a/internal/protocol/queue_poll.go
+++ b/internal/protocol/queue_poll.go
@@ -15,15 +15,15 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
 func QueuePollCalculateSize(name *string, timeoutMillis int64) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
-	dataSize += Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
 	return dataSize
 }
 
@@ -38,9 +38,9 @@ func QueuePollEncodeRequest(name *string, timeoutMillis int64) *ClientMessage {
 	return clientMessage
 }
 
-func QueuePollDecodeResponse(clientMessage *ClientMessage) func() (response *Data) {
+func QueuePollDecodeResponse(clientMessage *ClientMessage) func() (response *serialization.Data) {
 	// Decode response from client message
-	return func() (response *Data) {
+	return func() (response *serialization.Data) {
 
 		if !clientMessage.ReadBool() {
 			response = clientMessage.ReadData()

--- a/internal/protocol/queue_put.go
+++ b/internal/protocol/queue_put.go
@@ -15,10 +15,10 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
-func QueuePutCalculateSize(name *string, value *Data) int {
+func QueuePutCalculateSize(name *string, value *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
@@ -26,7 +26,7 @@ func QueuePutCalculateSize(name *string, value *Data) int {
 	return dataSize
 }
 
-func QueuePutEncodeRequest(name *string, value *Data) *ClientMessage {
+func QueuePutEncodeRequest(name *string, value *serialization.Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, QueuePutCalculateSize(name, value))
 	clientMessage.SetMessageType(queuePut)

--- a/internal/protocol/queue_remove.go
+++ b/internal/protocol/queue_remove.go
@@ -15,10 +15,10 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
-func QueueRemoveCalculateSize(name *string, value *Data) int {
+func QueueRemoveCalculateSize(name *string, value *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
@@ -26,7 +26,7 @@ func QueueRemoveCalculateSize(name *string, value *Data) int {
 	return dataSize
 }
 
-func QueueRemoveEncodeRequest(name *string, value *Data) *ClientMessage {
+func QueueRemoveEncodeRequest(name *string, value *serialization.Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, QueueRemoveCalculateSize(name, value))
 	clientMessage.SetMessageType(queueRemove)

--- a/internal/protocol/queue_take.go
+++ b/internal/protocol/queue_take.go
@@ -15,7 +15,7 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
 func QueueTakeCalculateSize(name *string) int {
@@ -35,9 +35,9 @@ func QueueTakeEncodeRequest(name *string) *ClientMessage {
 	return clientMessage
 }
 
-func QueueTakeDecodeResponse(clientMessage *ClientMessage) func() (response *Data) {
+func QueueTakeDecodeResponse(clientMessage *ClientMessage) func() (response *serialization.Data) {
 	// Decode response from client message
-	return func() (response *Data) {
+	return func() (response *serialization.Data) {
 
 		if !clientMessage.ReadBool() {
 			response = clientMessage.ReadData()

--- a/internal/protocol/replicatedmap_addentrylistener.go
+++ b/internal/protocol/replicatedmap_addentrylistener.go
@@ -15,16 +15,16 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
 func ReplicatedMapAddEntryListenerCalculateSize(name *string, localOnly bool) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
-	dataSize += BoolSizeInBytes
+	dataSize += common.BoolSizeInBytes
 	return dataSize
 }
 
@@ -47,9 +47,9 @@ func ReplicatedMapAddEntryListenerDecodeResponse(clientMessage *ClientMessage) f
 	}
 }
 
-type ReplicatedMapAddEntryListenerHandleEventEntryFunc func(*Data, *Data, *Data, *Data, int32, *string, int32)
+type ReplicatedMapAddEntryListenerHandleEventEntryFunc func(*serialization.Data, *serialization.Data, *serialization.Data, *serialization.Data, int32, *string, int32)
 
-func ReplicatedMapAddEntryListenerEventEntryDecode(clientMessage *ClientMessage) (key *Data, value *Data, oldValue *Data, mergingValue *Data, eventType int32, uuid *string, numberOfAffectedEntries int32) {
+func ReplicatedMapAddEntryListenerEventEntryDecode(clientMessage *ClientMessage) (key *serialization.Data, value *serialization.Data, oldValue *serialization.Data, mergingValue *serialization.Data, eventType int32, uuid *string, numberOfAffectedEntries int32) {
 
 	if !clientMessage.ReadBool() {
 		key = clientMessage.ReadData()
@@ -76,7 +76,7 @@ func ReplicatedMapAddEntryListenerHandle(clientMessage *ClientMessage,
 	handleEventEntry ReplicatedMapAddEntryListenerHandleEventEntryFunc) {
 	// Event handler
 	messageType := clientMessage.MessageType()
-	if messageType == EventEntry && handleEventEntry != nil {
+	if messageType == common.EventEntry && handleEventEntry != nil {
 		handleEventEntry(ReplicatedMapAddEntryListenerEventEntryDecode(clientMessage))
 	}
 }

--- a/internal/protocol/replicatedmap_addentrylistenertokey.go
+++ b/internal/protocol/replicatedmap_addentrylistenertokey.go
@@ -15,21 +15,21 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func ReplicatedMapAddEntryListenerToKeyCalculateSize(name *string, key *Data, localOnly bool) int {
+func ReplicatedMapAddEntryListenerToKeyCalculateSize(name *string, key *serialization.Data, localOnly bool) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
 	dataSize += DataCalculateSize(key)
-	dataSize += BoolSizeInBytes
+	dataSize += common.BoolSizeInBytes
 	return dataSize
 }
 
-func ReplicatedMapAddEntryListenerToKeyEncodeRequest(name *string, key *Data, localOnly bool) *ClientMessage {
+func ReplicatedMapAddEntryListenerToKeyEncodeRequest(name *string, key *serialization.Data, localOnly bool) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ReplicatedMapAddEntryListenerToKeyCalculateSize(name, key, localOnly))
 	clientMessage.SetMessageType(replicatedmapAddEntryListenerToKey)
@@ -49,9 +49,9 @@ func ReplicatedMapAddEntryListenerToKeyDecodeResponse(clientMessage *ClientMessa
 	}
 }
 
-type ReplicatedMapAddEntryListenerToKeyHandleEventEntryFunc func(*Data, *Data, *Data, *Data, int32, *string, int32)
+type ReplicatedMapAddEntryListenerToKeyHandleEventEntryFunc func(*serialization.Data, *serialization.Data, *serialization.Data, *serialization.Data, int32, *string, int32)
 
-func ReplicatedMapAddEntryListenerToKeyEventEntryDecode(clientMessage *ClientMessage) (key *Data, value *Data, oldValue *Data, mergingValue *Data, eventType int32, uuid *string, numberOfAffectedEntries int32) {
+func ReplicatedMapAddEntryListenerToKeyEventEntryDecode(clientMessage *ClientMessage) (key *serialization.Data, value *serialization.Data, oldValue *serialization.Data, mergingValue *serialization.Data, eventType int32, uuid *string, numberOfAffectedEntries int32) {
 
 	if !clientMessage.ReadBool() {
 		key = clientMessage.ReadData()
@@ -78,7 +78,7 @@ func ReplicatedMapAddEntryListenerToKeyHandle(clientMessage *ClientMessage,
 	handleEventEntry ReplicatedMapAddEntryListenerToKeyHandleEventEntryFunc) {
 	// Event handler
 	messageType := clientMessage.MessageType()
-	if messageType == EventEntry && handleEventEntry != nil {
+	if messageType == common.EventEntry && handleEventEntry != nil {
 		handleEventEntry(ReplicatedMapAddEntryListenerToKeyEventEntryDecode(clientMessage))
 	}
 }

--- a/internal/protocol/replicatedmap_addentrylistenertokeywithpredicate.go
+++ b/internal/protocol/replicatedmap_addentrylistenertokeywithpredicate.go
@@ -15,22 +15,22 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func ReplicatedMapAddEntryListenerToKeyWithPredicateCalculateSize(name *string, key *Data, predicate *Data, localOnly bool) int {
+func ReplicatedMapAddEntryListenerToKeyWithPredicateCalculateSize(name *string, key *serialization.Data, predicate *serialization.Data, localOnly bool) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
 	dataSize += DataCalculateSize(key)
 	dataSize += DataCalculateSize(predicate)
-	dataSize += BoolSizeInBytes
+	dataSize += common.BoolSizeInBytes
 	return dataSize
 }
 
-func ReplicatedMapAddEntryListenerToKeyWithPredicateEncodeRequest(name *string, key *Data, predicate *Data, localOnly bool) *ClientMessage {
+func ReplicatedMapAddEntryListenerToKeyWithPredicateEncodeRequest(name *string, key *serialization.Data, predicate *serialization.Data, localOnly bool) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ReplicatedMapAddEntryListenerToKeyWithPredicateCalculateSize(name, key, predicate, localOnly))
 	clientMessage.SetMessageType(replicatedmapAddEntryListenerToKeyWithPredicate)
@@ -51,9 +51,9 @@ func ReplicatedMapAddEntryListenerToKeyWithPredicateDecodeResponse(clientMessage
 	}
 }
 
-type ReplicatedMapAddEntryListenerToKeyWithPredicateHandleEventEntryFunc func(*Data, *Data, *Data, *Data, int32, *string, int32)
+type ReplicatedMapAddEntryListenerToKeyWithPredicateHandleEventEntryFunc func(*serialization.Data, *serialization.Data, *serialization.Data, *serialization.Data, int32, *string, int32)
 
-func ReplicatedMapAddEntryListenerToKeyWithPredicateEventEntryDecode(clientMessage *ClientMessage) (key *Data, value *Data, oldValue *Data, mergingValue *Data, eventType int32, uuid *string, numberOfAffectedEntries int32) {
+func ReplicatedMapAddEntryListenerToKeyWithPredicateEventEntryDecode(clientMessage *ClientMessage) (key *serialization.Data, value *serialization.Data, oldValue *serialization.Data, mergingValue *serialization.Data, eventType int32, uuid *string, numberOfAffectedEntries int32) {
 
 	if !clientMessage.ReadBool() {
 		key = clientMessage.ReadData()
@@ -80,7 +80,7 @@ func ReplicatedMapAddEntryListenerToKeyWithPredicateHandle(clientMessage *Client
 	handleEventEntry ReplicatedMapAddEntryListenerToKeyWithPredicateHandleEventEntryFunc) {
 	// Event handler
 	messageType := clientMessage.MessageType()
-	if messageType == EventEntry && handleEventEntry != nil {
+	if messageType == common.EventEntry && handleEventEntry != nil {
 		handleEventEntry(ReplicatedMapAddEntryListenerToKeyWithPredicateEventEntryDecode(clientMessage))
 	}
 }

--- a/internal/protocol/replicatedmap_addentrylistenerwithpredicate.go
+++ b/internal/protocol/replicatedmap_addentrylistenerwithpredicate.go
@@ -15,21 +15,21 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func ReplicatedMapAddEntryListenerWithPredicateCalculateSize(name *string, predicate *Data, localOnly bool) int {
+func ReplicatedMapAddEntryListenerWithPredicateCalculateSize(name *string, predicate *serialization.Data, localOnly bool) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
 	dataSize += DataCalculateSize(predicate)
-	dataSize += BoolSizeInBytes
+	dataSize += common.BoolSizeInBytes
 	return dataSize
 }
 
-func ReplicatedMapAddEntryListenerWithPredicateEncodeRequest(name *string, predicate *Data, localOnly bool) *ClientMessage {
+func ReplicatedMapAddEntryListenerWithPredicateEncodeRequest(name *string, predicate *serialization.Data, localOnly bool) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ReplicatedMapAddEntryListenerWithPredicateCalculateSize(name, predicate, localOnly))
 	clientMessage.SetMessageType(replicatedmapAddEntryListenerWithPredicate)
@@ -49,9 +49,9 @@ func ReplicatedMapAddEntryListenerWithPredicateDecodeResponse(clientMessage *Cli
 	}
 }
 
-type ReplicatedMapAddEntryListenerWithPredicateHandleEventEntryFunc func(*Data, *Data, *Data, *Data, int32, *string, int32)
+type ReplicatedMapAddEntryListenerWithPredicateHandleEventEntryFunc func(*serialization.Data, *serialization.Data, *serialization.Data, *serialization.Data, int32, *string, int32)
 
-func ReplicatedMapAddEntryListenerWithPredicateEventEntryDecode(clientMessage *ClientMessage) (key *Data, value *Data, oldValue *Data, mergingValue *Data, eventType int32, uuid *string, numberOfAffectedEntries int32) {
+func ReplicatedMapAddEntryListenerWithPredicateEventEntryDecode(clientMessage *ClientMessage) (key *serialization.Data, value *serialization.Data, oldValue *serialization.Data, mergingValue *serialization.Data, eventType int32, uuid *string, numberOfAffectedEntries int32) {
 
 	if !clientMessage.ReadBool() {
 		key = clientMessage.ReadData()
@@ -78,7 +78,7 @@ func ReplicatedMapAddEntryListenerWithPredicateHandle(clientMessage *ClientMessa
 	handleEventEntry ReplicatedMapAddEntryListenerWithPredicateHandleEventEntryFunc) {
 	// Event handler
 	messageType := clientMessage.MessageType()
-	if messageType == EventEntry && handleEventEntry != nil {
+	if messageType == common.EventEntry && handleEventEntry != nil {
 		handleEventEntry(ReplicatedMapAddEntryListenerWithPredicateEventEntryDecode(clientMessage))
 	}
 }

--- a/internal/protocol/replicatedmap_addnearcacheentrylistener.go
+++ b/internal/protocol/replicatedmap_addnearcacheentrylistener.go
@@ -15,17 +15,17 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
 func ReplicatedMapAddNearCacheEntryListenerCalculateSize(name *string, includeValue bool, localOnly bool) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
-	dataSize += BoolSizeInBytes
-	dataSize += BoolSizeInBytes
+	dataSize += common.BoolSizeInBytes
+	dataSize += common.BoolSizeInBytes
 	return dataSize
 }
 
@@ -49,9 +49,9 @@ func ReplicatedMapAddNearCacheEntryListenerDecodeResponse(clientMessage *ClientM
 	}
 }
 
-type ReplicatedMapAddNearCacheEntryListenerHandleEventEntryFunc func(*Data, *Data, *Data, *Data, int32, *string, int32)
+type ReplicatedMapAddNearCacheEntryListenerHandleEventEntryFunc func(*serialization.Data, *serialization.Data, *serialization.Data, *serialization.Data, int32, *string, int32)
 
-func ReplicatedMapAddNearCacheEntryListenerEventEntryDecode(clientMessage *ClientMessage) (key *Data, value *Data, oldValue *Data, mergingValue *Data, eventType int32, uuid *string, numberOfAffectedEntries int32) {
+func ReplicatedMapAddNearCacheEntryListenerEventEntryDecode(clientMessage *ClientMessage) (key *serialization.Data, value *serialization.Data, oldValue *serialization.Data, mergingValue *serialization.Data, eventType int32, uuid *string, numberOfAffectedEntries int32) {
 
 	if !clientMessage.ReadBool() {
 		key = clientMessage.ReadData()
@@ -78,7 +78,7 @@ func ReplicatedMapAddNearCacheEntryListenerHandle(clientMessage *ClientMessage,
 	handleEventEntry ReplicatedMapAddNearCacheEntryListenerHandleEventEntryFunc) {
 	// Event handler
 	messageType := clientMessage.MessageType()
-	if messageType == EventEntry && handleEventEntry != nil {
+	if messageType == common.EventEntry && handleEventEntry != nil {
 		handleEventEntry(ReplicatedMapAddNearCacheEntryListenerEventEntryDecode(clientMessage))
 	}
 }

--- a/internal/protocol/replicatedmap_containskey.go
+++ b/internal/protocol/replicatedmap_containskey.go
@@ -15,10 +15,10 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
-func ReplicatedMapContainsKeyCalculateSize(name *string, key *Data) int {
+func ReplicatedMapContainsKeyCalculateSize(name *string, key *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
@@ -26,7 +26,7 @@ func ReplicatedMapContainsKeyCalculateSize(name *string, key *Data) int {
 	return dataSize
 }
 
-func ReplicatedMapContainsKeyEncodeRequest(name *string, key *Data) *ClientMessage {
+func ReplicatedMapContainsKeyEncodeRequest(name *string, key *serialization.Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ReplicatedMapContainsKeyCalculateSize(name, key))
 	clientMessage.SetMessageType(replicatedmapContainsKey)

--- a/internal/protocol/replicatedmap_containsvalue.go
+++ b/internal/protocol/replicatedmap_containsvalue.go
@@ -15,10 +15,10 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
-func ReplicatedMapContainsValueCalculateSize(name *string, value *Data) int {
+func ReplicatedMapContainsValueCalculateSize(name *string, value *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
@@ -26,7 +26,7 @@ func ReplicatedMapContainsValueCalculateSize(name *string, value *Data) int {
 	return dataSize
 }
 
-func ReplicatedMapContainsValueEncodeRequest(name *string, value *Data) *ClientMessage {
+func ReplicatedMapContainsValueEncodeRequest(name *string, value *serialization.Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ReplicatedMapContainsValueCalculateSize(name, value))
 	clientMessage.SetMessageType(replicatedmapContainsValue)

--- a/internal/protocol/replicatedmap_get.go
+++ b/internal/protocol/replicatedmap_get.go
@@ -15,10 +15,10 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
-func ReplicatedMapGetCalculateSize(name *string, key *Data) int {
+func ReplicatedMapGetCalculateSize(name *string, key *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
@@ -26,7 +26,7 @@ func ReplicatedMapGetCalculateSize(name *string, key *Data) int {
 	return dataSize
 }
 
-func ReplicatedMapGetEncodeRequest(name *string, key *Data) *ClientMessage {
+func ReplicatedMapGetEncodeRequest(name *string, key *serialization.Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ReplicatedMapGetCalculateSize(name, key))
 	clientMessage.SetMessageType(replicatedmapGet)
@@ -37,9 +37,9 @@ func ReplicatedMapGetEncodeRequest(name *string, key *Data) *ClientMessage {
 	return clientMessage
 }
 
-func ReplicatedMapGetDecodeResponse(clientMessage *ClientMessage) func() (response *Data) {
+func ReplicatedMapGetDecodeResponse(clientMessage *ClientMessage) func() (response *serialization.Data) {
 	// Decode response from client message
-	return func() (response *Data) {
+	return func() (response *serialization.Data) {
 
 		if !clientMessage.ReadBool() {
 			response = clientMessage.ReadData()

--- a/internal/protocol/replicatedmap_keyset.go
+++ b/internal/protocol/replicatedmap_keyset.go
@@ -15,7 +15,7 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
 func ReplicatedMapKeySetCalculateSize(name *string) int {
@@ -35,11 +35,11 @@ func ReplicatedMapKeySetEncodeRequest(name *string) *ClientMessage {
 	return clientMessage
 }
 
-func ReplicatedMapKeySetDecodeResponse(clientMessage *ClientMessage) func() (response []*Data) {
+func ReplicatedMapKeySetDecodeResponse(clientMessage *ClientMessage) func() (response []*serialization.Data) {
 	// Decode response from client message
-	return func() (response []*Data) {
+	return func() (response []*serialization.Data) {
 		responseSize := clientMessage.ReadInt32()
-		response = make([]*Data, responseSize)
+		response = make([]*serialization.Data, responseSize)
 		for responseIndex := 0; responseIndex < int(responseSize); responseIndex++ {
 			responseItem := clientMessage.ReadData()
 			response[responseIndex] = responseItem

--- a/internal/protocol/replicatedmap_put.go
+++ b/internal/protocol/replicatedmap_put.go
@@ -15,22 +15,22 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func ReplicatedMapPutCalculateSize(name *string, key *Data, value *Data, ttl int64) int {
+func ReplicatedMapPutCalculateSize(name *string, key *serialization.Data, value *serialization.Data, ttl int64) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
 	dataSize += DataCalculateSize(key)
 	dataSize += DataCalculateSize(value)
-	dataSize += Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
 	return dataSize
 }
 
-func ReplicatedMapPutEncodeRequest(name *string, key *Data, value *Data, ttl int64) *ClientMessage {
+func ReplicatedMapPutEncodeRequest(name *string, key *serialization.Data, value *serialization.Data, ttl int64) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ReplicatedMapPutCalculateSize(name, key, value, ttl))
 	clientMessage.SetMessageType(replicatedmapPut)
@@ -43,9 +43,9 @@ func ReplicatedMapPutEncodeRequest(name *string, key *Data, value *Data, ttl int
 	return clientMessage
 }
 
-func ReplicatedMapPutDecodeResponse(clientMessage *ClientMessage) func() (response *Data) {
+func ReplicatedMapPutDecodeResponse(clientMessage *ClientMessage) func() (response *serialization.Data) {
 	// Decode response from client message
-	return func() (response *Data) {
+	return func() (response *serialization.Data) {
 
 		if !clientMessage.ReadBool() {
 			response = clientMessage.ReadData()

--- a/internal/protocol/replicatedmap_putall.go
+++ b/internal/protocol/replicatedmap_putall.go
@@ -15,19 +15,19 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
 func ReplicatedMapPutAllCalculateSize(name *string, entries []*Pair) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
-	dataSize += Int32SizeInBytes
+	dataSize += common.Int32SizeInBytes
 	for _, entriesItem := range entries {
-		key := entriesItem.key.(*Data)
-		val := entriesItem.value.(*Data)
+		key := entriesItem.key.(*serialization.Data)
+		val := entriesItem.value.(*serialization.Data)
 		dataSize += DataCalculateSize(key)
 		dataSize += DataCalculateSize(val)
 	}
@@ -42,8 +42,8 @@ func ReplicatedMapPutAllEncodeRequest(name *string, entries []*Pair) *ClientMess
 	clientMessage.AppendString(name)
 	clientMessage.AppendInt32(int32(len(entries)))
 	for _, entriesItem := range entries {
-		key := entriesItem.key.(*Data)
-		val := entriesItem.value.(*Data)
+		key := entriesItem.key.(*serialization.Data)
+		val := entriesItem.value.(*serialization.Data)
 		clientMessage.AppendData(key)
 		clientMessage.AppendData(val)
 	}

--- a/internal/protocol/replicatedmap_remove.go
+++ b/internal/protocol/replicatedmap_remove.go
@@ -15,10 +15,10 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
-func ReplicatedMapRemoveCalculateSize(name *string, key *Data) int {
+func ReplicatedMapRemoveCalculateSize(name *string, key *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
@@ -26,7 +26,7 @@ func ReplicatedMapRemoveCalculateSize(name *string, key *Data) int {
 	return dataSize
 }
 
-func ReplicatedMapRemoveEncodeRequest(name *string, key *Data) *ClientMessage {
+func ReplicatedMapRemoveEncodeRequest(name *string, key *serialization.Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, ReplicatedMapRemoveCalculateSize(name, key))
 	clientMessage.SetMessageType(replicatedmapRemove)
@@ -37,9 +37,9 @@ func ReplicatedMapRemoveEncodeRequest(name *string, key *Data) *ClientMessage {
 	return clientMessage
 }
 
-func ReplicatedMapRemoveDecodeResponse(clientMessage *ClientMessage) func() (response *Data) {
+func ReplicatedMapRemoveDecodeResponse(clientMessage *ClientMessage) func() (response *serialization.Data) {
 	// Decode response from client message
-	return func() (response *Data) {
+	return func() (response *serialization.Data) {
 
 		if !clientMessage.ReadBool() {
 			response = clientMessage.ReadData()

--- a/internal/protocol/replicatedmap_values.go
+++ b/internal/protocol/replicatedmap_values.go
@@ -15,7 +15,7 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
 func ReplicatedMapValuesCalculateSize(name *string) int {
@@ -35,11 +35,11 @@ func ReplicatedMapValuesEncodeRequest(name *string) *ClientMessage {
 	return clientMessage
 }
 
-func ReplicatedMapValuesDecodeResponse(clientMessage *ClientMessage) func() (response []*Data) {
+func ReplicatedMapValuesDecodeResponse(clientMessage *ClientMessage) func() (response []*serialization.Data) {
 	// Decode response from client message
-	return func() (response []*Data) {
+	return func() (response []*serialization.Data) {
 		responseSize := clientMessage.ReadInt32()
-		response = make([]*Data, responseSize)
+		response = make([]*serialization.Data, responseSize)
 		for responseIndex := 0; responseIndex < int(responseSize); responseIndex++ {
 			responseItem := clientMessage.ReadData()
 			response[responseIndex] = responseItem

--- a/internal/protocol/ringbuffer_add.go
+++ b/internal/protocol/ringbuffer_add.go
@@ -15,21 +15,21 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func RingbufferAddCalculateSize(name *string, overflowPolicy int32, value *Data) int {
+func RingbufferAddCalculateSize(name *string, overflowPolicy int32, value *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
-	dataSize += Int32SizeInBytes
+	dataSize += common.Int32SizeInBytes
 	dataSize += DataCalculateSize(value)
 	return dataSize
 }
 
-func RingbufferAddEncodeRequest(name *string, overflowPolicy int32, value *Data) *ClientMessage {
+func RingbufferAddEncodeRequest(name *string, overflowPolicy int32, value *serialization.Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, RingbufferAddCalculateSize(name, overflowPolicy, value))
 	clientMessage.SetMessageType(ringbufferAdd)

--- a/internal/protocol/ringbuffer_addall.go
+++ b/internal/protocol/ringbuffer_addall.go
@@ -15,24 +15,24 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func RingbufferAddAllCalculateSize(name *string, valueList []*Data, overflowPolicy int32) int {
+func RingbufferAddAllCalculateSize(name *string, valueList []*serialization.Data, overflowPolicy int32) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
-	dataSize += Int32SizeInBytes
+	dataSize += common.Int32SizeInBytes
 	for _, valueListItem := range valueList {
 		dataSize += DataCalculateSize(valueListItem)
 	}
-	dataSize += Int32SizeInBytes
+	dataSize += common.Int32SizeInBytes
 	return dataSize
 }
 
-func RingbufferAddAllEncodeRequest(name *string, valueList []*Data, overflowPolicy int32) *ClientMessage {
+func RingbufferAddAllEncodeRequest(name *string, valueList []*serialization.Data, overflowPolicy int32) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, RingbufferAddAllCalculateSize(name, valueList, overflowPolicy))
 	clientMessage.SetMessageType(ringbufferAddAll)

--- a/internal/protocol/ringbuffer_readmany.go
+++ b/internal/protocol/ringbuffer_readmany.go
@@ -15,26 +15,26 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func RingbufferReadManyCalculateSize(name *string, startSequence int64, minCount int32, maxCount int32, filter *Data) int {
+func RingbufferReadManyCalculateSize(name *string, startSequence int64, minCount int32, maxCount int32, filter *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
-	dataSize += Int64SizeInBytes
-	dataSize += Int32SizeInBytes
-	dataSize += Int32SizeInBytes
-	dataSize += BoolSizeInBytes
+	dataSize += common.Int64SizeInBytes
+	dataSize += common.Int32SizeInBytes
+	dataSize += common.Int32SizeInBytes
+	dataSize += common.BoolSizeInBytes
 	if filter != nil {
 		dataSize += DataCalculateSize(filter)
 	}
 	return dataSize
 }
 
-func RingbufferReadManyEncodeRequest(name *string, startSequence int64, minCount int32, maxCount int32, filter *Data) *ClientMessage {
+func RingbufferReadManyEncodeRequest(name *string, startSequence int64, minCount int32, maxCount int32, filter *serialization.Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, RingbufferReadManyCalculateSize(name, startSequence, minCount, maxCount, filter))
 	clientMessage.SetMessageType(ringbufferReadMany)
@@ -51,12 +51,12 @@ func RingbufferReadManyEncodeRequest(name *string, startSequence int64, minCount
 	return clientMessage
 }
 
-func RingbufferReadManyDecodeResponse(clientMessage *ClientMessage) func() (readCount int32, items []*Data, itemSeqs []int64, nextSeq int64) {
+func RingbufferReadManyDecodeResponse(clientMessage *ClientMessage) func() (readCount int32, items []*serialization.Data, itemSeqs []int64, nextSeq int64) {
 	// Decode response from client message
-	return func() (readCount int32, items []*Data, itemSeqs []int64, nextSeq int64) {
+	return func() (readCount int32, items []*serialization.Data, itemSeqs []int64, nextSeq int64) {
 		readCount = clientMessage.ReadInt32()
 		itemsSize := clientMessage.ReadInt32()
-		items = make([]*Data, itemsSize)
+		items = make([]*serialization.Data, itemsSize)
 		for itemsIndex := 0; itemsIndex < int(itemsSize); itemsIndex++ {
 			itemsItem := clientMessage.ReadData()
 			items[itemsIndex] = itemsItem

--- a/internal/protocol/ringbuffer_readone.go
+++ b/internal/protocol/ringbuffer_readone.go
@@ -15,15 +15,15 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
 func RingbufferReadOneCalculateSize(name *string, sequence int64) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
-	dataSize += Int64SizeInBytes
+	dataSize += common.Int64SizeInBytes
 	return dataSize
 }
 
@@ -38,9 +38,9 @@ func RingbufferReadOneEncodeRequest(name *string, sequence int64) *ClientMessage
 	return clientMessage
 }
 
-func RingbufferReadOneDecodeResponse(clientMessage *ClientMessage) func() (response *Data) {
+func RingbufferReadOneDecodeResponse(clientMessage *ClientMessage) func() (response *serialization.Data) {
 	// Decode response from client message
-	return func() (response *Data) {
+	return func() (response *serialization.Data) {
 
 		if !clientMessage.ReadBool() {
 			response = clientMessage.ReadData()

--- a/internal/protocol/set_add.go
+++ b/internal/protocol/set_add.go
@@ -15,10 +15,10 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
-func SetAddCalculateSize(name *string, value *Data) int {
+func SetAddCalculateSize(name *string, value *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
@@ -26,7 +26,7 @@ func SetAddCalculateSize(name *string, value *Data) int {
 	return dataSize
 }
 
-func SetAddEncodeRequest(name *string, value *Data) *ClientMessage {
+func SetAddEncodeRequest(name *string, value *serialization.Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, SetAddCalculateSize(name, value))
 	clientMessage.SetMessageType(setAdd)

--- a/internal/protocol/set_addall.go
+++ b/internal/protocol/set_addall.go
@@ -15,23 +15,23 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func SetAddAllCalculateSize(name *string, valueList []*Data) int {
+func SetAddAllCalculateSize(name *string, valueList []*serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
-	dataSize += Int32SizeInBytes
+	dataSize += common.Int32SizeInBytes
 	for _, valueListItem := range valueList {
 		dataSize += DataCalculateSize(valueListItem)
 	}
 	return dataSize
 }
 
-func SetAddAllEncodeRequest(name *string, valueList []*Data) *ClientMessage {
+func SetAddAllEncodeRequest(name *string, valueList []*serialization.Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, SetAddAllCalculateSize(name, valueList))
 	clientMessage.SetMessageType(setAddAll)

--- a/internal/protocol/set_addlistener.go
+++ b/internal/protocol/set_addlistener.go
@@ -15,17 +15,17 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
 func SetAddListenerCalculateSize(name *string, includeValue bool, localOnly bool) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
-	dataSize += BoolSizeInBytes
-	dataSize += BoolSizeInBytes
+	dataSize += common.BoolSizeInBytes
+	dataSize += common.BoolSizeInBytes
 	return dataSize
 }
 
@@ -49,9 +49,9 @@ func SetAddListenerDecodeResponse(clientMessage *ClientMessage) func() (response
 	}
 }
 
-type SetAddListenerHandleEventItemFunc func(*Data, *string, int32)
+type SetAddListenerHandleEventItemFunc func(*serialization.Data, *string, int32)
 
-func SetAddListenerEventItemDecode(clientMessage *ClientMessage) (item *Data, uuid *string, eventType int32) {
+func SetAddListenerEventItemDecode(clientMessage *ClientMessage) (item *serialization.Data, uuid *string, eventType int32) {
 
 	if !clientMessage.ReadBool() {
 		item = clientMessage.ReadData()
@@ -65,7 +65,7 @@ func SetAddListenerHandle(clientMessage *ClientMessage,
 	handleEventItem SetAddListenerHandleEventItemFunc) {
 	// Event handler
 	messageType := clientMessage.MessageType()
-	if messageType == EventItem && handleEventItem != nil {
+	if messageType == common.EventItem && handleEventItem != nil {
 		handleEventItem(SetAddListenerEventItemDecode(clientMessage))
 	}
 }

--- a/internal/protocol/set_compareandremoveall.go
+++ b/internal/protocol/set_compareandremoveall.go
@@ -15,23 +15,23 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func SetCompareAndRemoveAllCalculateSize(name *string, values []*Data) int {
+func SetCompareAndRemoveAllCalculateSize(name *string, values []*serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
-	dataSize += Int32SizeInBytes
+	dataSize += common.Int32SizeInBytes
 	for _, valuesItem := range values {
 		dataSize += DataCalculateSize(valuesItem)
 	}
 	return dataSize
 }
 
-func SetCompareAndRemoveAllEncodeRequest(name *string, values []*Data) *ClientMessage {
+func SetCompareAndRemoveAllEncodeRequest(name *string, values []*serialization.Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, SetCompareAndRemoveAllCalculateSize(name, values))
 	clientMessage.SetMessageType(setCompareAndRemoveAll)

--- a/internal/protocol/set_compareandretainall.go
+++ b/internal/protocol/set_compareandretainall.go
@@ -15,23 +15,23 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func SetCompareAndRetainAllCalculateSize(name *string, values []*Data) int {
+func SetCompareAndRetainAllCalculateSize(name *string, values []*serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
-	dataSize += Int32SizeInBytes
+	dataSize += common.Int32SizeInBytes
 	for _, valuesItem := range values {
 		dataSize += DataCalculateSize(valuesItem)
 	}
 	return dataSize
 }
 
-func SetCompareAndRetainAllEncodeRequest(name *string, values []*Data) *ClientMessage {
+func SetCompareAndRetainAllEncodeRequest(name *string, values []*serialization.Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, SetCompareAndRetainAllCalculateSize(name, values))
 	clientMessage.SetMessageType(setCompareAndRetainAll)

--- a/internal/protocol/set_contains.go
+++ b/internal/protocol/set_contains.go
@@ -15,10 +15,10 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
-func SetContainsCalculateSize(name *string, value *Data) int {
+func SetContainsCalculateSize(name *string, value *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
@@ -26,7 +26,7 @@ func SetContainsCalculateSize(name *string, value *Data) int {
 	return dataSize
 }
 
-func SetContainsEncodeRequest(name *string, value *Data) *ClientMessage {
+func SetContainsEncodeRequest(name *string, value *serialization.Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, SetContainsCalculateSize(name, value))
 	clientMessage.SetMessageType(setContains)

--- a/internal/protocol/set_containsall.go
+++ b/internal/protocol/set_containsall.go
@@ -15,23 +15,23 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
-func SetContainsAllCalculateSize(name *string, items []*Data) int {
+func SetContainsAllCalculateSize(name *string, items []*serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
-	dataSize += Int32SizeInBytes
+	dataSize += common.Int32SizeInBytes
 	for _, itemsItem := range items {
 		dataSize += DataCalculateSize(itemsItem)
 	}
 	return dataSize
 }
 
-func SetContainsAllEncodeRequest(name *string, items []*Data) *ClientMessage {
+func SetContainsAllEncodeRequest(name *string, items []*serialization.Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, SetContainsAllCalculateSize(name, items))
 	clientMessage.SetMessageType(setContainsAll)

--- a/internal/protocol/set_getall.go
+++ b/internal/protocol/set_getall.go
@@ -15,7 +15,7 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
 func SetGetAllCalculateSize(name *string) int {
@@ -35,11 +35,11 @@ func SetGetAllEncodeRequest(name *string) *ClientMessage {
 	return clientMessage
 }
 
-func SetGetAllDecodeResponse(clientMessage *ClientMessage) func() (response []*Data) {
+func SetGetAllDecodeResponse(clientMessage *ClientMessage) func() (response []*serialization.Data) {
 	// Decode response from client message
-	return func() (response []*Data) {
+	return func() (response []*serialization.Data) {
 		responseSize := clientMessage.ReadInt32()
-		response = make([]*Data, responseSize)
+		response = make([]*serialization.Data, responseSize)
 		for responseIndex := 0; responseIndex < int(responseSize); responseIndex++ {
 			responseItem := clientMessage.ReadData()
 			response[responseIndex] = responseItem

--- a/internal/protocol/set_remove.go
+++ b/internal/protocol/set_remove.go
@@ -15,10 +15,10 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
-func SetRemoveCalculateSize(name *string, value *Data) int {
+func SetRemoveCalculateSize(name *string, value *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
@@ -26,7 +26,7 @@ func SetRemoveCalculateSize(name *string, value *Data) int {
 	return dataSize
 }
 
-func SetRemoveEncodeRequest(name *string, value *Data) *ClientMessage {
+func SetRemoveEncodeRequest(name *string, value *serialization.Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, SetRemoveCalculateSize(name, value))
 	clientMessage.SetMessageType(setRemove)

--- a/internal/protocol/topic_addmessagelistener.go
+++ b/internal/protocol/topic_addmessagelistener.go
@@ -15,16 +15,16 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 )
 
 func TopicAddMessageListenerCalculateSize(name *string, localOnly bool) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
-	dataSize += BoolSizeInBytes
+	dataSize += common.BoolSizeInBytes
 	return dataSize
 }
 
@@ -47,9 +47,9 @@ func TopicAddMessageListenerDecodeResponse(clientMessage *ClientMessage) func() 
 	}
 }
 
-type TopicAddMessageListenerHandleEventTopicFunc func(*Data, int64, *string)
+type TopicAddMessageListenerHandleEventTopicFunc func(*serialization.Data, int64, *string)
 
-func TopicAddMessageListenerEventTopicDecode(clientMessage *ClientMessage) (item *Data, publishTime int64, uuid *string) {
+func TopicAddMessageListenerEventTopicDecode(clientMessage *ClientMessage) (item *serialization.Data, publishTime int64, uuid *string) {
 	item = clientMessage.ReadData()
 	publishTime = clientMessage.ReadInt64()
 	uuid = clientMessage.ReadString()
@@ -60,7 +60,7 @@ func TopicAddMessageListenerHandle(clientMessage *ClientMessage,
 	handleEventTopic TopicAddMessageListenerHandleEventTopicFunc) {
 	// Event handler
 	messageType := clientMessage.MessageType()
-	if messageType == EventTopic && handleEventTopic != nil {
+	if messageType == common.EventTopic && handleEventTopic != nil {
 		handleEventTopic(TopicAddMessageListenerEventTopicDecode(clientMessage))
 	}
 }

--- a/internal/protocol/topic_publish.go
+++ b/internal/protocol/topic_publish.go
@@ -15,10 +15,10 @@
 package protocol
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
-func TopicPublishCalculateSize(name *string, message *Data) int {
+func TopicPublishCalculateSize(name *string, message *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
 	dataSize += StringCalculateSize(name)
@@ -26,7 +26,7 @@ func TopicPublishCalculateSize(name *string, message *Data) int {
 	return dataSize
 }
 
-func TopicPublishEncodeRequest(name *string, message *Data) *ClientMessage {
+func TopicPublishEncodeRequest(name *string, message *serialization.Data) *ClientMessage {
 	// Encode request into clientMessage
 	clientMessage := NewClientMessage(nil, TopicPublishCalculateSize(name, message))
 	clientMessage.SetMessageType(topicPublish)

--- a/internal/proxy.go
+++ b/internal/proxy.go
@@ -16,10 +16,10 @@ package internal
 
 import (
 	"github.com/hazelcast/hazelcast-go-client/core"
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 	"github.com/hazelcast/hazelcast-go-client/internal/common/collection"
-	. "github.com/hazelcast/hazelcast-go-client/internal/protocol"
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
 const (
@@ -49,20 +49,20 @@ func (proxy *proxy) ServiceName() string {
 	return *proxy.serviceName
 }
 
-func (proxy *proxy) validateAndSerialize(arg1 interface{}) (arg1Data *Data, err error) {
+func (proxy *proxy) validateAndSerialize(arg1 interface{}) (arg1Data *serialization.Data, err error) {
 	if arg1 == nil {
-		return nil, core.NewHazelcastNilPointerError(NilArgIsNotAllowed, nil)
+		return nil, core.NewHazelcastNilPointerError(common.NilArgIsNotAllowed, nil)
 	}
 	arg1Data, err = proxy.toData(arg1)
 	return
 }
 
-func (proxy *proxy) validateAndSerialize2(arg1 interface{}, arg2 interface{}) (arg1Data *Data, arg2Data *Data, err error) {
+func (proxy *proxy) validateAndSerialize2(arg1 interface{}, arg2 interface{}) (arg1Data *serialization.Data, arg2Data *serialization.Data, err error) {
 	if arg1 == nil {
-		return nil, nil, core.NewHazelcastNilPointerError(NilArgIsNotAllowed, nil)
+		return nil, nil, core.NewHazelcastNilPointerError(common.NilArgIsNotAllowed, nil)
 	}
 	if arg2 == nil {
-		return nil, nil, core.NewHazelcastNilPointerError(NilArgIsNotAllowed, nil)
+		return nil, nil, core.NewHazelcastNilPointerError(common.NilArgIsNotAllowed, nil)
 	}
 	arg1Data, err = proxy.toData(arg1)
 	if err != nil {
@@ -72,12 +72,12 @@ func (proxy *proxy) validateAndSerialize2(arg1 interface{}, arg2 interface{}) (a
 	return
 }
 
-func (proxy *proxy) validateAndSerialize3(arg1 interface{}, arg2 interface{}, arg3 interface{}) (arg1Data *Data, arg2Data *Data, arg3Data *Data, err error) {
+func (proxy *proxy) validateAndSerialize3(arg1 interface{}, arg2 interface{}, arg3 interface{}) (arg1Data *serialization.Data, arg2Data *serialization.Data, arg3Data *serialization.Data, err error) {
 	if arg1 == nil {
-		return nil, nil, nil, core.NewHazelcastNilPointerError(NilArgIsNotAllowed, nil)
+		return nil, nil, nil, core.NewHazelcastNilPointerError(common.NilArgIsNotAllowed, nil)
 	}
 	if arg2 == nil || arg3 == nil {
-		return nil, nil, nil, core.NewHazelcastNilPointerError(NilArgIsNotAllowed, nil)
+		return nil, nil, nil, core.NewHazelcastNilPointerError(common.NilArgIsNotAllowed, nil)
 	}
 	arg1Data, err = proxy.toData(arg1)
 	if err != nil {
@@ -91,105 +91,105 @@ func (proxy *proxy) validateAndSerialize3(arg1 interface{}, arg2 interface{}, ar
 	return
 }
 
-func (proxy *proxy) validateAndSerializePredicate(arg1 interface{}) (arg1Data *Data, err error) {
+func (proxy *proxy) validateAndSerializePredicate(arg1 interface{}) (arg1Data *serialization.Data, err error) {
 	if arg1 == nil {
-		return nil, core.NewHazelcastSerializationError(NilPredicateIsNotAllowed, nil)
+		return nil, core.NewHazelcastSerializationError(common.NilPredicateIsNotAllowed, nil)
 	}
 	arg1Data, err = proxy.toData(arg1)
 	return
 }
 
-func (proxy *proxy) validateAndSerializeSlice(elements []interface{}) (elementsData []*Data, err error) {
+func (proxy *proxy) validateAndSerializeSlice(elements []interface{}) (elementsData []*serialization.Data, err error) {
 	if elements == nil {
-		return nil, core.NewHazelcastSerializationError(NilSliceIsNotAllowed, nil)
+		return nil, core.NewHazelcastSerializationError(common.NilSliceIsNotAllowed, nil)
 	}
 	elementsData, err = collection.ObjectToDataCollection(elements, proxy.client.SerializationService)
 	return
 }
 
-func (proxy *proxy) validateAndSerializeMapAndGetPartitions(entries map[interface{}]interface{}) (map[int32][]*Pair, error) {
+func (proxy *proxy) validateAndSerializeMapAndGetPartitions(entries map[interface{}]interface{}) (map[int32][]*protocol.Pair, error) {
 	if entries == nil {
-		return nil, core.NewHazelcastNilPointerError(NilMapIsNotAllowed, nil)
+		return nil, core.NewHazelcastNilPointerError(common.NilMapIsNotAllowed, nil)
 	}
-	partitions := make(map[int32][]*Pair)
+	partitions := make(map[int32][]*protocol.Pair)
 	for key, value := range entries {
 		keyData, valueData, err := proxy.validateAndSerialize2(key, value)
 		if err != nil {
 			return nil, err
 		}
-		pair := NewPair(keyData, valueData)
+		pair := protocol.NewPair(keyData, valueData)
 		partitionId := proxy.client.PartitionService.GetPartitionId(keyData)
 		partitions[partitionId] = append(partitions[partitionId], pair)
 	}
 	return partitions, nil
 }
 
-func (proxy *proxy) invokeOnKey(request *ClientMessage, keyData *Data) (*ClientMessage, error) {
+func (proxy *proxy) invokeOnKey(request *protocol.ClientMessage, keyData *serialization.Data) (*protocol.ClientMessage, error) {
 	return proxy.client.InvocationService.invokeOnKeyOwner(request, keyData).Result()
 }
 
-func (proxy *proxy) invokeOnRandomTarget(request *ClientMessage) (*ClientMessage, error) {
+func (proxy *proxy) invokeOnRandomTarget(request *protocol.ClientMessage) (*protocol.ClientMessage, error) {
 	return proxy.client.InvocationService.invokeOnRandomTarget(request).Result()
 }
 
-func (proxy *proxy) invokeOnPartition(request *ClientMessage, partitionId int32) (*ClientMessage, error) {
+func (proxy *proxy) invokeOnPartition(request *protocol.ClientMessage, partitionId int32) (*protocol.ClientMessage, error) {
 	return proxy.client.InvocationService.invokeOnPartitionOwner(request, partitionId).Result()
 }
 
-func (proxy *proxy) invokeOnAddress(request *ClientMessage, address *Address) (*ClientMessage, error) {
+func (proxy *proxy) invokeOnAddress(request *protocol.ClientMessage, address *protocol.Address) (*protocol.ClientMessage, error) {
 	return proxy.client.InvocationService.invokeOnTarget(request, address).Result()
 }
 
-func (proxy *proxy) toObject(data *Data) (interface{}, error) {
+func (proxy *proxy) toObject(data *serialization.Data) (interface{}, error) {
 	return proxy.client.SerializationService.ToObject(data)
 }
 
-func (proxy *proxy) toData(object interface{}) (*Data, error) {
+func (proxy *proxy) toData(object interface{}) (*serialization.Data, error) {
 	return proxy.client.SerializationService.ToData(object)
 }
 
-func (proxy *proxy) decodeToObjectAndError(responseMessage *ClientMessage, inputError error,
-	decodeFunc func(*ClientMessage) func() *Data) (response interface{}, err error) {
+func (proxy *proxy) decodeToObjectAndError(responseMessage *protocol.ClientMessage, inputError error,
+	decodeFunc func(*protocol.ClientMessage) func() *serialization.Data) (response interface{}, err error) {
 	if inputError != nil {
 		return nil, inputError
 	}
 	return proxy.toObject(decodeFunc(responseMessage)())
 }
 
-func (proxy *proxy) decodeToBoolAndError(responseMessage *ClientMessage, inputError error,
-	decodeFunc func(*ClientMessage) func() bool) (response bool, err error) {
+func (proxy *proxy) decodeToBoolAndError(responseMessage *protocol.ClientMessage, inputError error,
+	decodeFunc func(*protocol.ClientMessage) func() bool) (response bool, err error) {
 	if inputError != nil {
 		return false, inputError
 	}
 	return decodeFunc(responseMessage)(), nil
 }
 
-func (proxy *proxy) decodeToInterfaceSliceAndError(responseMessage *ClientMessage, inputError error,
-	decodeFunc func(*ClientMessage) func() []*Data) (response []interface{}, err error) {
+func (proxy *proxy) decodeToInterfaceSliceAndError(responseMessage *protocol.ClientMessage, inputError error,
+	decodeFunc func(*protocol.ClientMessage) func() []*serialization.Data) (response []interface{}, err error) {
 	if inputError != nil {
 		return nil, inputError
 	}
 	return collection.DataToObjectCollection(decodeFunc(responseMessage)(), proxy.client.SerializationService)
 }
 
-func (proxy *proxy) decodeToPairSliceAndError(responseMessage *ClientMessage, inputError error,
-	decodeFunc func(*ClientMessage) func() []*Pair) (response []core.IPair, err error) {
+func (proxy *proxy) decodeToPairSliceAndError(responseMessage *protocol.ClientMessage, inputError error,
+	decodeFunc func(*protocol.ClientMessage) func() []*protocol.Pair) (response []core.IPair, err error) {
 	if inputError != nil {
 		return nil, inputError
 	}
 	return collection.DataToObjectPairCollection(decodeFunc(responseMessage)(), proxy.client.SerializationService)
 }
 
-func (proxy *proxy) decodeToInt32AndError(responseMessage *ClientMessage, inputError error,
-	decodeFunc func(*ClientMessage) func() int32) (response int32, err error) {
+func (proxy *proxy) decodeToInt32AndError(responseMessage *protocol.ClientMessage, inputError error,
+	decodeFunc func(*protocol.ClientMessage) func() int32) (response int32, err error) {
 	if inputError != nil {
 		return 0, inputError
 	}
 	return decodeFunc(responseMessage)(), nil
 }
 
-func (proxy *proxy) decodeToInt64AndError(responseMessage *ClientMessage, inputError error,
-	decodeFunc func(*ClientMessage) func() int64) (response int64, err error) {
+func (proxy *proxy) decodeToInt64AndError(responseMessage *protocol.ClientMessage, inputError error,
+	decodeFunc func(*protocol.ClientMessage) func() int64) (response int64, err error) {
 	if inputError != nil {
 		return 0, inputError
 	}
@@ -209,21 +209,21 @@ func newPartitionSpecificProxy(client *HazelcastClient, serviceName *string, nam
 
 }
 
-func (parSpecProxy *partitionSpecificProxy) invoke(request *ClientMessage) (*ClientMessage, error) {
+func (parSpecProxy *partitionSpecificProxy) invoke(request *protocol.ClientMessage) (*protocol.ClientMessage, error) {
 	return parSpecProxy.invokeOnPartition(request, parSpecProxy.partitionId)
 }
 
-func (proxy *proxy) createOnItemEvent(listener interface{}) func(itemData *Data, uuid *string, eventType int32) {
-	return func(itemData *Data, uuid *string, eventType int32) {
+func (proxy *proxy) createOnItemEvent(listener interface{}) func(itemData *serialization.Data, uuid *string, eventType int32) {
+	return func(itemData *serialization.Data, uuid *string, eventType int32) {
 		var item interface{}
 		item, _ = proxy.toObject(itemData)
 		member := proxy.client.ClusterService.GetMemberByUuid(*uuid)
-		itemEvent := NewItemEvent(proxy.name, item, eventType, member.(*Member))
-		if eventType == ItemAdded {
+		itemEvent := protocol.NewItemEvent(proxy.name, item, eventType, member.(*protocol.Member))
+		if eventType == common.ItemAdded {
 			if _, ok := listener.(core.ItemAddedListener); ok {
 				listener.(core.ItemAddedListener).ItemAdded(itemEvent)
 			}
-		} else if eventType == ItemRemoved {
+		} else if eventType == common.ItemRemoved {
 			if _, ok := listener.(core.ItemRemovedListener); ok {
 				listener.(core.ItemRemovedListener).ItemRemoved(itemEvent)
 			}

--- a/internal/proxy_manager.go
+++ b/internal/proxy_manager.go
@@ -17,7 +17,7 @@ package internal
 import (
 	"github.com/hazelcast/hazelcast-go-client/core"
 	"github.com/hazelcast/hazelcast-go-client/internal/common"
-	. "github.com/hazelcast/hazelcast-go-client/internal/protocol"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol"
 	"sync"
 	"sync/atomic"
 )
@@ -60,7 +60,7 @@ func (proxyManager *proxyManager) getOrCreateProxy(serviceName string, name stri
 }
 
 func (proxyManager *proxyManager) createProxy(serviceName *string, name *string) (core.IDistributedObject, error) {
-	message := ClientCreateProxyEncodeRequest(name, serviceName, proxyManager.findNextProxyAddress())
+	message := protocol.ClientCreateProxyEncodeRequest(name, serviceName, proxyManager.findNextProxyAddress())
 	_, err := proxyManager.client.InvocationService.invokeOnRandomTarget(message).Result()
 	if err != nil {
 		return nil, err
@@ -76,7 +76,7 @@ func (proxyManager *proxyManager) destroyProxy(serviceName *string, name *string
 		proxyManager.mu.Lock()
 		delete(proxyManager.proxies, ns)
 		proxyManager.mu.Unlock()
-		message := ClientDestroyProxyEncodeRequest(name, serviceName)
+		message := protocol.ClientDestroyProxyEncodeRequest(name, serviceName)
 		_, err := proxyManager.client.InvocationService.invokeOnRandomTarget(message).Result()
 		if err != nil {
 			return false, err
@@ -87,7 +87,7 @@ func (proxyManager *proxyManager) destroyProxy(serviceName *string, name *string
 	return false, nil
 }
 
-func (proxyManager *proxyManager) findNextProxyAddress() *Address {
+func (proxyManager *proxyManager) findNextProxyAddress() *protocol.Address {
 	return proxyManager.client.LoadBalancer.nextAddress()
 }
 

--- a/internal/queue.go
+++ b/internal/queue.go
@@ -16,9 +16,9 @@ package internal
 
 import (
 	"github.com/hazelcast/hazelcast-go-client/core"
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
-	. "github.com/hazelcast/hazelcast-go-client/internal/protocol"
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 	"time"
 )
 
@@ -39,24 +39,24 @@ func (queue *QueueProxy) AddAll(items []interface{}) (changed bool, err error) {
 	if err != nil {
 		return false, err
 	}
-	request := QueueAddAllEncodeRequest(queue.name, itemData)
+	request := protocol.QueueAddAllEncodeRequest(queue.name, itemData)
 	responseMessage, err := queue.invoke(request)
-	return queue.decodeToBoolAndError(responseMessage, err, QueueAddAllDecodeResponse)
+	return queue.decodeToBoolAndError(responseMessage, err, protocol.QueueAddAllDecodeResponse)
 }
 
 func (queue *QueueProxy) AddItemListener(listener interface{}, includeValue bool) (registrationID *string, err error) {
-	request := QueueAddListenerEncodeRequest(queue.name, includeValue, false)
+	request := protocol.QueueAddListenerEncodeRequest(queue.name, includeValue, false)
 	eventHandler := queue.createEventHandler(listener)
 	return queue.client.ListenerService.registerListener(request, eventHandler,
-		func(registrationId *string) *ClientMessage {
-			return QueueRemoveListenerEncodeRequest(queue.name, registrationId)
-		}, func(clientMessage *ClientMessage) *string {
-			return QueueAddListenerDecodeResponse(clientMessage)()
+		func(registrationId *string) *protocol.ClientMessage {
+			return protocol.QueueRemoveListenerEncodeRequest(queue.name, registrationId)
+		}, func(clientMessage *protocol.ClientMessage) *string {
+			return protocol.QueueAddListenerDecodeResponse(clientMessage)()
 		})
 }
 
 func (queue *QueueProxy) Clear() (err error) {
-	request := QueueClearEncodeRequest(queue.name)
+	request := protocol.QueueClearEncodeRequest(queue.name)
 	_, err = queue.invoke(request)
 	return err
 }
@@ -66,9 +66,9 @@ func (queue *QueueProxy) Contains(item interface{}) (found bool, err error) {
 	if err != nil {
 		return false, err
 	}
-	request := QueueContainsEncodeRequest(queue.name, elementData)
+	request := protocol.QueueContainsEncodeRequest(queue.name, elementData)
 	responseMessage, err := queue.invoke(request)
-	return queue.decodeToBoolAndError(responseMessage, err, QueueContainsDecodeResponse)
+	return queue.decodeToBoolAndError(responseMessage, err, protocol.QueueContainsDecodeResponse)
 }
 
 func (queue *QueueProxy) ContainsAll(items []interface{}) (foundAll bool, err error) {
@@ -76,18 +76,18 @@ func (queue *QueueProxy) ContainsAll(items []interface{}) (foundAll bool, err er
 	if err != nil {
 		return false, err
 	}
-	request := QueueContainsAllEncodeRequest(queue.name, itemData)
+	request := protocol.QueueContainsAllEncodeRequest(queue.name, itemData)
 	responseMessage, err := queue.invoke(request)
-	return queue.decodeToBoolAndError(responseMessage, err, QueueContainsAllDecodeResponse)
+	return queue.decodeToBoolAndError(responseMessage, err, protocol.QueueContainsAllDecodeResponse)
 }
 
 func (queue *QueueProxy) DrainTo(slice *[]interface{}) (movedAmount int32, err error) {
 	if slice == nil {
-		return 0, core.NewHazelcastNilPointerError(NilSliceIsNotAllowed, nil)
+		return 0, core.NewHazelcastNilPointerError(common.NilSliceIsNotAllowed, nil)
 	}
-	request := QueueDrainToEncodeRequest(queue.name)
+	request := protocol.QueueDrainToEncodeRequest(queue.name)
 	responseMessage, err := queue.invoke(request)
-	resultSlice, err := queue.decodeToInterfaceSliceAndError(responseMessage, err, QueueDrainToDecodeResponse)
+	resultSlice, err := queue.decodeToInterfaceSliceAndError(responseMessage, err, protocol.QueueDrainToDecodeResponse)
 	if err != nil {
 		return 0, err
 	}
@@ -97,11 +97,11 @@ func (queue *QueueProxy) DrainTo(slice *[]interface{}) (movedAmount int32, err e
 
 func (queue *QueueProxy) DrainToWithMaxSize(slice *[]interface{}, maxElements int32) (movedAmount int32, err error) {
 	if slice == nil {
-		return 0, core.NewHazelcastNilPointerError(NilSliceIsNotAllowed, nil)
+		return 0, core.NewHazelcastNilPointerError(common.NilSliceIsNotAllowed, nil)
 	}
-	request := QueueDrainToMaxSizeEncodeRequest(queue.name, maxElements)
+	request := protocol.QueueDrainToMaxSizeEncodeRequest(queue.name, maxElements)
 	responseMessage, err := queue.invoke(request)
-	resultSlice, err := queue.decodeToInterfaceSliceAndError(responseMessage, err, QueueDrainToMaxSizeDecodeResponse)
+	resultSlice, err := queue.decodeToInterfaceSliceAndError(responseMessage, err, protocol.QueueDrainToMaxSizeDecodeResponse)
 	if err != nil {
 		return 0, err
 	}
@@ -110,9 +110,9 @@ func (queue *QueueProxy) DrainToWithMaxSize(slice *[]interface{}, maxElements in
 }
 
 func (queue *QueueProxy) IsEmpty() (empty bool, err error) {
-	request := QueueIsEmptyEncodeRequest(queue.name)
+	request := protocol.QueueIsEmptyEncodeRequest(queue.name)
 	responseMessage, err := queue.invoke(request)
-	return queue.decodeToBoolAndError(responseMessage, err, QueueIsEmptyDecodeResponse)
+	return queue.decodeToBoolAndError(responseMessage, err, protocol.QueueIsEmptyDecodeResponse)
 }
 
 func (queue *QueueProxy) Offer(item interface{}) (added bool, err error) {
@@ -120,9 +120,9 @@ func (queue *QueueProxy) Offer(item interface{}) (added bool, err error) {
 	if err != nil {
 		return false, err
 	}
-	request := QueueOfferEncodeRequest(queue.name, itemData, 0)
+	request := protocol.QueueOfferEncodeRequest(queue.name, itemData, 0)
 	responseMessage, err := queue.invoke(request)
-	return queue.decodeToBoolAndError(responseMessage, err, QueueOfferDecodeResponse)
+	return queue.decodeToBoolAndError(responseMessage, err, protocol.QueueOfferDecodeResponse)
 }
 
 func (queue *QueueProxy) OfferWithTimeout(item interface{}, timeout int64, timeoutUnit time.Duration) (added bool, err error) {
@@ -130,29 +130,29 @@ func (queue *QueueProxy) OfferWithTimeout(item interface{}, timeout int64, timeo
 	if err != nil {
 		return false, err
 	}
-	timeoutInMilliSeconds := GetTimeInMilliSeconds(timeout, timeoutUnit)
-	request := QueueOfferEncodeRequest(queue.name, itemData, timeoutInMilliSeconds)
+	timeoutInMilliSeconds := common.GetTimeInMilliSeconds(timeout, timeoutUnit)
+	request := protocol.QueueOfferEncodeRequest(queue.name, itemData, timeoutInMilliSeconds)
 	responseMessage, err := queue.invoke(request)
-	return queue.decodeToBoolAndError(responseMessage, err, QueueOfferDecodeResponse)
+	return queue.decodeToBoolAndError(responseMessage, err, protocol.QueueOfferDecodeResponse)
 }
 
 func (queue *QueueProxy) Peek() (item interface{}, err error) {
-	request := QueuePeekEncodeRequest(queue.name)
+	request := protocol.QueuePeekEncodeRequest(queue.name)
 	responseMessage, err := queue.invoke(request)
-	return queue.decodeToObjectAndError(responseMessage, err, QueuePeekDecodeResponse)
+	return queue.decodeToObjectAndError(responseMessage, err, protocol.QueuePeekDecodeResponse)
 }
 
 func (queue *QueueProxy) Poll() (item interface{}, err error) {
-	request := QueuePollEncodeRequest(queue.name, 0)
+	request := protocol.QueuePollEncodeRequest(queue.name, 0)
 	responseMessage, err := queue.invoke(request)
-	return queue.decodeToObjectAndError(responseMessage, err, QueuePollDecodeResponse)
+	return queue.decodeToObjectAndError(responseMessage, err, protocol.QueuePollDecodeResponse)
 }
 
 func (queue *QueueProxy) PollWithTimeout(timeout int64, timeoutUnit time.Duration) (item interface{}, err error) {
-	timeoutInMilliSeconds := GetTimeInMilliSeconds(timeout, timeoutUnit)
-	request := QueuePollEncodeRequest(queue.name, timeoutInMilliSeconds)
+	timeoutInMilliSeconds := common.GetTimeInMilliSeconds(timeout, timeoutUnit)
+	request := protocol.QueuePollEncodeRequest(queue.name, timeoutInMilliSeconds)
 	responseMessage, err := queue.invoke(request)
-	return queue.decodeToObjectAndError(responseMessage, err, QueuePollDecodeResponse)
+	return queue.decodeToObjectAndError(responseMessage, err, protocol.QueuePollDecodeResponse)
 }
 
 func (queue *QueueProxy) Put(item interface{}) (err error) {
@@ -160,15 +160,15 @@ func (queue *QueueProxy) Put(item interface{}) (err error) {
 	if err != nil {
 		return err
 	}
-	request := QueuePutEncodeRequest(queue.name, itemData)
+	request := protocol.QueuePutEncodeRequest(queue.name, itemData)
 	_, err = queue.invoke(request)
 	return err
 }
 
 func (queue *QueueProxy) RemainingCapacity() (remainingCapacity int32, err error) {
-	request := QueueRemainingCapacityEncodeRequest(queue.name)
+	request := protocol.QueueRemainingCapacityEncodeRequest(queue.name)
 	responseMessage, err := queue.invoke(request)
-	return queue.decodeToInt32AndError(responseMessage, err, QueueRemainingCapacityDecodeResponse)
+	return queue.decodeToInt32AndError(responseMessage, err, protocol.QueueRemainingCapacityDecodeResponse)
 }
 
 func (queue *QueueProxy) Remove(item interface{}) (removed bool, err error) {
@@ -176,9 +176,9 @@ func (queue *QueueProxy) Remove(item interface{}) (removed bool, err error) {
 	if err != nil {
 		return false, err
 	}
-	request := QueueRemoveEncodeRequest(queue.name, itemData)
+	request := protocol.QueueRemoveEncodeRequest(queue.name, itemData)
 	responseMessage, err := queue.invoke(request)
-	return queue.decodeToBoolAndError(responseMessage, err, QueueRemoveDecodeResponse)
+	return queue.decodeToBoolAndError(responseMessage, err, protocol.QueueRemoveDecodeResponse)
 }
 
 func (queue *QueueProxy) RemoveAll(items []interface{}) (changed bool, err error) {
@@ -186,14 +186,14 @@ func (queue *QueueProxy) RemoveAll(items []interface{}) (changed bool, err error
 	if err != nil {
 		return false, err
 	}
-	request := QueueCompareAndRemoveAllEncodeRequest(queue.name, itemData)
+	request := protocol.QueueCompareAndRemoveAllEncodeRequest(queue.name, itemData)
 	responseMessage, err := queue.invoke(request)
-	return queue.decodeToBoolAndError(responseMessage, err, QueueCompareAndRemoveAllDecodeResponse)
+	return queue.decodeToBoolAndError(responseMessage, err, protocol.QueueCompareAndRemoveAllDecodeResponse)
 }
 
 func (queue *QueueProxy) RemoveItemListener(registrationID *string) (removed bool, err error) {
-	return queue.client.ListenerService.deregisterListener(*registrationID, func(registrationID *string) *ClientMessage {
-		return QueueRemoveListenerEncodeRequest(queue.name, registrationID)
+	return queue.client.ListenerService.deregisterListener(*registrationID, func(registrationID *string) *protocol.ClientMessage {
+		return protocol.QueueRemoveListenerEncodeRequest(queue.name, registrationID)
 	})
 }
 
@@ -202,32 +202,32 @@ func (queue *QueueProxy) RetainAll(items []interface{}) (changed bool, err error
 	if err != nil {
 		return false, err
 	}
-	request := QueueCompareAndRetainAllEncodeRequest(queue.name, itemData)
+	request := protocol.QueueCompareAndRetainAllEncodeRequest(queue.name, itemData)
 	responseMessage, err := queue.invoke(request)
-	return queue.decodeToBoolAndError(responseMessage, err, QueueCompareAndRetainAllDecodeResponse)
+	return queue.decodeToBoolAndError(responseMessage, err, protocol.QueueCompareAndRetainAllDecodeResponse)
 }
 
 func (queue *QueueProxy) Size() (size int32, err error) {
-	request := QueueSizeEncodeRequest(queue.name)
+	request := protocol.QueueSizeEncodeRequest(queue.name)
 	responseMessage, err := queue.invoke(request)
-	return queue.decodeToInt32AndError(responseMessage, err, QueueSizeDecodeResponse)
+	return queue.decodeToInt32AndError(responseMessage, err, protocol.QueueSizeDecodeResponse)
 }
 
 func (queue *QueueProxy) Take() (item interface{}, err error) {
-	request := QueueTakeEncodeRequest(queue.name)
+	request := protocol.QueueTakeEncodeRequest(queue.name)
 	responseMessage, err := queue.invoke(request)
-	return queue.decodeToObjectAndError(responseMessage, err, QueueTakeDecodeResponse)
+	return queue.decodeToObjectAndError(responseMessage, err, protocol.QueueTakeDecodeResponse)
 }
 
 func (queue *QueueProxy) ToSlice() (items []interface{}, err error) {
-	request := QueueIteratorEncodeRequest(queue.name)
+	request := protocol.QueueIteratorEncodeRequest(queue.name)
 	responseMessage, err := queue.invoke(request)
-	return queue.decodeToInterfaceSliceAndError(responseMessage, err, QueueIteratorDecodeResponse)
+	return queue.decodeToInterfaceSliceAndError(responseMessage, err, protocol.QueueIteratorDecodeResponse)
 }
 
-func (queue *QueueProxy) createEventHandler(listener interface{}) func(clientMessage *ClientMessage) {
-	return func(clientMessage *ClientMessage) {
-		QueueAddListenerHandle(clientMessage, func(itemData *Data, uuid *string, eventType int32) {
+func (queue *QueueProxy) createEventHandler(listener interface{}) func(clientMessage *protocol.ClientMessage) {
+	return func(clientMessage *protocol.ClientMessage) {
+		protocol.QueueAddListenerHandle(clientMessage, func(itemData *serialization.Data, uuid *string, eventType int32) {
 			onItemEvent := queue.createOnItemEvent(listener)
 			onItemEvent(itemData, uuid, eventType)
 		})

--- a/internal/replicated_map.go
+++ b/internal/replicated_map.go
@@ -15,9 +15,9 @@
 package internal
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/core"
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
-	. "github.com/hazelcast/hazelcast-go-client/internal/protocol"
+	"github.com/hazelcast/hazelcast-go-client/core"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol"
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 	"math/rand"
 	"time"
@@ -42,26 +42,26 @@ func (rmp *ReplicatedMapProxy) PutWithTtl(key interface{}, value interface{}, tt
 	if err != nil {
 		return nil, err
 	}
-	request := ReplicatedMapPutEncodeRequest(rmp.name, keyData, valueData, ttl)
+	request := protocol.ReplicatedMapPutEncodeRequest(rmp.name, keyData, valueData, ttl)
 	responseMessage, err := rmp.invokeOnKey(request, keyData)
-	return rmp.decodeToObjectAndError(responseMessage, err, ReplicatedMapPutDecodeResponse)
+	return rmp.decodeToObjectAndError(responseMessage, err, protocol.ReplicatedMapPutDecodeResponse)
 }
 
 func (rmp *ReplicatedMapProxy) PutAll(entries map[interface{}]interface{}) (err error) {
 	if entries == nil {
-		return NewHazelcastNilPointerError(NilMapIsNotAllowed, nil)
+		return core.NewHazelcastNilPointerError(common.NilMapIsNotAllowed, nil)
 	}
-	pairs := make([]*Pair, len(entries))
+	pairs := make([]*protocol.Pair, len(entries))
 	index := 0
 	for key, value := range entries {
 		keyData, valueData, err := rmp.validateAndSerialize2(key, value)
 		if err != nil {
 			return err
 		}
-		pairs[index] = NewPair(keyData, valueData)
+		pairs[index] = protocol.NewPair(keyData, valueData)
 		index++
 	}
-	request := ReplicatedMapPutAllEncodeRequest(rmp.name, pairs)
+	request := protocol.ReplicatedMapPutAllEncodeRequest(rmp.name, pairs)
 	_, err = rmp.invokeOnRandomTarget(request)
 	return err
 }
@@ -71,9 +71,9 @@ func (rmp *ReplicatedMapProxy) Get(key interface{}) (value interface{}, err erro
 	if err != nil {
 		return nil, err
 	}
-	request := ReplicatedMapGetEncodeRequest(rmp.name, keyData)
+	request := protocol.ReplicatedMapGetEncodeRequest(rmp.name, keyData)
 	responseMessage, err := rmp.invokeOnKey(request, keyData)
-	return rmp.decodeToObjectAndError(responseMessage, err, ReplicatedMapGetDecodeResponse)
+	return rmp.decodeToObjectAndError(responseMessage, err, protocol.ReplicatedMapGetDecodeResponse)
 }
 
 func (rmp *ReplicatedMapProxy) ContainsKey(key interface{}) (found bool, err error) {
@@ -81,9 +81,9 @@ func (rmp *ReplicatedMapProxy) ContainsKey(key interface{}) (found bool, err err
 	if err != nil {
 		return false, err
 	}
-	request := ReplicatedMapContainsKeyEncodeRequest(rmp.name, keyData)
+	request := protocol.ReplicatedMapContainsKeyEncodeRequest(rmp.name, keyData)
 	responseMessage, err := rmp.invokeOnKey(request, keyData)
-	return rmp.decodeToBoolAndError(responseMessage, err, ReplicatedMapContainsKeyDecodeResponse)
+	return rmp.decodeToBoolAndError(responseMessage, err, protocol.ReplicatedMapContainsKeyDecodeResponse)
 }
 
 func (rmp *ReplicatedMapProxy) ContainsValue(value interface{}) (found bool, err error) {
@@ -91,13 +91,13 @@ func (rmp *ReplicatedMapProxy) ContainsValue(value interface{}) (found bool, err
 	if err != nil {
 		return false, err
 	}
-	request := ReplicatedMapContainsValueEncodeRequest(rmp.name, valueData)
+	request := protocol.ReplicatedMapContainsValueEncodeRequest(rmp.name, valueData)
 	responseMessage, err := rmp.invokeOnKey(request, valueData)
-	return rmp.decodeToBoolAndError(responseMessage, err, ReplicatedMapContainsValueDecodeResponse)
+	return rmp.decodeToBoolAndError(responseMessage, err, protocol.ReplicatedMapContainsValueDecodeResponse)
 }
 
 func (rmp *ReplicatedMapProxy) Clear() (err error) {
-	request := ReplicatedMapClearEncodeRequest(rmp.name)
+	request := protocol.ReplicatedMapClearEncodeRequest(rmp.name)
 	_, err = rmp.invokeOnRandomTarget(request)
 	return err
 }
@@ -107,49 +107,49 @@ func (rmp *ReplicatedMapProxy) Remove(key interface{}) (value interface{}, err e
 	if err != nil {
 		return nil, err
 	}
-	request := ReplicatedMapRemoveEncodeRequest(rmp.name, keyData)
+	request := protocol.ReplicatedMapRemoveEncodeRequest(rmp.name, keyData)
 	responseMessage, err := rmp.invokeOnKey(request, keyData)
-	return rmp.decodeToObjectAndError(responseMessage, err, ReplicatedMapRemoveDecodeResponse)
+	return rmp.decodeToObjectAndError(responseMessage, err, protocol.ReplicatedMapRemoveDecodeResponse)
 }
 
 func (rmp *ReplicatedMapProxy) IsEmpty() (empty bool, err error) {
-	request := ReplicatedMapIsEmptyEncodeRequest(rmp.name)
+	request := protocol.ReplicatedMapIsEmptyEncodeRequest(rmp.name)
 	responseMessage, err := rmp.invokeOnPartition(request, rmp.targetPartitionId)
-	return rmp.decodeToBoolAndError(responseMessage, err, ReplicatedMapIsEmptyDecodeResponse)
+	return rmp.decodeToBoolAndError(responseMessage, err, protocol.ReplicatedMapIsEmptyDecodeResponse)
 }
 
 func (rmp *ReplicatedMapProxy) Size() (size int32, err error) {
-	request := ReplicatedMapSizeEncodeRequest(rmp.name)
+	request := protocol.ReplicatedMapSizeEncodeRequest(rmp.name)
 	responseMessage, err := rmp.invokeOnPartition(request, rmp.targetPartitionId)
-	return rmp.decodeToInt32AndError(responseMessage, err, ReplicatedMapSizeDecodeResponse)
+	return rmp.decodeToInt32AndError(responseMessage, err, protocol.ReplicatedMapSizeDecodeResponse)
 
 }
 
 func (rmp *ReplicatedMapProxy) Values() (values []interface{}, err error) {
-	request := ReplicatedMapValuesEncodeRequest(rmp.name)
+	request := protocol.ReplicatedMapValuesEncodeRequest(rmp.name)
 	responseMessage, err := rmp.invokeOnPartition(request, rmp.targetPartitionId)
-	return rmp.decodeToInterfaceSliceAndError(responseMessage, err, ReplicatedMapValuesDecodeResponse)
+	return rmp.decodeToInterfaceSliceAndError(responseMessage, err, protocol.ReplicatedMapValuesDecodeResponse)
 }
 
 func (rmp *ReplicatedMapProxy) KeySet() (keySet []interface{}, err error) {
-	request := ReplicatedMapKeySetEncodeRequest(rmp.name)
+	request := protocol.ReplicatedMapKeySetEncodeRequest(rmp.name)
 	responseMessage, err := rmp.invokeOnPartition(request, rmp.targetPartitionId)
-	return rmp.decodeToInterfaceSliceAndError(responseMessage, err, ReplicatedMapKeySetDecodeResponse)
+	return rmp.decodeToInterfaceSliceAndError(responseMessage, err, protocol.ReplicatedMapKeySetDecodeResponse)
 }
 
-func (rmp *ReplicatedMapProxy) EntrySet() (resultPairs []IPair, err error) {
-	request := ReplicatedMapEntrySetEncodeRequest(rmp.name)
+func (rmp *ReplicatedMapProxy) EntrySet() (resultPairs []core.IPair, err error) {
+	request := protocol.ReplicatedMapEntrySetEncodeRequest(rmp.name)
 	responseMessage, err := rmp.invokeOnPartition(request, rmp.targetPartitionId)
-	return rmp.decodeToPairSliceAndError(responseMessage, err, ReplicatedMapEntrySetDecodeResponse)
+	return rmp.decodeToPairSliceAndError(responseMessage, err, protocol.ReplicatedMapEntrySetDecodeResponse)
 }
 
 func (rmp *ReplicatedMapProxy) AddEntryListener(listener interface{}) (registrationID *string, err error) {
-	request := ReplicatedMapAddEntryListenerEncodeRequest(rmp.name, rmp.isSmart())
+	request := protocol.ReplicatedMapAddEntryListenerEncodeRequest(rmp.name, rmp.isSmart())
 	eventHandler := rmp.createEventHandler(listener)
-	return rmp.client.ListenerService.registerListener(request, eventHandler, func(registrationId *string) *ClientMessage {
-		return ReplicatedMapRemoveEntryListenerEncodeRequest(rmp.name, registrationId)
-	}, func(clientMessage *ClientMessage) *string {
-		return ReplicatedMapAddEntryListenerDecodeResponse(clientMessage)()
+	return rmp.client.ListenerService.registerListener(request, eventHandler, func(registrationId *string) *protocol.ClientMessage {
+		return protocol.ReplicatedMapRemoveEntryListenerEncodeRequest(rmp.name, registrationId)
+	}, func(clientMessage *protocol.ClientMessage) *string {
+		return protocol.ReplicatedMapAddEntryListenerDecodeResponse(clientMessage)()
 	})
 }
 
@@ -158,12 +158,12 @@ func (rmp *ReplicatedMapProxy) AddEntryListenerWithPredicate(listener interface{
 	if err != nil {
 		return nil, err
 	}
-	request := ReplicatedMapAddEntryListenerWithPredicateEncodeRequest(rmp.name, predicateData, rmp.isSmart())
+	request := protocol.ReplicatedMapAddEntryListenerWithPredicateEncodeRequest(rmp.name, predicateData, rmp.isSmart())
 	eventHandler := rmp.createEventHandlerWithPredicate(listener)
-	return rmp.client.ListenerService.registerListener(request, eventHandler, func(registrationId *string) *ClientMessage {
-		return ReplicatedMapRemoveEntryListenerEncodeRequest(rmp.name, registrationId)
-	}, func(clientMessage *ClientMessage) *string {
-		return ReplicatedMapAddEntryListenerWithPredicateDecodeResponse(clientMessage)()
+	return rmp.client.ListenerService.registerListener(request, eventHandler, func(registrationId *string) *protocol.ClientMessage {
+		return protocol.ReplicatedMapRemoveEntryListenerEncodeRequest(rmp.name, registrationId)
+	}, func(clientMessage *protocol.ClientMessage) *string {
+		return protocol.ReplicatedMapAddEntryListenerWithPredicateDecodeResponse(clientMessage)()
 	})
 }
 
@@ -172,12 +172,12 @@ func (rmp *ReplicatedMapProxy) AddEntryListenerToKey(listener interface{}, key i
 	if err != nil {
 		return nil, err
 	}
-	request := ReplicatedMapAddEntryListenerToKeyEncodeRequest(rmp.name, keyData, rmp.isSmart())
+	request := protocol.ReplicatedMapAddEntryListenerToKeyEncodeRequest(rmp.name, keyData, rmp.isSmart())
 	eventHandler := rmp.createEventHandlerToKey(listener)
-	return rmp.client.ListenerService.registerListener(request, eventHandler, func(registrationId *string) *ClientMessage {
-		return ReplicatedMapRemoveEntryListenerEncodeRequest(rmp.name, registrationId)
-	}, func(clientMessage *ClientMessage) *string {
-		return ReplicatedMapAddEntryListenerToKeyDecodeResponse(clientMessage)()
+	return rmp.client.ListenerService.registerListener(request, eventHandler, func(registrationId *string) *protocol.ClientMessage {
+		return protocol.ReplicatedMapRemoveEntryListenerEncodeRequest(rmp.name, registrationId)
+	}, func(clientMessage *protocol.ClientMessage) *string {
+		return protocol.ReplicatedMapAddEntryListenerToKeyDecodeResponse(clientMessage)()
 	})
 }
 
@@ -190,18 +190,18 @@ func (rmp *ReplicatedMapProxy) AddEntryListenerToKeyWithPredicate(listener inter
 	if err != nil {
 		return nil, err
 	}
-	request := ReplicatedMapAddEntryListenerToKeyWithPredicateEncodeRequest(rmp.name, keyData, predicateData, rmp.isSmart())
+	request := protocol.ReplicatedMapAddEntryListenerToKeyWithPredicateEncodeRequest(rmp.name, keyData, predicateData, rmp.isSmart())
 	eventHandler := rmp.createEventHandlerToKeyWithPredicate(listener)
-	return rmp.client.ListenerService.registerListener(request, eventHandler, func(registrationId *string) *ClientMessage {
-		return ReplicatedMapRemoveEntryListenerEncodeRequest(rmp.name, registrationId)
-	}, func(clientMessage *ClientMessage) *string {
-		return ReplicatedMapAddEntryListenerToKeyWithPredicateDecodeResponse(clientMessage)()
+	return rmp.client.ListenerService.registerListener(request, eventHandler, func(registrationId *string) *protocol.ClientMessage {
+		return protocol.ReplicatedMapRemoveEntryListenerEncodeRequest(rmp.name, registrationId)
+	}, func(clientMessage *protocol.ClientMessage) *string {
+		return protocol.ReplicatedMapAddEntryListenerToKeyWithPredicateDecodeResponse(clientMessage)()
 	})
 }
 
 func (rmp *ReplicatedMapProxy) RemoveEntryListener(registrationId *string) (removed bool, err error) {
-	return rmp.client.ListenerService.deregisterListener(*registrationId, func(registrationId *string) *ClientMessage {
-		return ReplicatedMapRemoveEntryListenerEncodeRequest(rmp.name, registrationId)
+	return rmp.client.ListenerService.deregisterListener(*registrationId, func(registrationId *string) *protocol.ClientMessage {
+		return protocol.ReplicatedMapRemoveEntryListenerEncodeRequest(rmp.name, registrationId)
 	})
 }
 
@@ -210,34 +210,34 @@ func (rmp *ReplicatedMapProxy) onEntryEvent(keyData *serialization.Data, oldValu
 	oldValue, _ := rmp.toObject(oldValueData)
 	value, _ := rmp.toObject(valueData)
 	mergingValue, _ := rmp.toObject(mergingValueData)
-	entryEvent := NewEntryEvent(key, oldValue, value, mergingValue, eventType, Uuid)
-	mapEvent := NewMapEvent(eventType, Uuid, numberOfAffectedEntries)
+	entryEvent := protocol.NewEntryEvent(key, oldValue, value, mergingValue, eventType, Uuid)
+	mapEvent := protocol.NewMapEvent(eventType, Uuid, numberOfAffectedEntries)
 	switch eventType {
-	case EntryEventAdded:
-		listener.(EntryAddedListener).EntryAdded(entryEvent)
-	case EntryEventRemoved:
-		listener.(EntryRemovedListener).EntryRemoved(entryEvent)
-	case EntryEventUpdated:
-		listener.(EntryUpdatedListener).EntryUpdated(entryEvent)
-	case EntryEventEvicted:
-		listener.(EntryEvictedListener).EntryEvicted(entryEvent)
-	case EntryEventClearAll:
-		listener.(EntryClearAllListener).EntryClearAll(mapEvent)
+	case common.EntryEventAdded:
+		listener.(protocol.EntryAddedListener).EntryAdded(entryEvent)
+	case common.EntryEventRemoved:
+		listener.(protocol.EntryRemovedListener).EntryRemoved(entryEvent)
+	case common.EntryEventUpdated:
+		listener.(protocol.EntryUpdatedListener).EntryUpdated(entryEvent)
+	case common.EntryEventEvicted:
+		listener.(protocol.EntryEvictedListener).EntryEvicted(entryEvent)
+	case common.EntryEventClearAll:
+		listener.(protocol.EntryClearAllListener).EntryClearAll(mapEvent)
 	}
 }
 
-func (rmp *ReplicatedMapProxy) createEventHandler(listener interface{}) func(clientMessage *ClientMessage) {
-	return func(clientMessage *ClientMessage) {
-		ReplicatedMapAddEntryListenerHandle(clientMessage, func(key *serialization.Data, oldValue *serialization.Data,
+func (rmp *ReplicatedMapProxy) createEventHandler(listener interface{}) func(clientMessage *protocol.ClientMessage) {
+	return func(clientMessage *protocol.ClientMessage) {
+		protocol.ReplicatedMapAddEntryListenerHandle(clientMessage, func(key *serialization.Data, oldValue *serialization.Data,
 			value *serialization.Data, mergingValue *serialization.Data, eventType int32, Uuid *string, numberOfAffectedEntries int32) {
 			rmp.onEntryEvent(key, oldValue, value, mergingValue, eventType, Uuid, numberOfAffectedEntries, listener)
 		})
 	}
 }
 
-func (rmp *ReplicatedMapProxy) createEventHandlerWithPredicate(listener interface{}) func(clientMessage *ClientMessage) {
-	return func(clientMessage *ClientMessage) {
-		ReplicatedMapAddEntryListenerWithPredicateHandle(clientMessage,
+func (rmp *ReplicatedMapProxy) createEventHandlerWithPredicate(listener interface{}) func(clientMessage *protocol.ClientMessage) {
+	return func(clientMessage *protocol.ClientMessage) {
+		protocol.ReplicatedMapAddEntryListenerWithPredicateHandle(clientMessage,
 			func(key *serialization.Data, oldValue *serialization.Data, value *serialization.Data, mergingValue *serialization.Data,
 				eventType int32, Uuid *string, numberOfAffectedEntries int32) {
 				rmp.onEntryEvent(key, oldValue, value, mergingValue, eventType, Uuid, numberOfAffectedEntries, listener)
@@ -245,9 +245,9 @@ func (rmp *ReplicatedMapProxy) createEventHandlerWithPredicate(listener interfac
 	}
 }
 
-func (rmp *ReplicatedMapProxy) createEventHandlerToKey(listener interface{}) func(clientMessage *ClientMessage) {
-	return func(clientMessage *ClientMessage) {
-		ReplicatedMapAddEntryListenerToKeyHandle(clientMessage,
+func (rmp *ReplicatedMapProxy) createEventHandlerToKey(listener interface{}) func(clientMessage *protocol.ClientMessage) {
+	return func(clientMessage *protocol.ClientMessage) {
+		protocol.ReplicatedMapAddEntryListenerToKeyHandle(clientMessage,
 			func(key *serialization.Data, oldValue *serialization.Data, value *serialization.Data, mergingValue *serialization.Data,
 				eventType int32, Uuid *string, numberOfAffectedEntries int32) {
 				rmp.onEntryEvent(key, oldValue, value, mergingValue, eventType, Uuid, numberOfAffectedEntries, listener)
@@ -255,9 +255,9 @@ func (rmp *ReplicatedMapProxy) createEventHandlerToKey(listener interface{}) fun
 	}
 }
 
-func (rmp *ReplicatedMapProxy) createEventHandlerToKeyWithPredicate(listener interface{}) func(clientMessage *ClientMessage) {
-	return func(clientMessage *ClientMessage) {
-		ReplicatedMapAddEntryListenerToKeyWithPredicateHandle(clientMessage,
+func (rmp *ReplicatedMapProxy) createEventHandlerToKeyWithPredicate(listener interface{}) func(clientMessage *protocol.ClientMessage) {
+	return func(clientMessage *protocol.ClientMessage) {
+		protocol.ReplicatedMapAddEntryListenerToKeyWithPredicateHandle(clientMessage,
 			func(key *serialization.Data, oldValue *serialization.Data, value *serialization.Data, mergingValue *serialization.Data,
 				eventType int32, Uuid *string, numberOfAffectedEntries int32) {
 				rmp.onEntryEvent(key, oldValue, value, mergingValue, eventType, Uuid, numberOfAffectedEntries, listener)

--- a/internal/ringbuffer.go
+++ b/internal/ringbuffer.go
@@ -17,8 +17,8 @@ package internal
 import (
 	"fmt"
 	"github.com/hazelcast/hazelcast-go-client/core"
-	. "github.com/hazelcast/hazelcast-go-client/internal/protocol"
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
 type RingbufferProxy struct {
@@ -36,9 +36,9 @@ func newRingbufferProxy(client *HazelcastClient, serviceName *string, name *stri
 
 func (rp *RingbufferProxy) Capacity() (capacity int64, err error) {
 	if rp.capacity == -1 {
-		request := RingbufferCapacityEncodeRequest(rp.name)
+		request := protocol.RingbufferCapacityEncodeRequest(rp.name)
 		responseMessage, err := rp.invoke(request)
-		capacity, err := rp.decodeToInt64AndError(responseMessage, err, RingbufferCapacityDecodeResponse)
+		capacity, err := rp.decodeToInt64AndError(responseMessage, err, protocol.RingbufferCapacityDecodeResponse)
 		if err != nil {
 			return 0, nil
 		}
@@ -47,27 +47,27 @@ func (rp *RingbufferProxy) Capacity() (capacity int64, err error) {
 	return rp.capacity, nil
 }
 func (rp *RingbufferProxy) Size() (size int64, err error) {
-	request := RingbufferSizeEncodeRequest(rp.name)
+	request := protocol.RingbufferSizeEncodeRequest(rp.name)
 	responseMessage, err := rp.invoke(request)
-	return rp.decodeToInt64AndError(responseMessage, err, RingbufferSizeDecodeResponse)
+	return rp.decodeToInt64AndError(responseMessage, err, protocol.RingbufferSizeDecodeResponse)
 }
 
 func (rp *RingbufferProxy) TailSequence() (tailSequence int64, err error) {
-	request := RingbufferTailSequenceEncodeRequest(rp.name)
+	request := protocol.RingbufferTailSequenceEncodeRequest(rp.name)
 	responseMessage, err := rp.invoke(request)
-	return rp.decodeToInt64AndError(responseMessage, err, RingbufferTailSequenceDecodeResponse)
+	return rp.decodeToInt64AndError(responseMessage, err, protocol.RingbufferTailSequenceDecodeResponse)
 }
 
 func (rp *RingbufferProxy) HeadSequence() (headSequence int64, err error) {
-	request := RingbufferHeadSequenceEncodeRequest(rp.name)
+	request := protocol.RingbufferHeadSequenceEncodeRequest(rp.name)
 	responseMessage, err := rp.invoke(request)
-	return rp.decodeToInt64AndError(responseMessage, err, RingbufferHeadSequenceDecodeResponse)
+	return rp.decodeToInt64AndError(responseMessage, err, protocol.RingbufferHeadSequenceDecodeResponse)
 }
 
 func (rp *RingbufferProxy) RemainingCapacity() (remainingCapacity int64, err error) {
-	request := RingbufferRemainingCapacityEncodeRequest(rp.name)
+	request := protocol.RingbufferRemainingCapacityEncodeRequest(rp.name)
 	responseMessage, err := rp.invoke(request)
-	return rp.decodeToInt64AndError(responseMessage, err, RingbufferRemainingCapacityDecodeResponse)
+	return rp.decodeToInt64AndError(responseMessage, err, protocol.RingbufferRemainingCapacityDecodeResponse)
 }
 
 func (rp *RingbufferProxy) Add(item interface{}, overflowPolicy core.OverflowPolicy) (sequence int64, err error) {
@@ -75,9 +75,9 @@ func (rp *RingbufferProxy) Add(item interface{}, overflowPolicy core.OverflowPol
 	if err != nil {
 		return
 	}
-	request := RingbufferAddEncodeRequest(rp.name, int32(overflowPolicy.Policy()), itemData)
+	request := protocol.RingbufferAddEncodeRequest(rp.name, int32(overflowPolicy.Policy()), itemData)
 	responseMessage, err := rp.invoke(request)
-	return rp.decodeToInt64AndError(responseMessage, err, RingbufferAddDecodeResponse)
+	return rp.decodeToInt64AndError(responseMessage, err, protocol.RingbufferAddDecodeResponse)
 }
 
 func (rp *RingbufferProxy) AddAll(items []interface{}, overflowPolicy core.OverflowPolicy) (lastSequence int64, err error) {
@@ -85,18 +85,18 @@ func (rp *RingbufferProxy) AddAll(items []interface{}, overflowPolicy core.Overf
 	if err != nil {
 		return
 	}
-	request := RingbufferAddAllEncodeRequest(rp.name, itemsData, int32(overflowPolicy.Policy()))
+	request := protocol.RingbufferAddAllEncodeRequest(rp.name, itemsData, int32(overflowPolicy.Policy()))
 	responseMessage, err := rp.invoke(request)
-	return rp.decodeToInt64AndError(responseMessage, err, RingbufferAddAllDecodeResponse)
+	return rp.decodeToInt64AndError(responseMessage, err, protocol.RingbufferAddAllDecodeResponse)
 }
 
 func (rp *RingbufferProxy) ReadOne(sequence int64) (item interface{}, err error) {
 	if err = rp.validateSequenceNotNegative(sequence, "sequence"); err != nil {
 		return
 	}
-	request := RingbufferReadOneEncodeRequest(rp.name, sequence)
+	request := protocol.RingbufferReadOneEncodeRequest(rp.name, sequence)
 	responseMessage, err := rp.invoke(request)
-	return rp.decodeToObjectAndError(responseMessage, err, RingbufferReadOneDecodeResponse)
+	return rp.decodeToObjectAndError(responseMessage, err, protocol.RingbufferReadOneDecodeResponse)
 }
 
 func (rp *RingbufferProxy) ReadMany(startSequence int64, minCount int32, maxCount int32, filter interface{}) (readResultSet core.ReadResultSet, err error) {
@@ -110,12 +110,12 @@ func (rp *RingbufferProxy) ReadMany(startSequence int64, minCount int32, maxCoun
 	if err = rp.checkCounts(minCount, maxCount); err != nil {
 		return
 	}
-	request := RingbufferReadManyEncodeRequest(rp.name, startSequence, minCount, maxCount, filterData)
+	request := protocol.RingbufferReadManyEncodeRequest(rp.name, startSequence, minCount, maxCount, filterData)
 	responseMessage, err := rp.invoke(request)
 	if err != nil {
 		return
 	}
-	readCount, itemsData, itemSeqs, _ /*nextSeq*/ := RingbufferReadManyDecodeResponse(responseMessage)()
+	readCount, itemsData, itemSeqs, _ /*nextSeq*/ := protocol.RingbufferReadManyDecodeResponse(responseMessage)()
 	return NewLazyReadResultSet(readCount, itemsData, itemSeqs, rp.client.SerializationService), nil
 }
 
@@ -141,12 +141,12 @@ type LazyReadResultSet struct {
 	// This slice includes both data and de-serialized objects.
 	lazyItems            []interface{}
 	itemSequences        []int64
-	serializationService *SerializationService
+	serializationService *serialization.SerializationService
 }
 
 const sequenceUnavailable int64 = -1
 
-func NewLazyReadResultSet(readCount int32, itemsData []*Data, itemSeqs []int64, ss *SerializationService) (rs *LazyReadResultSet) {
+func NewLazyReadResultSet(readCount int32, itemsData []*serialization.Data, itemSeqs []int64, ss *serialization.SerializationService) (rs *LazyReadResultSet) {
 	rs = &LazyReadResultSet{readCount: readCount, itemSequences: itemSeqs, serializationService: ss}
 	lazyItems := make([]interface{}, len(itemsData))
 	for i, itemData := range itemsData {
@@ -164,7 +164,7 @@ func (rs *LazyReadResultSet) Get(index int32) (result interface{}, err error) {
 	if err = rs.rangeCheck(index); err != nil {
 		return
 	}
-	if itemData, ok := rs.lazyItems[index].(*Data); ok {
+	if itemData, ok := rs.lazyItems[index].(*serialization.Data); ok {
 		item, err := rs.serializationService.ToObject(itemData)
 		if err != nil {
 			return nil, err

--- a/internal/serialization/class_definition_writer.go
+++ b/internal/serialization/class_definition_writer.go
@@ -16,17 +16,17 @@ package serialization
 
 import (
 	"github.com/hazelcast/hazelcast-go-client/core"
-	. "github.com/hazelcast/hazelcast-go-client/serialization"
-	. "github.com/hazelcast/hazelcast-go-client/serialization/classdef"
+	"github.com/hazelcast/hazelcast-go-client/serialization"
+	"github.com/hazelcast/hazelcast-go-client/serialization/classdef"
 )
 
 type ClassDefinitionWriter struct {
 	portableContext        *PortableContext
-	classDefinitionBuilder *ClassDefinitionBuilder
+	classDefinitionBuilder *classdef.ClassDefinitionBuilder
 }
 
 func NewClassDefinitionWriter(portableContext *PortableContext, factoryId int32, classId int32, version int32) *ClassDefinitionWriter {
-	return &ClassDefinitionWriter{portableContext, NewClassDefinitionBuilder(factoryId, classId, version)}
+	return &ClassDefinitionWriter{portableContext, classdef.NewClassDefinitionBuilder(factoryId, classId, version)}
 }
 
 func (cdw *ClassDefinitionWriter) WriteByte(fieldName string, value byte) {
@@ -65,7 +65,7 @@ func (cdw *ClassDefinitionWriter) WriteUTF(fieldName string, value string) {
 	cdw.classDefinitionBuilder.AddUTFField(fieldName)
 }
 
-func (cdw *ClassDefinitionWriter) WritePortable(fieldName string, portable Portable) error {
+func (cdw *ClassDefinitionWriter) WritePortable(fieldName string, portable serialization.Portable) error {
 	if portable == nil {
 		return core.NewHazelcastSerializationError("cannot write nil portable without explicitly registering class definition", nil)
 	}
@@ -123,7 +123,7 @@ func (cdw *ClassDefinitionWriter) WriteUTFArray(fieldName string, value []string
 	cdw.classDefinitionBuilder.AddUTFArrayField(fieldName)
 }
 
-func (cdw *ClassDefinitionWriter) WritePortableArray(fieldName string, portables []Portable) error {
+func (cdw *ClassDefinitionWriter) WritePortableArray(fieldName string, portables []serialization.Portable) error {
 	if portables == nil {
 		return core.NewHazelcastSerializationError("non nil value expected", nil)
 	}
@@ -140,7 +140,7 @@ func (cdw *ClassDefinitionWriter) WritePortableArray(fieldName string, portables
 	return nil
 }
 
-func (cdw *ClassDefinitionWriter) registerAndGet() (ClassDefinition, error) {
+func (cdw *ClassDefinitionWriter) registerAndGet() (serialization.ClassDefinition, error) {
 	cd := cdw.classDefinitionBuilder.Build()
 	return cdw.portableContext.RegisterClassDefinition(cd)
 }

--- a/internal/serialization/classdef/class_definition.go
+++ b/internal/serialization/classdef/class_definition.go
@@ -15,18 +15,18 @@
 package classdef
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/serialization"
+	"github.com/hazelcast/hazelcast-go-client/serialization"
 )
 
 type ClassDefinitionImpl struct {
 	factoryId int32
 	classId   int32
 	version   int32
-	fields    map[string]FieldDefinition
+	fields    map[string]serialization.FieldDefinition
 }
 
 func NewClassDefinitionImpl(factoryId int32, classId int32, version int32) *ClassDefinitionImpl {
-	return &ClassDefinitionImpl{factoryId, classId, version, make(map[string]FieldDefinition)}
+	return &ClassDefinitionImpl{factoryId, classId, version, make(map[string]serialization.FieldDefinition)}
 }
 
 func (cd *ClassDefinitionImpl) FactoryId() int32 {
@@ -41,7 +41,7 @@ func (cd *ClassDefinitionImpl) Version() int32 {
 	return cd.version
 }
 
-func (cd *ClassDefinitionImpl) Field(name string) FieldDefinition {
+func (cd *ClassDefinitionImpl) Field(name string) serialization.FieldDefinition {
 	return cd.fields[name]
 }
 
@@ -49,7 +49,7 @@ func (cd *ClassDefinitionImpl) FieldCount() int {
 	return len(cd.fields)
 }
 
-func (cd *ClassDefinitionImpl) AddFieldDefinition(definition FieldDefinition) {
+func (cd *ClassDefinitionImpl) AddFieldDefinition(definition serialization.FieldDefinition) {
 	cd.fields[definition.Name()] = definition
 }
 

--- a/internal/serialization/classdef/class_definition_context.go
+++ b/internal/serialization/classdef/class_definition_context.go
@@ -16,31 +16,31 @@ package classdef
 
 import (
 	"fmt"
-	. "github.com/hazelcast/hazelcast-go-client/core"
-	. "github.com/hazelcast/hazelcast-go-client/serialization"
+	"github.com/hazelcast/hazelcast-go-client/core"
+	"github.com/hazelcast/hazelcast-go-client/serialization"
 	"reflect"
 	"strconv"
 )
 
 type ClassDefinitionContext struct {
 	factoryId int32
-	classDefs map[string]ClassDefinition
+	classDefs map[string]serialization.ClassDefinition
 }
 
 func NewClassDefinitionContext(factoryId int32, portableVersion int32) *ClassDefinitionContext {
-	return &ClassDefinitionContext{factoryId, make(map[string]ClassDefinition)}
+	return &ClassDefinitionContext{factoryId, make(map[string]serialization.ClassDefinition)}
 }
 
-func (c *ClassDefinitionContext) LookUp(classId int32, version int32) ClassDefinition {
+func (c *ClassDefinitionContext) LookUp(classId int32, version int32) serialization.ClassDefinition {
 	return c.classDefs[encodeVersionedClassId(classId, version)]
 }
 
-func (c *ClassDefinitionContext) Register(classDefinition ClassDefinition) (ClassDefinition, error) {
+func (c *ClassDefinitionContext) Register(classDefinition serialization.ClassDefinition) (serialization.ClassDefinition, error) {
 	if classDefinition == nil {
 		return nil, nil
 	}
 	if classDefinition.FactoryId() != c.factoryId {
-		return nil, NewHazelcastSerializationError(fmt.Sprintf("this factory's id is %d, intended factory id is %d.", c.factoryId, classDefinition.FactoryId()), nil)
+		return nil, core.NewHazelcastSerializationError(fmt.Sprintf("this factory's id is %d, intended factory id is %d.", c.factoryId, classDefinition.FactoryId()), nil)
 	}
 	classDefKey := encodeVersionedClassId(classDefinition.ClassId(), classDefinition.Version())
 	current := c.classDefs[classDefKey]
@@ -49,7 +49,7 @@ func (c *ClassDefinitionContext) Register(classDefinition ClassDefinition) (Clas
 		return classDefinition, nil
 	}
 	if !reflect.DeepEqual(current, classDefinition) {
-		return nil, NewHazelcastSerializationError(fmt.Sprintf("incompatible class definition with same class id: %d", classDefinition.ClassId()), nil)
+		return nil, core.NewHazelcastSerializationError(fmt.Sprintf("incompatible class definition with same class id: %d", classDefinition.ClassId()), nil)
 	}
 	return classDefinition, nil
 }

--- a/internal/serialization/data.go
+++ b/internal/serialization/data.go
@@ -16,7 +16,7 @@ package serialization
 
 import (
 	"encoding/binary"
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 	"math"
 )
 
@@ -57,5 +57,5 @@ func (d Data) DataSize() int {
 }
 
 func (d Data) GetPartitionHash() int32 {
-	return Murmur3ADefault(d.Payload, DataOffset, d.DataSize())
+	return common.Murmur3ADefault(d.Payload, DataOffset, d.DataSize())
 }

--- a/internal/serialization/default_portable_reader.go
+++ b/internal/serialization/default_portable_reader.go
@@ -16,22 +16,22 @@ package serialization
 
 import (
 	"fmt"
-	. "github.com/hazelcast/hazelcast-go-client/core"
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization/classdef"
-	. "github.com/hazelcast/hazelcast-go-client/serialization"
+	"github.com/hazelcast/hazelcast-go-client/core"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization/classdef"
+	"github.com/hazelcast/hazelcast-go-client/serialization"
 )
 
 type DefaultPortableReader struct {
 	serializer      *PortableSerializer
-	input           DataInput
-	classDefinition ClassDefinition
+	input           serialization.DataInput
+	classDefinition serialization.ClassDefinition
 	offset          int32
 	finalPos        int32
 	raw             bool
 }
 
-func NewDefaultPortableReader(serializer *PortableSerializer, input DataInput, classdefinition ClassDefinition) *DefaultPortableReader {
+func NewDefaultPortableReader(serializer *PortableSerializer, input serialization.DataInput, classdefinition serialization.ClassDefinition) *DefaultPortableReader {
 	finalPos, _ := input.ReadInt32()
 	input.ReadInt32()
 	offset := input.Position()
@@ -41,45 +41,45 @@ func NewDefaultPortableReader(serializer *PortableSerializer, input DataInput, c
 func getTypeByConst(fieldType int32) string {
 	var ret string
 	switch t := fieldType; t {
-	case TypePortable:
+	case classdef.TypePortable:
 		ret = "Portable"
-	case TypeByte:
+	case classdef.TypeByte:
 		ret = "byte"
-	case TypeBool:
+	case classdef.TypeBool:
 		ret = "bool"
-	case TypeUint16:
+	case classdef.TypeUint16:
 		ret = "uint16"
-	case TypeInt16:
+	case classdef.TypeInt16:
 		ret = "int16"
-	case TypeInt32:
+	case classdef.TypeInt32:
 		ret = "int32"
-	case TypeInt64:
+	case classdef.TypeInt64:
 		ret = "int64"
-	case TypeFloat32:
+	case classdef.TypeFloat32:
 		ret = "float32"
-	case TypeFloat64:
+	case classdef.TypeFloat64:
 		ret = "float64"
-	case TypeUTF:
+	case classdef.TypeUTF:
 		ret = "string"
-	case TypePortableArray:
+	case classdef.TypePortableArray:
 		ret = "[]Portable"
-	case TypeByteArray:
+	case classdef.TypeByteArray:
 		ret = "[]byte"
-	case TypeBoolArray:
+	case classdef.TypeBoolArray:
 		ret = "[]bool"
-	case TypeUint16Array:
+	case classdef.TypeUint16Array:
 		ret = "[]uint16"
-	case TypeInt16Array:
+	case classdef.TypeInt16Array:
 		ret = "[]int16"
-	case TypeInt32Array:
+	case classdef.TypeInt32Array:
 		ret = "[]int32"
-	case TypeInt64Array:
+	case classdef.TypeInt64Array:
 		ret = "[]int64"
-	case TypeFloat32Array:
+	case classdef.TypeFloat32Array:
 		ret = "[]float32"
-	case TypeFloat64Array:
+	case classdef.TypeFloat64Array:
 		ret = "[]float64"
-	case TypeUTFArray:
+	case classdef.TypeUTFArray:
 		ret = "[]string"
 	default:
 	}
@@ -89,14 +89,14 @@ func getTypeByConst(fieldType int32) string {
 func (pr *DefaultPortableReader) positionByField(fieldName string, fieldType int32) (int32, error) {
 	field := pr.classDefinition.Field(fieldName)
 	if pr.raw {
-		return 0, NewHazelcastSerializationError("cannot read portable fields after getRawDataInput called", nil)
+		return 0, core.NewHazelcastSerializationError("cannot read portable fields after getRawDataInput called", nil)
 
 	}
 
 	if field.Type() != fieldType {
-		return 0, NewHazelcastSerializationError(fmt.Sprintf("not a %s field: %s", getTypeByConst(fieldType), fieldName), nil)
+		return 0, core.NewHazelcastSerializationError(fmt.Sprintf("not a %s field: %s", getTypeByConst(fieldType), fieldName), nil)
 	}
-	pos, err := pr.input.(*ObjectDataInput).ReadInt32WithPosition(pr.offset + field.Index()*Int32SizeInBytes)
+	pos, err := pr.input.(*ObjectDataInput).ReadInt32WithPosition(pr.offset + field.Index()*common.Int32SizeInBytes)
 	if err != nil {
 		return 0, err
 	}
@@ -104,11 +104,11 @@ func (pr *DefaultPortableReader) positionByField(fieldName string, fieldType int
 	if err != nil {
 		return 0, err
 	}
-	return pos + Int16SizeInBytes + int32(length) + 1, nil
+	return pos + common.Int16SizeInBytes + int32(length) + 1, nil
 }
 
 func (pr *DefaultPortableReader) ReadByte(fieldName string) (byte, error) {
-	pos, err := pr.positionByField(fieldName, TypeByte)
+	pos, err := pr.positionByField(fieldName, classdef.TypeByte)
 	if err != nil {
 		return 0, err
 	}
@@ -116,7 +116,7 @@ func (pr *DefaultPortableReader) ReadByte(fieldName string) (byte, error) {
 }
 
 func (pr *DefaultPortableReader) ReadBool(fieldName string) (bool, error) {
-	pos, err := pr.positionByField(fieldName, TypeBool)
+	pos, err := pr.positionByField(fieldName, classdef.TypeBool)
 	if err != nil {
 		return false, err
 	}
@@ -124,7 +124,7 @@ func (pr *DefaultPortableReader) ReadBool(fieldName string) (bool, error) {
 }
 
 func (pr *DefaultPortableReader) ReadUInt16(fieldName string) (uint16, error) {
-	pos, err := pr.positionByField(fieldName, TypeUint16)
+	pos, err := pr.positionByField(fieldName, classdef.TypeUint16)
 	if err != nil {
 		return 0, err
 	}
@@ -132,7 +132,7 @@ func (pr *DefaultPortableReader) ReadUInt16(fieldName string) (uint16, error) {
 }
 
 func (pr *DefaultPortableReader) ReadInt16(fieldName string) (int16, error) {
-	pos, err := pr.positionByField(fieldName, TypeInt16)
+	pos, err := pr.positionByField(fieldName, classdef.TypeInt16)
 	if err != nil {
 		return 0, err
 	}
@@ -140,7 +140,7 @@ func (pr *DefaultPortableReader) ReadInt16(fieldName string) (int16, error) {
 }
 
 func (pr *DefaultPortableReader) ReadInt32(fieldName string) (int32, error) {
-	pos, err := pr.positionByField(fieldName, TypeInt32)
+	pos, err := pr.positionByField(fieldName, classdef.TypeInt32)
 	if err != nil {
 		return 0, err
 	}
@@ -148,7 +148,7 @@ func (pr *DefaultPortableReader) ReadInt32(fieldName string) (int32, error) {
 }
 
 func (pr *DefaultPortableReader) ReadInt64(fieldName string) (int64, error) {
-	pos, err := pr.positionByField(fieldName, TypeInt64)
+	pos, err := pr.positionByField(fieldName, classdef.TypeInt64)
 	if err != nil {
 		return 0, err
 	}
@@ -156,7 +156,7 @@ func (pr *DefaultPortableReader) ReadInt64(fieldName string) (int64, error) {
 }
 
 func (pr *DefaultPortableReader) ReadFloat32(fieldName string) (float32, error) {
-	pos, err := pr.positionByField(fieldName, TypeFloat32)
+	pos, err := pr.positionByField(fieldName, classdef.TypeFloat32)
 	if err != nil {
 		return 0, err
 	}
@@ -164,7 +164,7 @@ func (pr *DefaultPortableReader) ReadFloat32(fieldName string) (float32, error) 
 }
 
 func (pr *DefaultPortableReader) ReadFloat64(fieldName string) (float64, error) {
-	pos, err := pr.positionByField(fieldName, TypeFloat64)
+	pos, err := pr.positionByField(fieldName, classdef.TypeFloat64)
 	if err != nil {
 		return 0, err
 	}
@@ -172,17 +172,17 @@ func (pr *DefaultPortableReader) ReadFloat64(fieldName string) (float64, error) 
 }
 
 func (pr *DefaultPortableReader) ReadUTF(fieldName string) (string, error) {
-	pos, err := pr.positionByField(fieldName, TypeUTF)
+	pos, err := pr.positionByField(fieldName, classdef.TypeUTF)
 	if err != nil {
 		return "", err
 	}
 	return pr.input.(*ObjectDataInput).ReadUTFWithPosition(pos)
 }
 
-func (pr *DefaultPortableReader) ReadPortable(fieldName string) (Portable, error) {
+func (pr *DefaultPortableReader) ReadPortable(fieldName string) (serialization.Portable, error) {
 	backupPos := pr.input.Position()
 	defer pr.input.SetPosition(backupPos)
-	pos, err := pr.positionByField(fieldName, TypePortable)
+	pos, err := pr.positionByField(fieldName, classdef.TypePortable)
 	if err != nil {
 		return nil, err
 	}
@@ -206,7 +206,7 @@ func (pr *DefaultPortableReader) ReadPortable(fieldName string) (Portable, error
 }
 
 func (pr *DefaultPortableReader) ReadByteArray(fieldName string) ([]byte, error) {
-	pos, err := pr.positionByField(fieldName, TypeByteArray)
+	pos, err := pr.positionByField(fieldName, classdef.TypeByteArray)
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +214,7 @@ func (pr *DefaultPortableReader) ReadByteArray(fieldName string) ([]byte, error)
 }
 
 func (pr *DefaultPortableReader) ReadBoolArray(fieldName string) ([]bool, error) {
-	pos, err := pr.positionByField(fieldName, TypeBoolArray)
+	pos, err := pr.positionByField(fieldName, classdef.TypeBoolArray)
 	if err != nil {
 		return nil, err
 	}
@@ -222,7 +222,7 @@ func (pr *DefaultPortableReader) ReadBoolArray(fieldName string) ([]bool, error)
 }
 
 func (pr *DefaultPortableReader) ReadUInt16Array(fieldName string) ([]uint16, error) {
-	pos, err := pr.positionByField(fieldName, TypeUint16Array)
+	pos, err := pr.positionByField(fieldName, classdef.TypeUint16Array)
 	if err != nil {
 		return nil, err
 	}
@@ -230,7 +230,7 @@ func (pr *DefaultPortableReader) ReadUInt16Array(fieldName string) ([]uint16, er
 }
 
 func (pr *DefaultPortableReader) ReadInt16Array(fieldName string) ([]int16, error) {
-	pos, err := pr.positionByField(fieldName, TypeInt16Array)
+	pos, err := pr.positionByField(fieldName, classdef.TypeInt16Array)
 	if err != nil {
 		return nil, err
 	}
@@ -238,7 +238,7 @@ func (pr *DefaultPortableReader) ReadInt16Array(fieldName string) ([]int16, erro
 }
 
 func (pr *DefaultPortableReader) ReadInt32Array(fieldName string) ([]int32, error) {
-	pos, err := pr.positionByField(fieldName, TypeInt32Array)
+	pos, err := pr.positionByField(fieldName, classdef.TypeInt32Array)
 	if err != nil {
 		return nil, err
 	}
@@ -246,7 +246,7 @@ func (pr *DefaultPortableReader) ReadInt32Array(fieldName string) ([]int32, erro
 }
 
 func (pr *DefaultPortableReader) ReadInt64Array(fieldName string) ([]int64, error) {
-	pos, err := pr.positionByField(fieldName, TypeInt64Array)
+	pos, err := pr.positionByField(fieldName, classdef.TypeInt64Array)
 	if err != nil {
 		return nil, err
 	}
@@ -254,7 +254,7 @@ func (pr *DefaultPortableReader) ReadInt64Array(fieldName string) ([]int64, erro
 }
 
 func (pr *DefaultPortableReader) ReadFloat32Array(fieldName string) ([]float32, error) {
-	pos, err := pr.positionByField(fieldName, TypeFloat32Array)
+	pos, err := pr.positionByField(fieldName, classdef.TypeFloat32Array)
 	if err != nil {
 		return nil, err
 	}
@@ -262,7 +262,7 @@ func (pr *DefaultPortableReader) ReadFloat32Array(fieldName string) ([]float32, 
 }
 
 func (pr *DefaultPortableReader) ReadFloat64Array(fieldName string) ([]float64, error) {
-	pos, err := pr.positionByField(fieldName, TypeFloat64Array)
+	pos, err := pr.positionByField(fieldName, classdef.TypeFloat64Array)
 	if err != nil {
 		return nil, err
 	}
@@ -270,24 +270,24 @@ func (pr *DefaultPortableReader) ReadFloat64Array(fieldName string) ([]float64, 
 }
 
 func (pr *DefaultPortableReader) ReadUTFArray(fieldName string) ([]string, error) {
-	pos, err := pr.positionByField(fieldName, TypeUTFArray)
+	pos, err := pr.positionByField(fieldName, classdef.TypeUTFArray)
 	if err != nil {
 		return nil, err
 	}
 	return pr.input.(*ObjectDataInput).ReadUTFArrayWithPosition(pos)
 }
 
-func (pr *DefaultPortableReader) ReadPortableArray(fieldName string) ([]Portable, error) {
+func (pr *DefaultPortableReader) ReadPortableArray(fieldName string) ([]serialization.Portable, error) {
 	backupPos := pr.input.Position()
 	defer pr.input.SetPosition(backupPos)
 
-	pos, err := pr.positionByField(fieldName, TypePortableArray)
+	pos, err := pr.positionByField(fieldName, classdef.TypePortableArray)
 	if err != nil {
 		return nil, err
 	}
 	pr.input.SetPosition(pos)
 	length, err := pr.input.ReadInt32()
-	if err != nil || length == NilArrayLength {
+	if err != nil || length == common.NilArrayLength {
 		return nil, err
 	}
 	factoryId, err := pr.input.ReadInt32()
@@ -298,11 +298,11 @@ func (pr *DefaultPortableReader) ReadPortableArray(fieldName string) ([]Portable
 	if err != nil {
 		return nil, err
 	}
-	var portables []Portable = make([]Portable, length)
+	var portables []serialization.Portable = make([]serialization.Portable, length)
 	if length > 0 {
 		offset := pr.input.Position()
 		for i := int32(0); i < length; i++ {
-			start, err := pr.input.(*ObjectDataInput).ReadInt32WithPosition(offset + i*Int32SizeInBytes)
+			start, err := pr.input.(*ObjectDataInput).ReadInt32WithPosition(offset + i*common.Int32SizeInBytes)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/serialization/default_portable_reader_test.go
+++ b/internal/serialization/default_portable_reader_test.go
@@ -15,17 +15,17 @@
 package serialization
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/config"
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization/classdef"
-	. "github.com/hazelcast/hazelcast-go-client/serialization"
+	"github.com/hazelcast/hazelcast-go-client/config"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization/classdef"
+	"github.com/hazelcast/hazelcast-go-client/serialization"
 	"reflect"
 	"testing"
 )
 
 func TestDefaultPortableReader_ReadByte(t *testing.T) {
 	var expectedRet byte = 12
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "type", TypeByte, classDef.FactoryId(), classDef.ClassId(), 0))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "type", classdef.TypeByte, classDef.FactoryId(), classDef.ClassId(), 0))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteByte("type", expectedRet)
@@ -40,8 +40,8 @@ func TestDefaultPortableReader_ReadByte(t *testing.T) {
 
 func TestDefaultPortableReader_ReadBool(t *testing.T) {
 	var expectedRet bool = false
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "isReady", TypeBool, classDef.FactoryId(), classDef.ClassId(), 0))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "isReady", classdef.TypeBool, classDef.FactoryId(), classDef.ClassId(), 0))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteBool("isReady", expectedRet)
@@ -57,8 +57,8 @@ func TestDefaultPortableReader_ReadBool(t *testing.T) {
 
 func TestDefaultPortableReader_ReadUInt16(t *testing.T) {
 	var expectedRet uint16 = 'E'
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "char", TypeUint16, classDef.FactoryId(), classDef.ClassId(), 0))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "char", classdef.TypeUint16, classDef.FactoryId(), classDef.ClassId(), 0))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteUInt16("char", expectedRet)
@@ -73,8 +73,8 @@ func TestDefaultPortableReader_ReadUInt16(t *testing.T) {
 
 func TestDefaultPortableReader_ReadInt16(t *testing.T) {
 	var expectedRet int16 = 22
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "age", TypeInt16, classDef.FactoryId(), classDef.ClassId(), 0))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "age", classdef.TypeInt16, classDef.FactoryId(), classDef.ClassId(), 0))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteInt16("age", expectedRet)
@@ -89,8 +89,8 @@ func TestDefaultPortableReader_ReadInt16(t *testing.T) {
 
 func TestDefaultPortableReader_ReadInt32(t *testing.T) {
 	var expectedRet int32 = 22
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "age", TypeInt32, classDef.FactoryId(), classDef.ClassId(), 0))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "age", classdef.TypeInt32, classDef.FactoryId(), classDef.ClassId(), 0))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteInt32("age", expectedRet)
@@ -105,8 +105,8 @@ func TestDefaultPortableReader_ReadInt32(t *testing.T) {
 
 func TestDefaultPortableReader_ReadInt64(t *testing.T) {
 	var expectedRet int64 = 1000
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "score", TypeInt64, classDef.FactoryId(), classDef.ClassId(), 0))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "score", classdef.TypeInt64, classDef.FactoryId(), classDef.ClassId(), 0))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteInt64("score", expectedRet)
@@ -121,8 +121,8 @@ func TestDefaultPortableReader_ReadInt64(t *testing.T) {
 
 func TestDefaultPortableReader_ReadFloat32(t *testing.T) {
 	var expectedRet float32 = 18.2347123
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "rate", TypeFloat32, classDef.FactoryId(), classDef.ClassId(), 0))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "rate", classdef.TypeFloat32, classDef.FactoryId(), classDef.ClassId(), 0))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteFloat32("rate", expectedRet)
@@ -137,8 +137,8 @@ func TestDefaultPortableReader_ReadFloat32(t *testing.T) {
 
 func TestDefaultPortableReader_ReadFloat64(t *testing.T) {
 	var expectedRet float64 = 19.23433747
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "velocity", TypeFloat64, classDef.FactoryId(), classDef.ClassId(), 0))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "velocity", classdef.TypeFloat64, classDef.FactoryId(), classDef.ClassId(), 0))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteFloat64("velocity", expectedRet)
@@ -153,8 +153,8 @@ func TestDefaultPortableReader_ReadFloat64(t *testing.T) {
 
 func TestDefaultPortableReader_ReadUTF(t *testing.T) {
 	var expectedRet string = ""
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "engineer", TypeUTF, classDef.FactoryId(), classDef.ClassId(), 0))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "engineer", classdef.TypeUTF, classDef.FactoryId(), classDef.ClassId(), 0))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteUTF("engineer", expectedRet)
@@ -168,12 +168,12 @@ func TestDefaultPortableReader_ReadUTF(t *testing.T) {
 }
 
 func TestDefaultPortableReader_ReadPortable(t *testing.T) {
-	var expectedRet Portable = &student{10, 22, "Furkan Şenharputlu"}
-	config := NewSerializationConfig()
+	var expectedRet serialization.Portable = &student{10, 22, "Furkan Şenharputlu"}
+	config := config.NewSerializationConfig()
 	config.AddPortableFactory(2, &PortableFactory1{})
-	classDef := NewClassDefinitionImpl(2, 1, 3)
+	classDef := classdef.NewClassDefinitionImpl(2, 1, 3)
 	service := NewSerializationService(config)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "engineer", TypePortable, classDef.FactoryId(), classDef.ClassId(), 0))
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "engineer", classdef.TypePortable, classDef.FactoryId(), classDef.ClassId(), 0))
 	o := NewPositionalObjectDataOutput(0, service, false)
 	serializer, _ := service.FindSerializerFor(expectedRet)
 	pw := NewDefaultPortableWriter(serializer.(*PortableSerializer), o, classDef)
@@ -189,12 +189,12 @@ func TestDefaultPortableReader_ReadPortable(t *testing.T) {
 }
 
 func TestDefaultPortableReader_ReadNilPortable(t *testing.T) {
-	var expectedRet Portable = nil
-	config := NewSerializationConfig()
+	var expectedRet serialization.Portable = nil
+	config := config.NewSerializationConfig()
 	config.AddPortableFactory(2, &PortableFactory1{})
-	classDef := NewClassDefinitionImpl(2, 1, 3)
+	classDef := classdef.NewClassDefinitionImpl(2, 1, 3)
 	service := NewSerializationService(config)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "engineer", TypePortable, classDef.FactoryId(), classDef.ClassId(), 0))
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "engineer", classdef.TypePortable, classDef.FactoryId(), classDef.ClassId(), 0))
 	o := NewPositionalObjectDataOutput(0, service, false)
 
 	pw := NewDefaultPortableWriter(nil, o, classDef)
@@ -211,8 +211,8 @@ func TestDefaultPortableReader_ReadNilPortable(t *testing.T) {
 
 func TestDefaultPortableReader_ReadByteArray(t *testing.T) {
 	var expectedRet []byte = []byte{9, 12, 34, 6, 7, 3, 2, 0, 10, 2, 0}
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "types", TypeByteArray, classDef.FactoryId(), classDef.ClassId(), 0))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "types", classdef.TypeByteArray, classDef.FactoryId(), classDef.ClassId(), 0))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteByteArray("types", expectedRet)
@@ -228,8 +228,8 @@ func TestDefaultPortableReader_ReadByteArray(t *testing.T) {
 
 func TestDefaultPortableReader_ReadBoolArray(t *testing.T) {
 	var expectedRet []bool = []bool{true, true, false, true, false, false, false, true, false, true, true}
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "areReady", TypeBoolArray, classDef.FactoryId(), classDef.ClassId(), 0))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "areReady", classdef.TypeBoolArray, classDef.FactoryId(), classDef.ClassId(), 0))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteBoolArray("areReady", expectedRet)
@@ -245,8 +245,8 @@ func TestDefaultPortableReader_ReadBoolArray(t *testing.T) {
 
 func TestDefaultPortableReader_ReadUInt16Array(t *testing.T) {
 	var expectedRet []uint16 = []uint16{'^', '%', '#', '!', '$'}
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "scores", TypeUint16Array, classDef.FactoryId(), classDef.ClassId(), 0))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "scores", classdef.TypeUint16Array, classDef.FactoryId(), classDef.ClassId(), 0))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteUInt16Array("scores", expectedRet)
@@ -262,8 +262,8 @@ func TestDefaultPortableReader_ReadUInt16Array(t *testing.T) {
 
 func TestDefaultPortableReader_ReadInt16Array(t *testing.T) {
 	var expectedRet []int16 = []int16{9432, 12, 34, 126, 7, 343, 2, 0, 1120, 222, 440}
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "scores", TypeInt16Array, classDef.FactoryId(), classDef.ClassId(), 0))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "scores", classdef.TypeInt16Array, classDef.FactoryId(), classDef.ClassId(), 0))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteInt16Array("scores", expectedRet)
@@ -279,8 +279,8 @@ func TestDefaultPortableReader_ReadInt16Array(t *testing.T) {
 
 func TestDefaultPortableReader_ReadInt32Array(t *testing.T) {
 	var expectedRet []int32 = []int32{9432, 12, 34, 6123, 45367, 31341, 43142, 78690, 16790, 362, 0}
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "scores", TypeInt32Array, classDef.FactoryId(), classDef.ClassId(), 0))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "scores", classdef.TypeInt32Array, classDef.FactoryId(), classDef.ClassId(), 0))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteInt32Array("scores", expectedRet)
@@ -296,8 +296,8 @@ func TestDefaultPortableReader_ReadInt32Array(t *testing.T) {
 
 func TestDefaultPortableReader_ReadInt64Array(t *testing.T) {
 	var expectedRet []int64 = []int64{9412332, 929812, 34, 61223493, 4523367, 31235341, 46423142, 78690, 16790, 3662, 0}
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "scores", TypeInt64Array, classDef.FactoryId(), classDef.ClassId(), 0))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "scores", classdef.TypeInt64Array, classDef.FactoryId(), classDef.ClassId(), 0))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteInt64Array("scores", expectedRet)
@@ -313,8 +313,8 @@ func TestDefaultPortableReader_ReadInt64Array(t *testing.T) {
 
 func TestDefaultPortableReader_ReadFloat32Array(t *testing.T) {
 	var expectedRet []float32 = []float32{12.1431, 1212.3, 34, 6123, 4.5367, 3.1341, 43.142, 786.90, 16.790, 3.62, 0}
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "longitude", TypeFloat32Array, classDef.FactoryId(), classDef.ClassId(), 0))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "longitude", classdef.TypeFloat32Array, classDef.FactoryId(), classDef.ClassId(), 0))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteFloat32Array("longitude", expectedRet)
@@ -330,8 +330,8 @@ func TestDefaultPortableReader_ReadFloat32Array(t *testing.T) {
 
 func TestDefaultPortableReader_ReadFloat64Array(t *testing.T) {
 	var expectedRet []float64 = []float64{12234.1431, 121092.3, 34, 6123, 499.5364327, 3.1323441, 43.142, 799986.90, 16.790, 3.9996342, 0}
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "longitude", TypeFloat64Array, classDef.FactoryId(), classDef.ClassId(), 0))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "longitude", classdef.TypeFloat64Array, classDef.FactoryId(), classDef.ClassId(), 0))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteFloat64Array("longitude", expectedRet)
@@ -347,8 +347,8 @@ func TestDefaultPortableReader_ReadFloat64Array(t *testing.T) {
 
 func TestDefaultPortableReader_ReadUTFArray(t *testing.T) {
 	var expectedRet []string = []string{"Furkan Şenharputlu", "こんにちは", "おはようございます", "今晩は"}
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "words", TypeUTFArray, classDef.FactoryId(), classDef.ClassId(), 0))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "words", classdef.TypeUTFArray, classDef.FactoryId(), classDef.ClassId(), 0))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteUTFArray("words", expectedRet)
@@ -363,12 +363,12 @@ func TestDefaultPortableReader_ReadUTFArray(t *testing.T) {
 }
 
 func TestDefaultPortableReader_ReadPortableArray(t *testing.T) {
-	var expectedRet []Portable = []Portable{&student{10, 22, "Furkan Şenharputlu"}, &student{11, 20, "Jack Purcell"}}
-	config := NewSerializationConfig()
+	var expectedRet []serialization.Portable = []serialization.Portable{&student{10, 22, "Furkan Şenharputlu"}, &student{11, 20, "Jack Purcell"}}
+	config := config.NewSerializationConfig()
 	config.AddPortableFactory(2, &PortableFactory1{})
-	classDef := NewClassDefinitionImpl(2, 1, 3)
+	classDef := classdef.NewClassDefinitionImpl(2, 1, 3)
 	service := NewSerializationService(config)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "engineers", TypePortableArray, classDef.FactoryId(), classDef.ClassId(), 0))
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "engineers", classdef.TypePortableArray, classDef.FactoryId(), classDef.ClassId(), 0))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	serializer := NewPortableSerializer(service, config.PortableFactories(), 0)
 	pw := NewDefaultPortableWriter(serializer, o, classDef)
@@ -384,22 +384,22 @@ func TestDefaultPortableReader_ReadPortableArray(t *testing.T) {
 }
 
 func TestDefaultPortableReader_NilObjects(t *testing.T) {
-	var expectedRet Portable = nil
-	config := NewSerializationConfig()
+	var expectedRet serialization.Portable = nil
+	config := config.NewSerializationConfig()
 	config.AddPortableFactory(2, &PortableFactory1{})
-	classDef := NewClassDefinitionImpl(2, 1, 3)
+	classDef := classdef.NewClassDefinitionImpl(2, 1, 3)
 	service := NewSerializationService(config)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "engineer", TypePortable, classDef.FactoryId(), classDef.ClassId(), 3))
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(1, "name", TypeUTF, classDef.FactoryId(), classDef.ClassId(), 3))
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(2, "a1", TypeByteArray, classDef.FactoryId(), classDef.ClassId(), 3))
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(3, "a2", TypeBoolArray, classDef.FactoryId(), classDef.ClassId(), 3))
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(4, "a3", TypeUint16Array, classDef.FactoryId(), classDef.ClassId(), 3))
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(5, "a4", TypeInt16Array, classDef.FactoryId(), classDef.ClassId(), 3))
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(6, "a5", TypeInt32Array, classDef.FactoryId(), classDef.ClassId(), 3))
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(7, "a6", TypeInt64Array, classDef.FactoryId(), classDef.ClassId(), 3))
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(8, "a7", TypeFloat32Array, classDef.FactoryId(), classDef.ClassId(), 3))
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(9, "a8", TypeFloat64Array, classDef.FactoryId(), classDef.ClassId(), 3))
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(10, "a9", TypeUTFArray, classDef.FactoryId(), classDef.ClassId(), 3))
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "engineer", classdef.TypePortable, classDef.FactoryId(), classDef.ClassId(), 3))
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(1, "name", classdef.TypeUTF, classDef.FactoryId(), classDef.ClassId(), 3))
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(2, "a1", classdef.TypeByteArray, classDef.FactoryId(), classDef.ClassId(), 3))
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(3, "a2", classdef.TypeBoolArray, classDef.FactoryId(), classDef.ClassId(), 3))
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(4, "a3", classdef.TypeUint16Array, classDef.FactoryId(), classDef.ClassId(), 3))
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(5, "a4", classdef.TypeInt16Array, classDef.FactoryId(), classDef.ClassId(), 3))
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(6, "a5", classdef.TypeInt32Array, classDef.FactoryId(), classDef.ClassId(), 3))
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(7, "a6", classdef.TypeInt64Array, classDef.FactoryId(), classDef.ClassId(), 3))
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(8, "a7", classdef.TypeFloat32Array, classDef.FactoryId(), classDef.ClassId(), 3))
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(9, "a8", classdef.TypeFloat64Array, classDef.FactoryId(), classDef.ClassId(), 3))
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(10, "a9", classdef.TypeUTFArray, classDef.FactoryId(), classDef.ClassId(), 3))
 	o := NewPositionalObjectDataOutput(0, service, false)
 
 	pw := NewDefaultPortableWriter(nil, o, classDef)

--- a/internal/serialization/default_portable_writer.go
+++ b/internal/serialization/default_portable_writer.go
@@ -15,76 +15,76 @@
 package serialization
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization/classdef"
-	. "github.com/hazelcast/hazelcast-go-client/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization/classdef"
+	"github.com/hazelcast/hazelcast-go-client/serialization"
 )
 
 type DefaultPortableWriter struct {
 	serializer      *PortableSerializer
-	output          PositionalDataOutput
-	classDefinition ClassDefinition
+	output          serialization.PositionalDataOutput
+	classDefinition serialization.ClassDefinition
 	begin           int32
 	offset          int32
 }
 
-func NewDefaultPortableWriter(serializer *PortableSerializer, output PositionalDataOutput, classDefinition ClassDefinition) *DefaultPortableWriter {
+func NewDefaultPortableWriter(serializer *PortableSerializer, output serialization.PositionalDataOutput, classDefinition serialization.ClassDefinition) *DefaultPortableWriter {
 	begin := output.Position()
 	output.WriteZeroBytes(4)
 	output.WriteInt32(int32(classDefinition.FieldCount()))
 	offset := output.Position()
-	fieldIndexesLength := (classDefinition.FieldCount() + 1) * Int32SizeInBytes
+	fieldIndexesLength := (classDefinition.FieldCount() + 1) * common.Int32SizeInBytes
 	output.WriteZeroBytes(int(fieldIndexesLength))
 	return &DefaultPortableWriter{serializer, output, classDefinition, begin, offset}
 }
 
 func (pw *DefaultPortableWriter) WriteByte(fieldName string, value byte) {
-	pw.setPosition(fieldName, TypeByte)
+	pw.setPosition(fieldName, classdef.TypeByte)
 	pw.output.WriteByte(value)
 }
 
 func (pw *DefaultPortableWriter) WriteBool(fieldName string, value bool) {
-	pw.setPosition(fieldName, TypeBool)
+	pw.setPosition(fieldName, classdef.TypeBool)
 	pw.output.WriteBool(value)
 }
 
 func (pw *DefaultPortableWriter) WriteUInt16(fieldName string, value uint16) {
-	pw.setPosition(fieldName, TypeUint16)
+	pw.setPosition(fieldName, classdef.TypeUint16)
 	pw.output.WriteUInt16(value)
 }
 
 func (pw *DefaultPortableWriter) WriteInt16(fieldName string, value int16) {
-	pw.setPosition(fieldName, TypeInt16)
+	pw.setPosition(fieldName, classdef.TypeInt16)
 	pw.output.WriteInt16(value)
 }
 
 func (pw *DefaultPortableWriter) WriteInt32(fieldName string, value int32) {
-	pw.setPosition(fieldName, TypeInt32)
+	pw.setPosition(fieldName, classdef.TypeInt32)
 	pw.output.WriteInt32(value)
 }
 
 func (pw *DefaultPortableWriter) WriteInt64(fieldName string, value int64) {
-	pw.setPosition(fieldName, TypeInt64)
+	pw.setPosition(fieldName, classdef.TypeInt64)
 	pw.output.WriteInt64(value)
 }
 
 func (pw *DefaultPortableWriter) WriteFloat32(fieldName string, value float32) {
-	pw.setPosition(fieldName, TypeFloat32)
+	pw.setPosition(fieldName, classdef.TypeFloat32)
 	pw.output.WriteFloat32(value)
 }
 
 func (pw *DefaultPortableWriter) WriteFloat64(fieldName string, value float64) {
-	pw.setPosition(fieldName, TypeFloat64)
+	pw.setPosition(fieldName, classdef.TypeFloat64)
 	pw.output.WriteFloat64(value)
 }
 
 func (pw *DefaultPortableWriter) WriteUTF(fieldName string, value string) {
-	pw.setPosition(fieldName, TypeUTF)
+	pw.setPosition(fieldName, classdef.TypeUTF)
 	pw.output.WriteUTF(value)
 }
 
-func (pw *DefaultPortableWriter) WritePortable(fieldName string, portable Portable) error {
-	fieldDefinition := pw.setPosition(fieldName, TypePortable)
+func (pw *DefaultPortableWriter) WritePortable(fieldName string, portable serialization.Portable) error {
+	fieldDefinition := pw.setPosition(fieldName, classdef.TypePortable)
 	isNullPortable := portable == nil
 	pw.output.WriteBool(isNullPortable)
 	pw.output.WriteInt32(fieldDefinition.FactoryId())
@@ -99,7 +99,7 @@ func (pw *DefaultPortableWriter) WritePortable(fieldName string, portable Portab
 }
 
 func (pw *DefaultPortableWriter) WriteNilPortable(fieldName string, factoryId int32, classId int32) error {
-	pw.setPosition(fieldName, TypePortable)
+	pw.setPosition(fieldName, classdef.TypePortable)
 	pw.output.WriteBool(true)
 	pw.output.WriteInt32(factoryId)
 	pw.output.WriteInt32(classId)
@@ -107,59 +107,59 @@ func (pw *DefaultPortableWriter) WriteNilPortable(fieldName string, factoryId in
 }
 
 func (pw *DefaultPortableWriter) WriteByteArray(fieldName string, array []byte) {
-	pw.setPosition(fieldName, TypeByteArray)
+	pw.setPosition(fieldName, classdef.TypeByteArray)
 	pw.output.WriteByteArray(array)
 }
 
 func (pw *DefaultPortableWriter) WriteBoolArray(fieldName string, array []bool) {
-	pw.setPosition(fieldName, TypeBoolArray)
+	pw.setPosition(fieldName, classdef.TypeBoolArray)
 	pw.output.WriteBoolArray(array)
 }
 
 func (pw *DefaultPortableWriter) WriteUInt16Array(fieldName string, array []uint16) {
-	pw.setPosition(fieldName, TypeUint16Array)
+	pw.setPosition(fieldName, classdef.TypeUint16Array)
 	pw.output.WriteUInt16Array(array)
 }
 
 func (pw *DefaultPortableWriter) WriteInt16Array(fieldName string, array []int16) {
-	pw.setPosition(fieldName, TypeInt16Array)
+	pw.setPosition(fieldName, classdef.TypeInt16Array)
 	pw.output.WriteInt16Array(array)
 }
 
 func (pw *DefaultPortableWriter) WriteInt32Array(fieldName string, array []int32) {
-	pw.setPosition(fieldName, TypeInt32Array)
+	pw.setPosition(fieldName, classdef.TypeInt32Array)
 	pw.output.WriteInt32Array(array)
 }
 
 func (pw *DefaultPortableWriter) WriteInt64Array(fieldName string, array []int64) {
-	pw.setPosition(fieldName, TypeInt64Array)
+	pw.setPosition(fieldName, classdef.TypeInt64Array)
 	pw.output.WriteInt64Array(array)
 }
 
 func (pw *DefaultPortableWriter) WriteFloat32Array(fieldName string, array []float32) {
-	pw.setPosition(fieldName, TypeFloat32Array)
+	pw.setPosition(fieldName, classdef.TypeFloat32Array)
 	pw.output.WriteFloat32Array(array)
 }
 
 func (pw *DefaultPortableWriter) WriteFloat64Array(fieldName string, array []float64) {
-	pw.setPosition(fieldName, TypeFloat64Array)
+	pw.setPosition(fieldName, classdef.TypeFloat64Array)
 	pw.output.WriteFloat64Array(array)
 }
 
 func (pw *DefaultPortableWriter) WriteUTFArray(fieldName string, array []string) {
-	pw.setPosition(fieldName, TypeUTFArray)
+	pw.setPosition(fieldName, classdef.TypeUTFArray)
 	pw.output.WriteUTFArray(array)
 }
 
-func (pw *DefaultPortableWriter) WritePortableArray(fieldName string, portableArray []Portable) error {
+func (pw *DefaultPortableWriter) WritePortableArray(fieldName string, portableArray []serialization.Portable) error {
 	var innerOffset int32
-	var sample Portable
-	fieldDefinition := pw.setPosition(fieldName, TypePortableArray)
+	var sample serialization.Portable
+	fieldDefinition := pw.setPosition(fieldName, classdef.TypePortableArray)
 	var length int32
 	if portableArray != nil {
 		length = int32(len(portableArray))
 	} else {
-		length = NilArrayLength
+		length = common.NilArrayLength
 	}
 	pw.output.WriteInt32(length)
 	pw.output.WriteInt32(fieldDefinition.FactoryId())
@@ -171,7 +171,7 @@ func (pw *DefaultPortableWriter) WritePortableArray(fieldName string, portableAr
 		for i := int32(0); i < length; i++ {
 			sample = portableArray[i]
 			posVal := pw.output.Position()
-			pw.output.PWriteInt32(innerOffset+i*Int32SizeInBytes, posVal)
+			pw.output.PWriteInt32(innerOffset+i*common.Int32SizeInBytes, posVal)
 			err := pw.serializer.WriteObject(pw.output, sample)
 			if err != nil {
 				return err
@@ -181,11 +181,11 @@ func (pw *DefaultPortableWriter) WritePortableArray(fieldName string, portableAr
 	return nil
 }
 
-func (pw *DefaultPortableWriter) setPosition(fieldName string, fieldType int32) FieldDefinition {
+func (pw *DefaultPortableWriter) setPosition(fieldName string, fieldType int32) serialization.FieldDefinition {
 	field := pw.classDefinition.Field(fieldName)
 	pos := pw.output.Position()
 	index := field.Index()
-	pw.output.PWriteInt32(pw.offset+index*Int32SizeInBytes, pos)
+	pw.output.PWriteInt32(pw.offset+index*common.Int32SizeInBytes, pos)
 	pw.output.WriteInt16(int16(len(fieldName)))
 	pw.output.WriteBytes(fieldName)
 	pw.output.WriteByte(byte(fieldType))

--- a/internal/serialization/default_serializer.go
+++ b/internal/serialization/default_serializer.go
@@ -18,8 +18,8 @@ import (
 	"bytes"
 	"encoding/gob"
 	"fmt"
-	. "github.com/hazelcast/hazelcast-go-client/core"
-	. "github.com/hazelcast/hazelcast-go-client/serialization"
+	"github.com/hazelcast/hazelcast-go-client/core"
+	"github.com/hazelcast/hazelcast-go-client/serialization"
 	"reflect"
 )
 
@@ -29,20 +29,20 @@ func (*NilSerializer) Id() int32 {
 	return ConstantTypeNil
 }
 
-func (*NilSerializer) Read(input DataInput) (interface{}, error) {
+func (*NilSerializer) Read(input serialization.DataInput) (interface{}, error) {
 	return nil, nil
 }
 
-func (*NilSerializer) Write(output DataOutput, i interface{}) error {
+func (*NilSerializer) Write(output serialization.DataOutput, i interface{}) error {
 	// Empty method
 	return nil
 }
 
 type IdentifiedDataSerializableSerializer struct {
-	factories map[int32]IdentifiedDataSerializableFactory
+	factories map[int32]serialization.IdentifiedDataSerializableFactory
 }
 
-func NewIdentifiedDataSerializableSerializer(factories map[int32]IdentifiedDataSerializableFactory) *IdentifiedDataSerializableSerializer {
+func NewIdentifiedDataSerializableSerializer(factories map[int32]serialization.IdentifiedDataSerializableFactory) *IdentifiedDataSerializableSerializer {
 	return &IdentifiedDataSerializableSerializer{factories: factories}
 }
 
@@ -50,13 +50,13 @@ func (*IdentifiedDataSerializableSerializer) Id() int32 {
 	return ConstantTypeDataSerializable
 }
 
-func (idss *IdentifiedDataSerializableSerializer) Read(input DataInput) (interface{}, error) {
+func (idss *IdentifiedDataSerializableSerializer) Read(input serialization.DataInput) (interface{}, error) {
 	isIdentified, err := input.ReadBool()
 	if err != nil {
 		return nil, err
 	}
 	if !isIdentified {
-		return nil, NewHazelcastSerializationError("native clients do not support DataSerializable, please use IdentifiedDataSerializable", nil)
+		return nil, core.NewHazelcastSerializationError("native clients do not support DataSerializable, please use IdentifiedDataSerializable", nil)
 	}
 	factoryId, err := input.ReadInt32()
 	if err != nil {
@@ -67,14 +67,14 @@ func (idss *IdentifiedDataSerializableSerializer) Read(input DataInput) (interfa
 		return nil, err
 	}
 
-	var factory IdentifiedDataSerializableFactory
+	var factory serialization.IdentifiedDataSerializableFactory
 	factory = idss.factories[factoryId]
 	if factory == nil {
-		return nil, NewHazelcastSerializationError(fmt.Sprintf("there is no IdentifiedDataSerializable factory with id: %d", factoryId), nil)
+		return nil, core.NewHazelcastSerializationError(fmt.Sprintf("there is no IdentifiedDataSerializable factory with id: %d", factoryId), nil)
 	}
 	var object = factory.Create(classId)
 	if object == nil {
-		return nil, NewHazelcastSerializationError(fmt.Sprintf("%v is not able to create an instance for id: %v on factory id: %v",
+		return nil, core.NewHazelcastSerializationError(fmt.Sprintf("%v is not able to create an instance for id: %v on factory id: %v",
 			reflect.TypeOf(factory), classId, factoryId), nil)
 	}
 	err = object.ReadData(input)
@@ -84,8 +84,8 @@ func (idss *IdentifiedDataSerializableSerializer) Read(input DataInput) (interfa
 	return object, nil
 }
 
-func (*IdentifiedDataSerializableSerializer) Write(output DataOutput, i interface{}) error {
-	r := i.(IdentifiedDataSerializable)
+func (*IdentifiedDataSerializableSerializer) Write(output serialization.DataOutput, i interface{}) error {
+	r := i.(serialization.IdentifiedDataSerializable)
 	output.WriteBool(true)
 	output.WriteInt32(r.FactoryId())
 	output.WriteInt32(r.ClassId())
@@ -98,11 +98,11 @@ func (*ByteSerializer) Id() int32 {
 	return ConstantTypeByte
 }
 
-func (*ByteSerializer) Read(input DataInput) (interface{}, error) {
+func (*ByteSerializer) Read(input serialization.DataInput) (interface{}, error) {
 	return input.ReadByte()
 }
 
-func (*ByteSerializer) Write(output DataOutput, i interface{}) error {
+func (*ByteSerializer) Write(output serialization.DataOutput, i interface{}) error {
 	output.WriteByte(i.(byte))
 	return nil
 }
@@ -113,11 +113,11 @@ func (*BoolSerializer) Id() int32 {
 	return ConstantTypeBool
 }
 
-func (*BoolSerializer) Read(input DataInput) (interface{}, error) {
+func (*BoolSerializer) Read(input serialization.DataInput) (interface{}, error) {
 	return input.ReadBool()
 }
 
-func (*BoolSerializer) Write(output DataOutput, i interface{}) error {
+func (*BoolSerializer) Write(output serialization.DataOutput, i interface{}) error {
 	output.WriteBool(i.(bool))
 	return nil
 }
@@ -128,11 +128,11 @@ func (*UInteger16Serializer) Id() int32 {
 	return ConstantTypeUInteger16
 }
 
-func (*UInteger16Serializer) Read(input DataInput) (interface{}, error) {
+func (*UInteger16Serializer) Read(input serialization.DataInput) (interface{}, error) {
 	return input.ReadUInt16()
 }
 
-func (*UInteger16Serializer) Write(output DataOutput, i interface{}) error {
+func (*UInteger16Serializer) Write(output serialization.DataOutput, i interface{}) error {
 	output.WriteUInt16(i.(uint16))
 	return nil
 }
@@ -143,11 +143,11 @@ func (*Integer16Serializer) Id() int32 {
 	return ConstantTypeInteger16
 }
 
-func (*Integer16Serializer) Read(input DataInput) (interface{}, error) {
+func (*Integer16Serializer) Read(input serialization.DataInput) (interface{}, error) {
 	return input.ReadInt16()
 }
 
-func (*Integer16Serializer) Write(output DataOutput, i interface{}) error {
+func (*Integer16Serializer) Write(output serialization.DataOutput, i interface{}) error {
 	output.WriteInt16(i.(int16))
 	return nil
 }
@@ -158,11 +158,11 @@ func (*Integer32Serializer) Id() int32 {
 	return ConstantTypeInteger32
 }
 
-func (*Integer32Serializer) Read(input DataInput) (interface{}, error) {
+func (*Integer32Serializer) Read(input serialization.DataInput) (interface{}, error) {
 	return input.ReadInt32()
 }
 
-func (*Integer32Serializer) Write(output DataOutput, i interface{}) error {
+func (*Integer32Serializer) Write(output serialization.DataOutput, i interface{}) error {
 	output.WriteInt32(i.(int32))
 	return nil
 }
@@ -173,11 +173,11 @@ func (*Integer64Serializer) Id() int32 {
 	return ConstantTypeInteger64
 }
 
-func (*Integer64Serializer) Read(input DataInput) (interface{}, error) {
+func (*Integer64Serializer) Read(input serialization.DataInput) (interface{}, error) {
 	return input.ReadInt64()
 }
 
-func (*Integer64Serializer) Write(output DataOutput, i interface{}) error {
+func (*Integer64Serializer) Write(output serialization.DataOutput, i interface{}) error {
 	val, ok := i.(int64)
 	if !ok {
 		val = int64(i.(int))
@@ -192,11 +192,11 @@ func (*Float32Serializer) Id() int32 {
 	return ConstantTypeFloat32
 }
 
-func (*Float32Serializer) Read(input DataInput) (interface{}, error) {
+func (*Float32Serializer) Read(input serialization.DataInput) (interface{}, error) {
 	return input.ReadFloat32()
 }
 
-func (*Float32Serializer) Write(output DataOutput, i interface{}) error {
+func (*Float32Serializer) Write(output serialization.DataOutput, i interface{}) error {
 	output.WriteFloat32(i.(float32))
 	return nil
 }
@@ -207,11 +207,11 @@ func (*Float64Serializer) Id() int32 {
 	return ConstantTypeFloat64
 }
 
-func (*Float64Serializer) Read(input DataInput) (interface{}, error) {
+func (*Float64Serializer) Read(input serialization.DataInput) (interface{}, error) {
 	return input.ReadFloat64()
 }
 
-func (*Float64Serializer) Write(output DataOutput, i interface{}) error {
+func (*Float64Serializer) Write(output serialization.DataOutput, i interface{}) error {
 	output.WriteFloat64(i.(float64))
 	return nil
 }
@@ -222,11 +222,11 @@ func (*StringSerializer) Id() int32 {
 	return ConstantTypeString
 }
 
-func (*StringSerializer) Read(input DataInput) (interface{}, error) {
+func (*StringSerializer) Read(input serialization.DataInput) (interface{}, error) {
 	return input.ReadUTF()
 }
 
-func (*StringSerializer) Write(output DataOutput, i interface{}) error {
+func (*StringSerializer) Write(output serialization.DataOutput, i interface{}) error {
 	output.WriteUTF(i.(string))
 	return nil
 }
@@ -237,11 +237,11 @@ func (*ByteArraySerializer) Id() int32 {
 	return ConstantTypeByteArray
 }
 
-func (*ByteArraySerializer) Read(input DataInput) (interface{}, error) {
+func (*ByteArraySerializer) Read(input serialization.DataInput) (interface{}, error) {
 	return input.ReadByteArray()
 }
 
-func (*ByteArraySerializer) Write(output DataOutput, i interface{}) error {
+func (*ByteArraySerializer) Write(output serialization.DataOutput, i interface{}) error {
 	output.WriteByteArray(i.([]byte))
 	return nil
 }
@@ -252,11 +252,11 @@ func (*BoolArraySerializer) Id() int32 {
 	return ConstantTypeBoolArray
 }
 
-func (*BoolArraySerializer) Read(input DataInput) (interface{}, error) {
+func (*BoolArraySerializer) Read(input serialization.DataInput) (interface{}, error) {
 	return input.ReadBoolArray()
 }
 
-func (*BoolArraySerializer) Write(output DataOutput, i interface{}) error {
+func (*BoolArraySerializer) Write(output serialization.DataOutput, i interface{}) error {
 	output.WriteBoolArray(i.([]bool))
 	return nil
 }
@@ -267,11 +267,11 @@ func (*UInteger16ArraySerializer) Id() int32 {
 	return ConstantTypeUInteger16Array
 }
 
-func (*UInteger16ArraySerializer) Read(input DataInput) (interface{}, error) {
+func (*UInteger16ArraySerializer) Read(input serialization.DataInput) (interface{}, error) {
 	return input.ReadUInt16Array()
 }
 
-func (*UInteger16ArraySerializer) Write(output DataOutput, i interface{}) error {
+func (*UInteger16ArraySerializer) Write(output serialization.DataOutput, i interface{}) error {
 	output.WriteUInt16Array(i.([]uint16))
 	return nil
 }
@@ -282,11 +282,11 @@ func (*Integer16ArraySerializer) Id() int32 {
 	return ConstantTypeInteger16Array
 }
 
-func (*Integer16ArraySerializer) Read(input DataInput) (interface{}, error) {
+func (*Integer16ArraySerializer) Read(input serialization.DataInput) (interface{}, error) {
 	return input.ReadInt16Array()
 }
 
-func (*Integer16ArraySerializer) Write(output DataOutput, i interface{}) error {
+func (*Integer16ArraySerializer) Write(output serialization.DataOutput, i interface{}) error {
 	output.WriteInt16Array(i.([]int16))
 	return nil
 }
@@ -297,11 +297,11 @@ func (*Integer32ArraySerializer) Id() int32 {
 	return ConstantTypeInteger32Array
 }
 
-func (*Integer32ArraySerializer) Read(input DataInput) (interface{}, error) {
+func (*Integer32ArraySerializer) Read(input serialization.DataInput) (interface{}, error) {
 	return input.ReadInt32Array()
 }
 
-func (*Integer32ArraySerializer) Write(output DataOutput, i interface{}) error {
+func (*Integer32ArraySerializer) Write(output serialization.DataOutput, i interface{}) error {
 	output.WriteInt32Array(i.([]int32))
 	return nil
 }
@@ -312,11 +312,11 @@ func (*Integer64ArraySerializer) Id() int32 {
 	return ConstantTypeInteger64Array
 }
 
-func (*Integer64ArraySerializer) Read(input DataInput) (interface{}, error) {
+func (*Integer64ArraySerializer) Read(input serialization.DataInput) (interface{}, error) {
 	return input.ReadInt64Array()
 }
 
-func (*Integer64ArraySerializer) Write(output DataOutput, i interface{}) error {
+func (*Integer64ArraySerializer) Write(output serialization.DataOutput, i interface{}) error {
 	val, ok := i.([]int64)
 	if !ok {
 		tmp := i.([]int)
@@ -336,11 +336,11 @@ func (*Float32ArraySerializer) Id() int32 {
 	return ConstantTypeFloat32Array
 }
 
-func (*Float32ArraySerializer) Read(input DataInput) (interface{}, error) {
+func (*Float32ArraySerializer) Read(input serialization.DataInput) (interface{}, error) {
 	return input.ReadFloat32Array()
 }
 
-func (*Float32ArraySerializer) Write(output DataOutput, i interface{}) error {
+func (*Float32ArraySerializer) Write(output serialization.DataOutput, i interface{}) error {
 	output.WriteFloat32Array(i.([]float32))
 	return nil
 }
@@ -351,11 +351,11 @@ func (*Float64ArraySerializer) Id() int32 {
 	return ConstantTypeFloat64Array
 }
 
-func (*Float64ArraySerializer) Read(input DataInput) (interface{}, error) {
+func (*Float64ArraySerializer) Read(input serialization.DataInput) (interface{}, error) {
 	return input.ReadFloat64Array()
 }
 
-func (*Float64ArraySerializer) Write(output DataOutput, i interface{}) error {
+func (*Float64ArraySerializer) Write(output serialization.DataOutput, i interface{}) error {
 	output.WriteFloat64Array(i.([]float64))
 	return nil
 }
@@ -366,11 +366,11 @@ func (*StringArraySerializer) Id() int32 {
 	return ConstantTypeStringArray
 }
 
-func (*StringArraySerializer) Read(input DataInput) (interface{}, error) {
+func (*StringArraySerializer) Read(input serialization.DataInput) (interface{}, error) {
 	return input.ReadUTFArray()
 }
 
-func (*StringArraySerializer) Write(output DataOutput, i interface{}) error {
+func (*StringArraySerializer) Write(output serialization.DataOutput, i interface{}) error {
 	output.WriteUTFArray(i.([]string))
 	return nil
 }
@@ -381,7 +381,7 @@ func (*GobSerializer) Id() int32 {
 	return GoGobSerializationType
 }
 
-func (*GobSerializer) Read(input DataInput) (interface{}, error) {
+func (*GobSerializer) Read(input serialization.DataInput) (interface{}, error) {
 	var network bytes.Buffer
 	data, err := input.ReadData()
 	if err != nil {
@@ -397,7 +397,7 @@ func (*GobSerializer) Read(input DataInput) (interface{}, error) {
 	return result, nil
 }
 
-func (*GobSerializer) Write(output DataOutput, i interface{}) error {
+func (*GobSerializer) Write(output serialization.DataOutput, i interface{}) error {
 	var network bytes.Buffer
 	t := reflect.TypeOf(i)
 	v := reflect.New(t).Elem().Interface()

--- a/internal/serialization/default_serializer_test.go
+++ b/internal/serialization/default_serializer_test.go
@@ -16,9 +16,9 @@ package serialization
 
 import (
 	"fmt"
-	. "github.com/hazelcast/hazelcast-go-client/config"
+	"github.com/hazelcast/hazelcast-go-client/config"
 	"github.com/hazelcast/hazelcast-go-client/core"
-	. "github.com/hazelcast/hazelcast-go-client/serialization"
+	"github.com/hazelcast/hazelcast-go-client/serialization"
 	"reflect"
 	"testing"
 )
@@ -38,7 +38,7 @@ func TestNilSerializer_Write(t *testing.T) {
 
 type factory struct{}
 
-func (factory) Create(classId int32) IdentifiedDataSerializable {
+func (factory) Create(classId int32) serialization.IdentifiedDataSerializable {
 	if classId == 1 {
 		return &employee{}
 	} else {
@@ -51,13 +51,13 @@ type employee struct {
 	name string
 }
 
-func (e *employee) ReadData(input DataInput) error {
+func (e *employee) ReadData(input serialization.DataInput) error {
 	e.age, _ = input.ReadInt32()
 	e.name, _ = input.ReadUTF()
 	return nil
 }
 
-func (e *employee) WriteData(output DataOutput) error {
+func (e *employee) WriteData(output serialization.DataOutput) error {
 	output.WriteInt32(e.age)
 	output.WriteUTF(e.name)
 	return nil
@@ -76,13 +76,13 @@ type customer struct {
 	name string
 }
 
-func (c *customer) ReadData(input DataInput) error {
+func (c *customer) ReadData(input serialization.DataInput) error {
 	c.age, _ = input.ReadInt32()
 	c.name, _ = input.ReadUTF()
 	return nil
 }
 
-func (c *customer) WriteData(output DataOutput) error {
+func (c *customer) WriteData(output serialization.DataOutput) error {
 	output.WriteInt32(c.age)
 	output.WriteUTF(c.name)
 	return nil
@@ -98,7 +98,7 @@ func (*customer) ClassId() int32 {
 
 func TestIdentifiedDataSerializableSerializer_Write(t *testing.T) {
 	var employee1 employee = employee{22, "Furkan Şenharputlu"}
-	c := NewSerializationConfig()
+	c := config.NewSerializationConfig()
 	c.AddDataSerializableFactory(employee1.FactoryId(), factory{})
 
 	service := NewSerializationService(c)
@@ -113,7 +113,7 @@ func TestIdentifiedDataSerializableSerializer_Write(t *testing.T) {
 
 func TestIdentifiedDataSerializableSerializer_NoInstanceCreated(t *testing.T) {
 	c := &customer{38, "Jack"}
-	config := NewSerializationConfig()
+	config := config.NewSerializationConfig()
 	config.AddDataSerializableFactory(c.FactoryId(), factory{})
 
 	service := NewSerializationService(config)
@@ -149,11 +149,11 @@ func (*x) ClassId() int32 {
 	return 1
 }
 
-func (*x) WriteData(output DataOutput) error {
+func (*x) WriteData(output serialization.DataOutput) error {
 	return nil
 }
 
-func (*x) ReadData(input DataInput) error {
+func (*x) ReadData(input serialization.DataInput) error {
 	return nil
 }
 

--- a/internal/serialization/morphing_portable_reader.go
+++ b/internal/serialization/morphing_portable_reader.go
@@ -17,15 +17,15 @@ package serialization
 import (
 	"fmt"
 	"github.com/hazelcast/hazelcast-go-client/core"
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization/classdef"
-	. "github.com/hazelcast/hazelcast-go-client/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization/classdef"
+	"github.com/hazelcast/hazelcast-go-client/serialization"
 )
 
 type MorphingPortableReader struct {
 	*DefaultPortableReader
 }
 
-func NewMorphingPortableReader(portableSerializer *PortableSerializer, input DataInput, classDefinition ClassDefinition) *MorphingPortableReader {
+func NewMorphingPortableReader(portableSerializer *PortableSerializer, input serialization.DataInput, classDefinition serialization.ClassDefinition) *MorphingPortableReader {
 	return &MorphingPortableReader{NewDefaultPortableReader(portableSerializer, input, classDefinition)}
 }
 
@@ -34,7 +34,7 @@ func (mpr *MorphingPortableReader) ReadByte(fieldName string) (byte, error) {
 	if fieldDef == nil {
 		return 0, nil
 	}
-	err := mpr.validateTypeCompatibility(fieldDef, TypeByte)
+	err := mpr.validateTypeCompatibility(fieldDef, classdef.TypeByte)
 	if err != nil {
 		return 0, err
 	}
@@ -46,7 +46,7 @@ func (mpr *MorphingPortableReader) ReadBool(fieldName string) (bool, error) {
 	if fieldDef == nil {
 		return false, nil
 	}
-	err := mpr.validateTypeCompatibility(fieldDef, TypeBool)
+	err := mpr.validateTypeCompatibility(fieldDef, classdef.TypeBool)
 	if err != nil {
 		return false, err
 	}
@@ -58,7 +58,7 @@ func (mpr *MorphingPortableReader) ReadUInt16(fieldName string) (uint16, error) 
 	if fieldDef == nil {
 		return 0, nil
 	}
-	err := mpr.validateTypeCompatibility(fieldDef, TypeUint16)
+	err := mpr.validateTypeCompatibility(fieldDef, classdef.TypeUint16)
 	if err != nil {
 		return 0, err
 	}
@@ -71,13 +71,13 @@ func (mpr *MorphingPortableReader) ReadInt16(fieldName string) (int16, error) {
 		return 0, nil
 	}
 	switch fieldDef.Type() {
-	case TypeInt16:
+	case classdef.TypeInt16:
 		return mpr.DefaultPortableReader.ReadInt16(fieldName)
-	case TypeByte:
+	case classdef.TypeByte:
 		ret, err := mpr.DefaultPortableReader.ReadByte(fieldName)
 		return int16(ret), err
 	default:
-		return 0, mpr.createIncompatibleClassChangeError(fieldDef, TypeInt16)
+		return 0, mpr.createIncompatibleClassChangeError(fieldDef, classdef.TypeInt16)
 	}
 }
 
@@ -87,19 +87,19 @@ func (mpr *MorphingPortableReader) ReadInt32(fieldName string) (int32, error) {
 		return 0, nil
 	}
 	switch fieldDef.Type() {
-	case TypeInt32:
+	case classdef.TypeInt32:
 		return mpr.DefaultPortableReader.ReadInt32(fieldName)
-	case TypeByte:
+	case classdef.TypeByte:
 		ret, err := mpr.DefaultPortableReader.ReadByte(fieldName)
 		return int32(ret), err
-	case TypeUint16:
+	case classdef.TypeUint16:
 		ret, err := mpr.DefaultPortableReader.ReadUInt16(fieldName)
 		return int32(ret), err
-	case TypeInt16:
+	case classdef.TypeInt16:
 		ret, err := mpr.DefaultPortableReader.ReadInt16(fieldName)
 		return int32(ret), err
 	default:
-		return 0, mpr.createIncompatibleClassChangeError(fieldDef, TypeInt32)
+		return 0, mpr.createIncompatibleClassChangeError(fieldDef, classdef.TypeInt32)
 	}
 }
 
@@ -109,22 +109,22 @@ func (mpr *MorphingPortableReader) ReadInt64(fieldName string) (int64, error) {
 		return 0, nil
 	}
 	switch fieldDef.Type() {
-	case TypeInt64:
+	case classdef.TypeInt64:
 		return mpr.DefaultPortableReader.ReadInt64(fieldName)
-	case TypeInt32:
+	case classdef.TypeInt32:
 		ret, err := mpr.DefaultPortableReader.ReadInt32(fieldName)
 		return int64(ret), err
-	case TypeByte:
+	case classdef.TypeByte:
 		ret, err := mpr.DefaultPortableReader.ReadByte(fieldName)
 		return int64(ret), err
-	case TypeUint16:
+	case classdef.TypeUint16:
 		ret, err := mpr.DefaultPortableReader.ReadUInt16(fieldName)
 		return int64(ret), err
-	case TypeInt16:
+	case classdef.TypeInt16:
 		ret, err := mpr.DefaultPortableReader.ReadInt16(fieldName)
 		return int64(ret), err
 	default:
-		return 0, mpr.createIncompatibleClassChangeError(fieldDef, TypeInt64)
+		return 0, mpr.createIncompatibleClassChangeError(fieldDef, classdef.TypeInt64)
 	}
 }
 
@@ -134,22 +134,22 @@ func (mpr *MorphingPortableReader) ReadFloat32(fieldName string) (float32, error
 		return 0, nil
 	}
 	switch fieldDef.Type() {
-	case TypeFloat32:
+	case classdef.TypeFloat32:
 		return mpr.DefaultPortableReader.ReadFloat32(fieldName)
-	case TypeInt32:
+	case classdef.TypeInt32:
 		ret, err := mpr.DefaultPortableReader.ReadInt32(fieldName)
 		return float32(ret), err
-	case TypeByte:
+	case classdef.TypeByte:
 		ret, err := mpr.DefaultPortableReader.ReadByte(fieldName)
 		return float32(ret), err
-	case TypeUint16:
+	case classdef.TypeUint16:
 		ret, err := mpr.DefaultPortableReader.ReadUInt16(fieldName)
 		return float32(ret), err
-	case TypeInt16:
+	case classdef.TypeInt16:
 		ret, err := mpr.DefaultPortableReader.ReadInt16(fieldName)
 		return float32(ret), err
 	default:
-		return 0, mpr.createIncompatibleClassChangeError(fieldDef, TypeFloat32)
+		return 0, mpr.createIncompatibleClassChangeError(fieldDef, classdef.TypeFloat32)
 	}
 }
 
@@ -159,28 +159,28 @@ func (mpr *MorphingPortableReader) ReadFloat64(fieldName string) (float64, error
 		return 0, nil
 	}
 	switch fieldDef.Type() {
-	case TypeFloat64:
+	case classdef.TypeFloat64:
 		return mpr.DefaultPortableReader.ReadFloat64(fieldName)
-	case TypeInt64:
+	case classdef.TypeInt64:
 		ret, err := mpr.DefaultPortableReader.ReadInt64(fieldName)
 		return float64(ret), err
-	case TypeFloat32:
+	case classdef.TypeFloat32:
 		ret, err := mpr.DefaultPortableReader.ReadFloat32(fieldName)
 		return float64(ret), err
-	case TypeInt32:
+	case classdef.TypeInt32:
 		ret, err := mpr.DefaultPortableReader.ReadInt32(fieldName)
 		return float64(ret), err
-	case TypeByte:
+	case classdef.TypeByte:
 		ret, err := mpr.DefaultPortableReader.ReadByte(fieldName)
 		return float64(ret), err
-	case TypeUint16:
+	case classdef.TypeUint16:
 		ret, err := mpr.DefaultPortableReader.ReadUInt16(fieldName)
 		return float64(ret), err
-	case TypeInt16:
+	case classdef.TypeInt16:
 		ret, err := mpr.DefaultPortableReader.ReadInt16(fieldName)
 		return float64(ret), err
 	default:
-		return 0, mpr.createIncompatibleClassChangeError(fieldDef, TypeFloat64)
+		return 0, mpr.createIncompatibleClassChangeError(fieldDef, classdef.TypeFloat64)
 	}
 }
 
@@ -189,19 +189,19 @@ func (mpr *MorphingPortableReader) ReadUTF(fieldName string) (string, error) {
 	if fieldDef == nil {
 		return "", nil
 	}
-	err := mpr.validateTypeCompatibility(fieldDef, TypeUTF)
+	err := mpr.validateTypeCompatibility(fieldDef, classdef.TypeUTF)
 	if err != nil {
 		return "", err
 	}
 	return mpr.DefaultPortableReader.ReadUTF(fieldName)
 }
 
-func (mpr *MorphingPortableReader) ReadPortable(fieldName string) (Portable, error) {
+func (mpr *MorphingPortableReader) ReadPortable(fieldName string) (serialization.Portable, error) {
 	fieldDef := mpr.DefaultPortableReader.classDefinition.Field(fieldName)
 	if fieldDef == nil {
 		return nil, nil
 	}
-	err := mpr.validateTypeCompatibility(fieldDef, TypePortable)
+	err := mpr.validateTypeCompatibility(fieldDef, classdef.TypePortable)
 	if err != nil {
 		return nil, err
 	}
@@ -213,7 +213,7 @@ func (mpr *MorphingPortableReader) ReadByteArray(fieldName string) ([]byte, erro
 	if fieldDef == nil {
 		return nil, nil
 	}
-	err := mpr.validateTypeCompatibility(fieldDef, TypeByteArray)
+	err := mpr.validateTypeCompatibility(fieldDef, classdef.TypeByteArray)
 	if err != nil {
 		return nil, err
 	}
@@ -225,7 +225,7 @@ func (mpr *MorphingPortableReader) ReadBoolArray(fieldName string) ([]bool, erro
 	if fieldDef == nil {
 		return nil, nil
 	}
-	err := mpr.validateTypeCompatibility(fieldDef, TypeBoolArray)
+	err := mpr.validateTypeCompatibility(fieldDef, classdef.TypeBoolArray)
 	if err != nil {
 		return nil, err
 	}
@@ -237,7 +237,7 @@ func (mpr *MorphingPortableReader) ReadUInt16Array(fieldName string) ([]uint16, 
 	if fieldDef == nil {
 		return nil, nil
 	}
-	err := mpr.validateTypeCompatibility(fieldDef, TypeUint16Array)
+	err := mpr.validateTypeCompatibility(fieldDef, classdef.TypeUint16Array)
 	if err != nil {
 		return nil, err
 	}
@@ -249,7 +249,7 @@ func (mpr *MorphingPortableReader) ReadInt16Array(fieldName string) ([]int16, er
 	if fieldDef == nil {
 		return nil, nil
 	}
-	err := mpr.validateTypeCompatibility(fieldDef, TypeInt16Array)
+	err := mpr.validateTypeCompatibility(fieldDef, classdef.TypeInt16Array)
 	if err != nil {
 		return nil, err
 	}
@@ -261,7 +261,7 @@ func (mpr *MorphingPortableReader) ReadInt32Array(fieldName string) ([]int32, er
 	if fieldDef == nil {
 		return nil, nil
 	}
-	err := mpr.validateTypeCompatibility(fieldDef, TypeInt32Array)
+	err := mpr.validateTypeCompatibility(fieldDef, classdef.TypeInt32Array)
 	if err != nil {
 		return nil, err
 	}
@@ -273,7 +273,7 @@ func (mpr *MorphingPortableReader) ReadInt64Array(fieldName string) ([]int64, er
 	if fieldDef == nil {
 		return nil, nil
 	}
-	err := mpr.validateTypeCompatibility(fieldDef, TypeInt64Array)
+	err := mpr.validateTypeCompatibility(fieldDef, classdef.TypeInt64Array)
 	if err != nil {
 		return nil, err
 	}
@@ -285,7 +285,7 @@ func (mpr *MorphingPortableReader) ReadFloat32Array(fieldName string) ([]float32
 	if fieldDef == nil {
 		return nil, nil
 	}
-	err := mpr.validateTypeCompatibility(fieldDef, TypeFloat32Array)
+	err := mpr.validateTypeCompatibility(fieldDef, classdef.TypeFloat32Array)
 	if err != nil {
 		return nil, err
 	}
@@ -297,7 +297,7 @@ func (mpr *MorphingPortableReader) ReadFloat64Array(fieldName string) ([]float64
 	if fieldDef == nil {
 		return nil, nil
 	}
-	err := mpr.validateTypeCompatibility(fieldDef, TypeFloat64Array)
+	err := mpr.validateTypeCompatibility(fieldDef, classdef.TypeFloat64Array)
 	if err != nil {
 		return nil, err
 	}
@@ -309,30 +309,30 @@ func (mpr *MorphingPortableReader) ReadUTFArray(fieldName string) ([]string, err
 	if fieldDef == nil {
 		return nil, nil
 	}
-	err := mpr.validateTypeCompatibility(fieldDef, TypeUTFArray)
+	err := mpr.validateTypeCompatibility(fieldDef, classdef.TypeUTFArray)
 	if err != nil {
 		return nil, err
 	}
 	return mpr.DefaultPortableReader.ReadUTFArray(fieldName)
 }
 
-func (mpr *MorphingPortableReader) ReadPortableArray(fieldName string) ([]Portable, error) {
+func (mpr *MorphingPortableReader) ReadPortableArray(fieldName string) ([]serialization.Portable, error) {
 	fieldDef := mpr.DefaultPortableReader.classDefinition.Field(fieldName)
 	if fieldDef == nil {
 		return nil, nil
 	}
-	err := mpr.validateTypeCompatibility(fieldDef, TypePortableArray)
+	err := mpr.validateTypeCompatibility(fieldDef, classdef.TypePortableArray)
 	if err != nil {
 		return nil, err
 	}
 	return mpr.DefaultPortableReader.ReadPortableArray(fieldName)
 }
 
-func (mpr *MorphingPortableReader) createIncompatibleClassChangeError(fd FieldDefinition, expectedType int32) error {
+func (mpr *MorphingPortableReader) createIncompatibleClassChangeError(fd serialization.FieldDefinition, expectedType int32) error {
 	return core.NewHazelcastSerializationError(fmt.Sprintf("incompatible to read %v from %v while reading field : %v", getTypeByConst(expectedType), getTypeByConst(fd.Type()), fd.Name()), nil)
 }
 
-func (mpr *MorphingPortableReader) validateTypeCompatibility(fd FieldDefinition, expectedType int32) error {
+func (mpr *MorphingPortableReader) validateTypeCompatibility(fd serialization.FieldDefinition, expectedType int32) error {
 	if fd.Type() != expectedType {
 		return mpr.createIncompatibleClassChangeError(fd, expectedType)
 	}

--- a/internal/serialization/morphing_portable_reader_test.go
+++ b/internal/serialization/morphing_portable_reader_test.go
@@ -15,18 +15,18 @@
 package serialization
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/config"
+	"github.com/hazelcast/hazelcast-go-client/config"
 	"github.com/hazelcast/hazelcast-go-client/core"
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization/classdef"
-	. "github.com/hazelcast/hazelcast-go-client/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization/classdef"
+	"github.com/hazelcast/hazelcast-go-client/serialization"
 	"reflect"
 	"testing"
 )
 
 func TestMorphingPortableReader_ReadByte(t *testing.T) {
 	var expectedRet byte = 12
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "type", TypeByte, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "type", classdef.TypeByte, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteByte("type", expectedRet)
@@ -42,8 +42,8 @@ func TestMorphingPortableReader_ReadByte(t *testing.T) {
 func TestMorphingPortableReader_ReadByteWithEmptyFieldName(t *testing.T) {
 	var value byte = 12
 	var expectedRet byte = 0
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "type", TypeByte, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "type", classdef.TypeByte, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteByte("type", value)
@@ -58,8 +58,8 @@ func TestMorphingPortableReader_ReadByteWithEmptyFieldName(t *testing.T) {
 
 func TestMorphingPortableReader_ReadByteWithIncompatibleClassChangeError(t *testing.T) {
 	var expectedRet bool = true
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "type", TypeBool, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "type", classdef.TypeBool, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteBool("type", expectedRet)
@@ -74,8 +74,8 @@ func TestMorphingPortableReader_ReadByteWithIncompatibleClassChangeError(t *test
 
 func TestMorphingPortableReader_ReadBool(t *testing.T) {
 	var expectedRet bool = true
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "isReady", TypeBool, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "isReady", classdef.TypeBool, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteBool("isReady", expectedRet)
@@ -92,8 +92,8 @@ func TestMorphingPortableReader_ReadBool(t *testing.T) {
 func TestMorphingPortableReader_ReadBoolWithEmptyFieldName(t *testing.T) {
 	var value bool = true
 	var expectedRet bool = false
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "isReady", TypeBool, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "isReady", classdef.TypeBool, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteBool("isReady", value)
@@ -109,8 +109,8 @@ func TestMorphingPortableReader_ReadBoolWithEmptyFieldName(t *testing.T) {
 
 func TestMorphingPortableReader_ReadBoolWithIncompatibleClassChangeError(t *testing.T) {
 	var expectedRet byte = 23
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "type", TypeByte, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "type", classdef.TypeByte, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteByte("type", expectedRet)
@@ -125,8 +125,8 @@ func TestMorphingPortableReader_ReadBoolWithIncompatibleClassChangeError(t *test
 
 func TestMorphingPortableReader_ReadUInt16(t *testing.T) {
 	var expectedRet uint16 = 'E'
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "char", TypeUint16, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "char", classdef.TypeUint16, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteUInt16("char", expectedRet)
@@ -142,8 +142,8 @@ func TestMorphingPortableReader_ReadUInt16(t *testing.T) {
 func TestMorphingPortableReader_ReadUInt16WithEmptyFieldName(t *testing.T) {
 	var value uint16 = 22
 	var expectedRet uint16 = 0
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "char", TypeUint16, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "char", classdef.TypeUint16, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteUInt16("char", value)
@@ -158,8 +158,8 @@ func TestMorphingPortableReader_ReadUInt16WithEmptyFieldName(t *testing.T) {
 
 func TestMorphingPortableReader_ReadUInt16WithIncompatibleClassChangeError(t *testing.T) {
 	var expectedRet int16 = 23
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "char", TypeInt16, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "char", classdef.TypeInt16, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteInt16("char", expectedRet)
@@ -174,8 +174,8 @@ func TestMorphingPortableReader_ReadUInt16WithIncompatibleClassChangeError(t *te
 
 func TestMorphingPortableReader_ReadInt16FromByte(t *testing.T) {
 	var expectedRet int16 = 22
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "age", TypeByte, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "age", classdef.TypeByte, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteByte("age", byte(expectedRet))
@@ -190,8 +190,8 @@ func TestMorphingPortableReader_ReadInt16FromByte(t *testing.T) {
 
 func TestMorphingPortableReader_ReadInt16FromInt16(t *testing.T) {
 	var expectedRet int16 = 22
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "age", TypeInt16, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "age", classdef.TypeInt16, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteInt16("age", expectedRet)
@@ -207,8 +207,8 @@ func TestMorphingPortableReader_ReadInt16FromInt16(t *testing.T) {
 func TestMorphingPortableReader_ReadInt16WithEmptyFieldName(t *testing.T) {
 	var value int16 = 22
 	var expectedRet int16 = 0
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "age", TypeInt16, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "age", classdef.TypeInt16, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteInt16("age", value)
@@ -223,8 +223,8 @@ func TestMorphingPortableReader_ReadInt16WithEmptyFieldName(t *testing.T) {
 
 func TestMorphingPortableReader_ReadInt16WithIncompatibleClassChangeError(t *testing.T) {
 	var value int64 = 22
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "age", TypeInt64, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "age", classdef.TypeInt64, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteInt64("age", value)
@@ -239,8 +239,8 @@ func TestMorphingPortableReader_ReadInt16WithIncompatibleClassChangeError(t *tes
 
 func TestMorphingPortableReader_ReadInt32FromByte(t *testing.T) {
 	var expectedRet int32 = 22
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "age", TypeByte, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "age", classdef.TypeByte, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteByte("age", byte(expectedRet))
@@ -255,8 +255,8 @@ func TestMorphingPortableReader_ReadInt32FromByte(t *testing.T) {
 
 func TestMorphingPortableReader_ReadInt32FromUInt16(t *testing.T) {
 	var expectedRet uint16 = 'a'
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "letter", TypeUint16, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "letter", classdef.TypeUint16, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteUInt16("letter", expectedRet)
@@ -271,8 +271,8 @@ func TestMorphingPortableReader_ReadInt32FromUInt16(t *testing.T) {
 
 func TestMorphingPortableReader_ReadInt32FromInt16(t *testing.T) {
 	var expectedRet int32 = 22
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "age", TypeInt16, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "age", classdef.TypeInt16, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteInt16("age", int16(expectedRet))
@@ -287,8 +287,8 @@ func TestMorphingPortableReader_ReadInt32FromInt16(t *testing.T) {
 
 func TestMorphingPortableReader_ReadInt32FromInt32(t *testing.T) {
 	var expectedRet int32 = 22
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "age", TypeInt32, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "age", classdef.TypeInt32, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteInt32("age", expectedRet)
@@ -304,8 +304,8 @@ func TestMorphingPortableReader_ReadInt32FromInt32(t *testing.T) {
 func TestMorphingPortableReader_ReadInt32WithEmptyFieldName(t *testing.T) {
 	var value int32 = 22
 	var expectedRet int32 = 0
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "age", TypeInt16, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "age", classdef.TypeInt16, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteInt16("age", int16(value))
@@ -320,8 +320,8 @@ func TestMorphingPortableReader_ReadInt32WithEmptyFieldName(t *testing.T) {
 
 func TestMorphingPortableReader_ReadInt32WithIncompatibleClassChangeError(t *testing.T) {
 	var value int64 = 22
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "age", TypeInt64, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "age", classdef.TypeInt64, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteInt64("age", value)
@@ -336,8 +336,8 @@ func TestMorphingPortableReader_ReadInt32WithIncompatibleClassChangeError(t *tes
 
 func TestMorphingPortableReader_ReadInt64FromByte(t *testing.T) {
 	var expectedRet int64 = 22
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "age", TypeByte, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "age", classdef.TypeByte, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteByte("age", byte(expectedRet))
@@ -352,8 +352,8 @@ func TestMorphingPortableReader_ReadInt64FromByte(t *testing.T) {
 
 func TestMorphingPortableReader_ReadInt64FromUInt16(t *testing.T) {
 	var expectedRet int64 = 22
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "age", TypeUint16, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "age", classdef.TypeUint16, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteUInt16("age", uint16(expectedRet))
@@ -368,8 +368,8 @@ func TestMorphingPortableReader_ReadInt64FromUInt16(t *testing.T) {
 
 func TestMorphingPortableReader_ReadInt64FromInt16(t *testing.T) {
 	var expectedRet int64 = 22
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "age", TypeInt16, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "age", classdef.TypeInt16, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteInt16("age", int16(expectedRet))
@@ -384,8 +384,8 @@ func TestMorphingPortableReader_ReadInt64FromInt16(t *testing.T) {
 
 func TestMorphingPortableReader_ReadInt64FromInt32(t *testing.T) {
 	var expectedRet int64 = 22
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "age", TypeInt32, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "age", classdef.TypeInt32, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteInt32("age", int32(expectedRet))
@@ -400,8 +400,8 @@ func TestMorphingPortableReader_ReadInt64FromInt32(t *testing.T) {
 
 func TestMorphingPortableReader_ReadInt64FromInt64(t *testing.T) {
 	var expectedRet int64 = 22
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "age", TypeInt64, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "age", classdef.TypeInt64, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteInt64("age", expectedRet)
@@ -417,8 +417,8 @@ func TestMorphingPortableReader_ReadInt64FromInt64(t *testing.T) {
 func TestMorphingPortableReader_ReadInt64WithEmptyFieldName(t *testing.T) {
 	var value int64 = 22
 	var expectedRet int64 = 0
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "age", TypeUint16, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "age", classdef.TypeUint16, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteUInt16("age", uint16(value))
@@ -433,8 +433,8 @@ func TestMorphingPortableReader_ReadInt64WithEmptyFieldName(t *testing.T) {
 
 func TestMorphingPortableReader_ReadInt64WithIncompatibleClassChangeError(t *testing.T) {
 	var value float32 = 22.23
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "age", TypeFloat32, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "age", classdef.TypeFloat32, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteFloat32("age", value)
@@ -449,8 +449,8 @@ func TestMorphingPortableReader_ReadInt64WithIncompatibleClassChangeError(t *tes
 
 func TestMorphingPortableReader_ReadFloat32FromByte(t *testing.T) {
 	var expectedRet byte = 22
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "age", TypeByte, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "age", classdef.TypeByte, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteByte("age", expectedRet)
@@ -465,8 +465,8 @@ func TestMorphingPortableReader_ReadFloat32FromByte(t *testing.T) {
 
 func TestMorphingPortableReader_ReadFloat32FromUInt16(t *testing.T) {
 	var expectedRet uint16 = 22
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "age", TypeUint16, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "age", classdef.TypeUint16, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteUInt16("age", expectedRet)
@@ -481,8 +481,8 @@ func TestMorphingPortableReader_ReadFloat32FromUInt16(t *testing.T) {
 
 func TestMorphingPortableReader_ReadFloat32FromInt16(t *testing.T) {
 	var expectedRet int16 = 22
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "age", TypeInt16, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "age", classdef.TypeInt16, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteInt16("age", expectedRet)
@@ -497,8 +497,8 @@ func TestMorphingPortableReader_ReadFloat32FromInt16(t *testing.T) {
 
 func TestMorphingPortableReader_ReadFloat32FromInt32(t *testing.T) {
 	var expectedRet int32 = 22
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "age", TypeInt32, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "age", classdef.TypeInt32, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteInt32("age", expectedRet)
@@ -513,8 +513,8 @@ func TestMorphingPortableReader_ReadFloat32FromInt32(t *testing.T) {
 
 func TestMorphingPortableReader_ReadFloat32FromFloat32(t *testing.T) {
 	var expectedRet float32 = 22.5
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "age", TypeFloat32, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "age", classdef.TypeFloat32, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteFloat32("age", expectedRet)
@@ -530,8 +530,8 @@ func TestMorphingPortableReader_ReadFloat32FromFloat32(t *testing.T) {
 func TestMorphingPortableReader_ReadFloat32WithEmptyFieldName(t *testing.T) {
 	var value float32 = 22.5
 	var expectedRet float32 = 0
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "age", TypeFloat32, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "age", classdef.TypeFloat32, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteFloat32("age", value)
@@ -546,8 +546,8 @@ func TestMorphingPortableReader_ReadFloat32WithEmptyFieldName(t *testing.T) {
 
 func TestMorphingPortableReader_ReadFloat32WithIncompatibleClassChangeError(t *testing.T) {
 	var expectedRet float64 = 22.5
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "age", TypeFloat64, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "age", classdef.TypeFloat64, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteFloat64("age", expectedRet)
@@ -562,8 +562,8 @@ func TestMorphingPortableReader_ReadFloat32WithIncompatibleClassChangeError(t *t
 
 func TestMorphingPortableReader_ReadFloat64FromByte(t *testing.T) {
 	var expectedRet byte = 22
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "point", TypeByte, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "point", classdef.TypeByte, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteByte("point", expectedRet)
@@ -578,8 +578,8 @@ func TestMorphingPortableReader_ReadFloat64FromByte(t *testing.T) {
 
 func TestMorphingPortableReader_ReadFloat64FromUInt16(t *testing.T) {
 	var expectedRet uint16 = 22
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "point", TypeUint16, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "point", classdef.TypeUint16, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteUInt16("point", expectedRet)
@@ -594,8 +594,8 @@ func TestMorphingPortableReader_ReadFloat64FromUInt16(t *testing.T) {
 
 func TestMorphingPortableReader_ReadFloat64FromInt16(t *testing.T) {
 	var expectedRet int16 = 22
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "point", TypeInt16, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "point", classdef.TypeInt16, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteInt16("point", expectedRet)
@@ -610,8 +610,8 @@ func TestMorphingPortableReader_ReadFloat64FromInt16(t *testing.T) {
 
 func TestMorphingPortableReader_ReadFloat64FromInt32(t *testing.T) {
 	var expectedRet int32 = 22
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "point", TypeInt32, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "point", classdef.TypeInt32, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteInt32("point", expectedRet)
@@ -626,8 +626,8 @@ func TestMorphingPortableReader_ReadFloat64FromInt32(t *testing.T) {
 
 func TestMorphingPortableReader_ReadFloat64FromInt64(t *testing.T) {
 	var expectedRet int64 = 22
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "point", TypeInt64, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "point", classdef.TypeInt64, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteInt64("point", expectedRet)
@@ -642,8 +642,8 @@ func TestMorphingPortableReader_ReadFloat64FromInt64(t *testing.T) {
 
 func TestMorphingPortableReader_ReadFloat64FromFloat32(t *testing.T) {
 	var expectedRet float32 = 22.43
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "point", TypeFloat32, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "point", classdef.TypeFloat32, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteFloat32("point", expectedRet)
@@ -658,8 +658,8 @@ func TestMorphingPortableReader_ReadFloat64FromFloat32(t *testing.T) {
 
 func TestMorphingPortableReader_ReadFloat64FromFloat64(t *testing.T) {
 	var expectedRet float64 = 22.43
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "point", TypeFloat64, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "point", classdef.TypeFloat64, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteFloat64("point", expectedRet)
@@ -675,8 +675,8 @@ func TestMorphingPortableReader_ReadFloat64FromFloat64(t *testing.T) {
 func TestMorphingPortableReader_ReadFloat64WithEmptyFieldName(t *testing.T) {
 	var value float64 = 22.43
 	var expectedRet float64 = 0
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "point", TypeFloat64, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "point", classdef.TypeFloat64, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteFloat64("point", value)
@@ -691,8 +691,8 @@ func TestMorphingPortableReader_ReadFloat64WithEmptyFieldName(t *testing.T) {
 
 func TestMorphingPortableReader_ReadFloat64WithIncompatibleClassChangeError(t *testing.T) {
 	var expectedRet bool = true
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "age", TypeBool, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "age", classdef.TypeBool, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteBool("age", expectedRet)
@@ -707,8 +707,8 @@ func TestMorphingPortableReader_ReadFloat64WithIncompatibleClassChangeError(t *t
 
 func TestMorphingPortableReader_ReadUTF(t *testing.T) {
 	var expectedRet string = "Furkan"
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "engineer", TypeUTF, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "engineer", classdef.TypeUTF, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteUTF("engineer", expectedRet)
@@ -724,8 +724,8 @@ func TestMorphingPortableReader_ReadUTF(t *testing.T) {
 func TestMorphingPortableReader_ReadUTFWithEmptyFieldName(t *testing.T) {
 	var value string = "Furkan"
 	var expectedRet string = ""
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "engineer", TypeUTF, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "engineer", classdef.TypeUTF, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteUTF("engineer", value)
@@ -740,8 +740,8 @@ func TestMorphingPortableReader_ReadUTFWithEmptyFieldName(t *testing.T) {
 
 func TestMorphingPortableReader_ReadUTFWithIncompatibleClassChangeError(t *testing.T) {
 	var expectedRet int16 = 12
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "engineer", TypeInt16, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "engineer", classdef.TypeInt16, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteInt16("engineer", expectedRet)
@@ -755,12 +755,12 @@ func TestMorphingPortableReader_ReadUTFWithIncompatibleClassChangeError(t *testi
 }
 
 func TestMorphingPortableReader_ReadPortable(t *testing.T) {
-	var expectedRet Portable = &student{10, 22, "Furkan Şenharputlu"}
-	config := NewSerializationConfig()
+	var expectedRet serialization.Portable = &student{10, 22, "Furkan Şenharputlu"}
+	config := config.NewSerializationConfig()
 	config.AddPortableFactory(2, &PortableFactory1{})
-	classDef := NewClassDefinitionImpl(2, 1, 3)
+	classDef := classdef.NewClassDefinitionImpl(2, 1, 3)
 	service := NewSerializationService(config)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "engineer", TypePortable, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "engineer", classdef.TypePortable, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, service, false)
 	serializer, _ := service.FindSerializerFor(expectedRet)
 	pw := NewDefaultPortableWriter(serializer.(*PortableSerializer), o, classDef)
@@ -776,13 +776,13 @@ func TestMorphingPortableReader_ReadPortable(t *testing.T) {
 }
 
 func TestMorphingPortableReader_ReadPortableWithEmptyFieldName(t *testing.T) {
-	var value Portable = &student{10, 22, "Furkan Şenharputlu"}
-	var expectedRet Portable
-	config := NewSerializationConfig()
+	var value serialization.Portable = &student{10, 22, "Furkan Şenharputlu"}
+	var expectedRet serialization.Portable
+	config := config.NewSerializationConfig()
 	config.AddPortableFactory(2, &PortableFactory1{})
-	classDef := NewClassDefinitionImpl(2, 1, 3)
+	classDef := classdef.NewClassDefinitionImpl(2, 1, 3)
 	service := NewSerializationService(config)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "engineer", TypePortable, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "engineer", classdef.TypePortable, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, service, false)
 	serializer, _ := service.FindSerializerFor(value)
 	pw := NewDefaultPortableWriter(serializer.(*PortableSerializer), o, classDef)
@@ -799,8 +799,8 @@ func TestMorphingPortableReader_ReadPortableWithEmptyFieldName(t *testing.T) {
 
 func TestMorphingPortableReader_ReadPortableWithIncompatibleClassChangeError(t *testing.T) {
 	var expectedRet int16 = 12
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "engineer", TypeInt16, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "engineer", classdef.TypeInt16, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteInt16("engineer", expectedRet)
@@ -815,8 +815,8 @@ func TestMorphingPortableReader_ReadPortableWithIncompatibleClassChangeError(t *
 
 func TestMorphingPortableReader_ReadByteArray(t *testing.T) {
 	var expectedRet []byte = []byte{9, 12, 34, 6, 7, 3, 2, 0, 10, 2, 0}
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "types", TypeByteArray, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "types", classdef.TypeByteArray, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteByteArray("types", expectedRet)
@@ -833,8 +833,8 @@ func TestMorphingPortableReader_ReadByteArray(t *testing.T) {
 func TestMorphingPortableReader_ReadByteArrayWithEmptyFieldName(t *testing.T) {
 	var value []byte = []byte{9, 12, 34, 6, 7, 3, 2, 0, 10, 2, 0}
 	var expectedRet []byte
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "types", TypeByteArray, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "types", classdef.TypeByteArray, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteByteArray("types", value)
@@ -850,8 +850,8 @@ func TestMorphingPortableReader_ReadByteArrayWithEmptyFieldName(t *testing.T) {
 
 func TestMorphingPortableReader_ReadByteArrayWithIncompatibleClassChangeError(t *testing.T) {
 	var expectedRet []int32 = []int32{9, 12, 34, 6, 7, 3, 2, 0, 10, 2, 0}
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "types", TypeInt32Array, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "types", classdef.TypeInt32Array, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteInt32Array("types", expectedRet)
@@ -866,8 +866,8 @@ func TestMorphingPortableReader_ReadByteArrayWithIncompatibleClassChangeError(t 
 
 func TestMorphingPortableReader_ReadBoolArray(t *testing.T) {
 	var expectedRet []bool = []bool{true, true, false, true, false, false, false, true, false, true, true}
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "areReady", TypeBoolArray, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "areReady", classdef.TypeBoolArray, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteBoolArray("areReady", expectedRet)
@@ -884,8 +884,8 @@ func TestMorphingPortableReader_ReadBoolArray(t *testing.T) {
 func TestMorphingPortableReader_ReadBoolArrayWithEmptyFieldName(t *testing.T) {
 	var value []bool = []bool{true, true, false, true, false, false, false, true, false, true, true}
 	var expectedRet []bool
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "areReady", TypeBoolArray, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "areReady", classdef.TypeBoolArray, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteBoolArray("areReady", value)
@@ -901,8 +901,8 @@ func TestMorphingPortableReader_ReadBoolArrayWithEmptyFieldName(t *testing.T) {
 
 func TestMorphingPortableReader_ReadBoolArrayWithIncompatibleClassChangeError(t *testing.T) {
 	var expectedRet []int32 = []int32{9, 12, 34, 6, 7, 3, 2, 0, 10, 2, 0}
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "types", TypeInt32Array, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "types", classdef.TypeInt32Array, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteInt32Array("types", expectedRet)
@@ -917,8 +917,8 @@ func TestMorphingPortableReader_ReadBoolArrayWithIncompatibleClassChangeError(t 
 
 func TestMorphingPortableReader_ReadUInt16Array(t *testing.T) {
 	var expectedRet []uint16 = []uint16{'^', '%', '#', '!', '$'}
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "scores", TypeUint16Array, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "scores", classdef.TypeUint16Array, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteUInt16Array("scores", expectedRet)
@@ -935,8 +935,8 @@ func TestMorphingPortableReader_ReadUInt16Array(t *testing.T) {
 func TestMorphingPortableReader_ReadUInt16ArrayWithEmptyFieldName(t *testing.T) {
 	var value []uint16 = []uint16{'^', '%', '#', '!', '$'}
 	var expectedRet []uint16
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "scores", TypeUint16Array, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "scores", classdef.TypeUint16Array, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteUInt16Array("scores", value)
@@ -952,8 +952,8 @@ func TestMorphingPortableReader_ReadUInt16ArrayWithEmptyFieldName(t *testing.T) 
 
 func TestMorphingPortableReader_ReadUInt16ArrayWithIncompatibleClassChangeError(t *testing.T) {
 	var expectedRet []int32 = []int32{9, 12, 34, 6, 7, 3, 2, 0, 10, 2, 0}
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "types", TypeInt32Array, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "types", classdef.TypeInt32Array, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteInt32Array("types", expectedRet)
@@ -968,8 +968,8 @@ func TestMorphingPortableReader_ReadUInt16ArrayWithIncompatibleClassChangeError(
 
 func TestMorphingPortableReader_ReadInt16Array(t *testing.T) {
 	var expectedRet []int16 = []int16{9432, 12, 34, 126, 7, 343, 2, 0, 1120, 222, 440}
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "scores", TypeInt16Array, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "scores", classdef.TypeInt16Array, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteInt16Array("scores", expectedRet)
@@ -986,8 +986,8 @@ func TestMorphingPortableReader_ReadInt16Array(t *testing.T) {
 func TestMorphingPortableReader_ReadInt16ArrayWithEmptyFieldName(t *testing.T) {
 	var value []int16 = []int16{9432, 12, 34, 126, 7, 343, 2, 0, 1120, 222, 440}
 	var expectedRet []int16
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "scores", TypeInt16Array, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "scores", classdef.TypeInt16Array, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteInt16Array("scores", value)
@@ -1003,8 +1003,8 @@ func TestMorphingPortableReader_ReadInt16ArrayWithEmptyFieldName(t *testing.T) {
 
 func TestMorphingPortableReader_ReadInt16ArrayWithIncompatibleClassChangeError(t *testing.T) {
 	var expectedRet []int32 = []int32{9, 12, 34, 6, 7, 3, 2, 0, 10, 2, 0}
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "types", TypeInt32Array, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "types", classdef.TypeInt32Array, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteInt32Array("types", expectedRet)
@@ -1019,8 +1019,8 @@ func TestMorphingPortableReader_ReadInt16ArrayWithIncompatibleClassChangeError(t
 
 func TestMorphingPortableReader_ReadInt32Array(t *testing.T) {
 	var expectedRet []int32 = []int32{9432, 12, 34, 6123, 45367, 31341, 43142, 78690, 16790, 362, 0}
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "scores", TypeInt32Array, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "scores", classdef.TypeInt32Array, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteInt32Array("scores", expectedRet)
@@ -1037,8 +1037,8 @@ func TestMorphingPortableReader_ReadInt32Array(t *testing.T) {
 func TestMorphingPortableReader_ReadInt32ArrayWithEmptyFieldName(t *testing.T) {
 	var value []int32 = []int32{9432, 12, 34, 6123, 45367, 31341, 43142, 78690, 16790, 362, 0}
 	var expectedRet []int32
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "scores", TypeInt32Array, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "scores", classdef.TypeInt32Array, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteInt32Array("scores", value)
@@ -1054,8 +1054,8 @@ func TestMorphingPortableReader_ReadInt32ArrayWithEmptyFieldName(t *testing.T) {
 
 func TestMorphingPortableReader_ReadInt32ArrayWithIncompatibleClassChangeError(t *testing.T) {
 	var expectedRet []int64 = []int64{9, 12, 34, 6, 7, 3, 2, 0, 10, 2, 0}
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "types", TypeInt64Array, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "types", classdef.TypeInt64Array, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteInt64Array("types", expectedRet)
@@ -1070,8 +1070,8 @@ func TestMorphingPortableReader_ReadInt32ArrayWithIncompatibleClassChangeError(t
 
 func TestMorphingPortableReader_ReadInt64Array(t *testing.T) {
 	var expectedRet []int64 = []int64{9412332, 929812, 34, 61223493, 4523367, 31235341, 46423142, 78690, 16790, 3662, 0}
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "scores", TypeInt64Array, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "scores", classdef.TypeInt64Array, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteInt64Array("scores", expectedRet)
@@ -1088,8 +1088,8 @@ func TestMorphingPortableReader_ReadInt64Array(t *testing.T) {
 func TestMorphingPortableReader_ReadInt64ArrayWithEmptyFieldName(t *testing.T) {
 	var value []int64 = []int64{9412332, 929812, 34, 61223493, 4523367, 31235341, 46423142, 78690, 16790, 3662, 0}
 	var expectedRet []int64
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "scores", TypeInt64Array, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "scores", classdef.TypeInt64Array, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteInt64Array("scores", value)
@@ -1105,8 +1105,8 @@ func TestMorphingPortableReader_ReadInt64ArrayWithEmptyFieldName(t *testing.T) {
 
 func TestMorphingPortableReader_ReadInt64ArrayWithIncompatibleClassChangeError(t *testing.T) {
 	var expectedRet []float32 = []float32{9, 12, 34, 6, 7, 3, 2, 0, 10, 2, 0}
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "types", TypeFloat32Array, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "types", classdef.TypeFloat32Array, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteFloat32Array("types", expectedRet)
@@ -1121,8 +1121,8 @@ func TestMorphingPortableReader_ReadInt64ArrayWithIncompatibleClassChangeError(t
 
 func TestMorphingPortableReader_ReadFloat32Array(t *testing.T) {
 	var expectedRet []float32 = []float32{12.1431, 1212.3, 34, 6123, 4.5367, 3.1341, 43.142, 786.90, 16.790, 3.62, 0}
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "longitude", TypeFloat32Array, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "longitude", classdef.TypeFloat32Array, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteFloat32Array("longitude", expectedRet)
@@ -1139,8 +1139,8 @@ func TestMorphingPortableReader_ReadFloat32Array(t *testing.T) {
 func TestMorphingPortableReader_ReadFloat32ArrayWithEmptyFieldName(t *testing.T) {
 	var value []float32 = []float32{12.1431, 1212.3, 34, 6123, 4.5367, 3.1341, 43.142, 786.90, 16.790, 3.62, 0}
 	var expectedRet []float32
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "longitude", TypeFloat32Array, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "longitude", classdef.TypeFloat32Array, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteFloat32Array("longitude", value)
@@ -1156,8 +1156,8 @@ func TestMorphingPortableReader_ReadFloat32ArrayWithEmptyFieldName(t *testing.T)
 
 func TestMorphingPortableReader_ReadFloat32ArrayWithIncompatibleClassChangeError(t *testing.T) {
 	var expectedRet []float64 = []float64{9, 12, 34, 6, 7, 3, 2, 0, 10, 2, 0}
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "types", TypeFloat64Array, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "types", classdef.TypeFloat64Array, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteFloat64Array("types", expectedRet)
@@ -1172,8 +1172,8 @@ func TestMorphingPortableReader_ReadFloat32ArrayWithIncompatibleClassChangeError
 
 func TestMorphingPortableReader_ReadFloat64Array(t *testing.T) {
 	var expectedRet []float64 = []float64{12234.1431, 121092.3, 34, 6123, 499.5364327, 3.1323441, 43.142, 799986.90, 16.790, 3.9996342, 0}
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "longitude", TypeFloat64Array, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "longitude", classdef.TypeFloat64Array, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteFloat64Array("longitude", expectedRet)
@@ -1190,8 +1190,8 @@ func TestMorphingPortableReader_ReadFloat64Array(t *testing.T) {
 func TestMorphingPortableReader_ReadFloat64ArrayWithEmptyFieldName(t *testing.T) {
 	var value []float64 = []float64{12234.1431, 121092.3, 34, 6123, 499.5364327, 3.1323441, 43.142, 799986.90, 16.790, 3.9996342, 0}
 	var expectedRet []float64
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "longitude", TypeFloat64Array, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "longitude", classdef.TypeFloat64Array, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteFloat64Array("longitude", value)
@@ -1207,8 +1207,8 @@ func TestMorphingPortableReader_ReadFloat64ArrayWithEmptyFieldName(t *testing.T)
 
 func TestMorphingPortableReader_ReadFloat64ArrayWithIncompatibleClassChangeError(t *testing.T) {
 	var expectedRet []float32 = []float32{9, 12, 34, 6, 7, 3, 2, 0, 10, 2, 0}
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "types", TypeFloat32Array, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "types", classdef.TypeFloat32Array, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteFloat32Array("types", expectedRet)
@@ -1223,8 +1223,8 @@ func TestMorphingPortableReader_ReadFloat64ArrayWithIncompatibleClassChangeError
 
 func TestMorphingPortableReader_ReadUTFArray(t *testing.T) {
 	var expectedRet []string = []string{"Furkan Şenharputlu", "こんにちは", "おはようございます", "今晩は"}
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "words", TypeUTFArray, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "words", classdef.TypeUTFArray, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteUTFArray("words", expectedRet)
@@ -1241,8 +1241,8 @@ func TestMorphingPortableReader_ReadUTFArray(t *testing.T) {
 func TestMorphingPortableReader_ReadUTFArrayWithEmptyFieldName(t *testing.T) {
 	var value []string = []string{"Furkan Şenharputlu", "こんにちは", "おはようございます", "今晩は"}
 	var expectedRet []string
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "words", TypeUTFArray, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "words", classdef.TypeUTFArray, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteUTFArray("words", value)
@@ -1258,8 +1258,8 @@ func TestMorphingPortableReader_ReadUTFArrayWithEmptyFieldName(t *testing.T) {
 
 func TestMorphingPortableReader_ReadUTFArrayWithIncompatibleClassChangeError(t *testing.T) {
 	var expectedRet []float64 = []float64{9, 12, 34, 6, 7, 3, 2, 0, 10, 2, 0}
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "types", TypeFloat64Array, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "types", classdef.TypeFloat64Array, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteFloat64Array("types", expectedRet)
@@ -1273,12 +1273,12 @@ func TestMorphingPortableReader_ReadUTFArrayWithIncompatibleClassChangeError(t *
 }
 
 func TestMorphingPortableReader_ReadPortableArray(t *testing.T) {
-	var expectedRet []Portable = []Portable{&student{10, 22, "Furkan Şenharputlu"}, &student{11, 20, "Jack Purcell"}}
-	config := NewSerializationConfig()
+	var expectedRet []serialization.Portable = []serialization.Portable{&student{10, 22, "Furkan Şenharputlu"}, &student{11, 20, "Jack Purcell"}}
+	config := config.NewSerializationConfig()
 	config.AddPortableFactory(2, &PortableFactory1{})
-	classDef := NewClassDefinitionImpl(2, 1, 3)
+	classDef := classdef.NewClassDefinitionImpl(2, 1, 3)
 	service := NewSerializationService(config)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "engineers", TypePortableArray, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "engineers", classdef.TypePortableArray, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	serializer := NewPortableSerializer(service, config.PortableFactories(), 0)
 	pw := NewDefaultPortableWriter(serializer, o, classDef)
@@ -1294,13 +1294,13 @@ func TestMorphingPortableReader_ReadPortableArray(t *testing.T) {
 }
 
 func TestMorphingPortableReader_ReadPortableArrayWithEmptyFieldName(t *testing.T) {
-	var value []Portable = []Portable{&student{10, 22, "Furkan Şenharputlu"}, &student{11, 20, "Jack Purcell"}}
-	var expectedRet []Portable
-	config := NewSerializationConfig()
+	var value []serialization.Portable = []serialization.Portable{&student{10, 22, "Furkan Şenharputlu"}, &student{11, 20, "Jack Purcell"}}
+	var expectedRet []serialization.Portable
+	config := config.NewSerializationConfig()
 	config.AddPortableFactory(2, &PortableFactory1{})
-	classDef := NewClassDefinitionImpl(2, 1, 3)
+	classDef := classdef.NewClassDefinitionImpl(2, 1, 3)
 	service := NewSerializationService(config)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "engineers", TypePortableArray, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "engineers", classdef.TypePortableArray, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	serializer := NewPortableSerializer(service, config.PortableFactories(), 0)
 	pw := NewDefaultPortableWriter(serializer, o, classDef)
@@ -1317,8 +1317,8 @@ func TestMorphingPortableReader_ReadPortableArrayWithEmptyFieldName(t *testing.T
 
 func TestMorphingPortableReader_ReadPortableArrayWithIncompatibleClassChangeError(t *testing.T) {
 	var expectedRet []float64 = []float64{9, 12, 34, 6, 7, 3, 2, 0, 10, 2, 0}
-	classDef := NewClassDefinitionImpl(1, 2, 3)
-	classDef.AddFieldDefinition(NewFieldDefinitionImpl(0, "types", TypeFloat64Array, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
+	classDef := classdef.NewClassDefinitionImpl(1, 2, 3)
+	classDef.AddFieldDefinition(classdef.NewFieldDefinitionImpl(0, "types", classdef.TypeFloat64Array, classDef.FactoryId(), classDef.ClassId(), classDef.Version()))
 	o := NewPositionalObjectDataOutput(0, nil, false)
 	pw := NewDefaultPortableWriter(nil, o, classDef)
 	pw.WriteFloat64Array("types", expectedRet)
@@ -1333,7 +1333,7 @@ func TestMorphingPortableReader_ReadPortableArrayWithIncompatibleClassChangeErro
 
 func TestNewMorphingPortableReader(t *testing.T) {
 	s := &student{10, 22, "Furkan Şenharputlu"}
-	config := NewSerializationConfig()
+	config := config.NewSerializationConfig()
 	config.AddPortableFactory(2, &PortableFactory2{})
 	service := NewSerializationService(config)
 	data, _ := service.ToData(s)

--- a/internal/serialization/object_data.go
+++ b/internal/serialization/object_data.go
@@ -16,9 +16,9 @@ package serialization
 
 import (
 	"fmt"
-	. "github.com/hazelcast/hazelcast-go-client/core"
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
-	. "github.com/hazelcast/hazelcast-go-client/serialization"
+	"github.com/hazelcast/hazelcast-go-client/core"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/serialization"
 	"unicode/utf8"
 )
 
@@ -74,51 +74,51 @@ func (o *ObjectDataOutput) EnsureAvailable(size int) {
 }
 
 func (o *ObjectDataOutput) WriteByte(v byte) {
-	o.EnsureAvailable(ByteSizeInBytes)
-	WriteUInt8(o.buffer, o.position, v)
-	o.position += ByteSizeInBytes
+	o.EnsureAvailable(common.ByteSizeInBytes)
+	common.WriteUInt8(o.buffer, o.position, v)
+	o.position += common.ByteSizeInBytes
 }
 
 func (o *ObjectDataOutput) WriteBool(v bool) {
-	o.EnsureAvailable(BoolSizeInBytes)
-	WriteBool(o.buffer, o.position, v)
-	o.position += BoolSizeInBytes
+	o.EnsureAvailable(common.BoolSizeInBytes)
+	common.WriteBool(o.buffer, o.position, v)
+	o.position += common.BoolSizeInBytes
 }
 
 func (o *ObjectDataOutput) WriteUInt16(v uint16) {
-	o.EnsureAvailable(Uint16SizeInBytes)
-	WriteUInt16(o.buffer, o.position, v, o.bigEndian)
-	o.position += Uint16SizeInBytes
+	o.EnsureAvailable(common.Uint16SizeInBytes)
+	common.WriteUInt16(o.buffer, o.position, v, o.bigEndian)
+	o.position += common.Uint16SizeInBytes
 }
 
 func (o *ObjectDataOutput) WriteInt16(v int16) {
-	o.EnsureAvailable(Int16SizeInBytes)
-	WriteInt16(o.buffer, o.position, v, o.bigEndian)
-	o.position += Int16SizeInBytes
+	o.EnsureAvailable(common.Int16SizeInBytes)
+	common.WriteInt16(o.buffer, o.position, v, o.bigEndian)
+	o.position += common.Int16SizeInBytes
 }
 
 func (o *ObjectDataOutput) WriteInt32(v int32) {
-	o.EnsureAvailable(Int32SizeInBytes)
-	WriteInt32(o.buffer, o.position, v, o.bigEndian)
-	o.position += Int32SizeInBytes
+	o.EnsureAvailable(common.Int32SizeInBytes)
+	common.WriteInt32(o.buffer, o.position, v, o.bigEndian)
+	o.position += common.Int32SizeInBytes
 }
 
 func (o *ObjectDataOutput) WriteInt64(v int64) {
-	o.EnsureAvailable(Int64SizeInBytes)
-	WriteInt64(o.buffer, o.position, v, o.bigEndian)
-	o.position += Int64SizeInBytes
+	o.EnsureAvailable(common.Int64SizeInBytes)
+	common.WriteInt64(o.buffer, o.position, v, o.bigEndian)
+	o.position += common.Int64SizeInBytes
 }
 
 func (o *ObjectDataOutput) WriteFloat32(v float32) {
-	o.EnsureAvailable(Float32SizeInBytes)
-	WriteFloat32(o.buffer, o.position, v, o.bigEndian)
-	o.position += Float32SizeInBytes
+	o.EnsureAvailable(common.Float32SizeInBytes)
+	common.WriteFloat32(o.buffer, o.position, v, o.bigEndian)
+	o.position += common.Float32SizeInBytes
 }
 
 func (o *ObjectDataOutput) WriteFloat64(v float64) {
-	o.EnsureAvailable(Float64SizeInBytes)
-	WriteFloat64(o.buffer, o.position, v, o.bigEndian)
-	o.position += Float64SizeInBytes
+	o.EnsureAvailable(common.Float64SizeInBytes)
+	common.WriteFloat64(o.buffer, o.position, v, o.bigEndian)
+	o.position += common.Float64SizeInBytes
 }
 
 func (o *ObjectDataOutput) WriteUTF(v string) {
@@ -144,7 +144,7 @@ func (o *ObjectDataOutput) WriteByteArray(v []byte) {
 	if v != nil {
 		length = int32(len(v))
 	} else {
-		length = NilArrayLength
+		length = common.NilArrayLength
 	}
 	o.WriteInt32(length)
 	for j := int32(0); j < length; j++ {
@@ -157,7 +157,7 @@ func (o *ObjectDataOutput) WriteBoolArray(v []bool) {
 	if v != nil {
 		length = int32(len(v))
 	} else {
-		length = NilArrayLength
+		length = common.NilArrayLength
 	}
 	o.WriteInt32(length)
 	for j := int32(0); j < length; j++ {
@@ -170,7 +170,7 @@ func (o *ObjectDataOutput) WriteUInt16Array(v []uint16) {
 	if v != nil {
 		length = int32(len(v))
 	} else {
-		length = NilArrayLength
+		length = common.NilArrayLength
 	}
 	o.WriteInt32(length)
 	for j := int32(0); j < length; j++ {
@@ -183,7 +183,7 @@ func (o *ObjectDataOutput) WriteInt16Array(v []int16) {
 	if v != nil {
 		length = int32(len(v))
 	} else {
-		length = NilArrayLength
+		length = common.NilArrayLength
 	}
 	o.WriteInt32(length)
 	for j := int32(0); j < length; j++ {
@@ -196,7 +196,7 @@ func (o *ObjectDataOutput) WriteInt32Array(v []int32) {
 	if v != nil {
 		length = int32(len(v))
 	} else {
-		length = NilArrayLength
+		length = common.NilArrayLength
 	}
 	o.WriteInt32(length)
 	for j := int32(0); j < length; j++ {
@@ -209,7 +209,7 @@ func (o *ObjectDataOutput) WriteInt64Array(v []int64) {
 	if v != nil {
 		length = int32(len(v))
 	} else {
-		length = NilArrayLength
+		length = common.NilArrayLength
 	}
 	o.WriteInt32(length)
 	for j := int32(0); j < length; j++ {
@@ -222,7 +222,7 @@ func (o *ObjectDataOutput) WriteFloat32Array(v []float32) {
 	if v != nil {
 		length = int32(len(v))
 	} else {
-		length = NilArrayLength
+		length = common.NilArrayLength
 	}
 	o.WriteInt32(length)
 	for j := int32(0); j < length; j++ {
@@ -235,7 +235,7 @@ func (o *ObjectDataOutput) WriteFloat64Array(v []float64) {
 	if v != nil {
 		length = int32(len(v))
 	} else {
-		length = NilArrayLength
+		length = common.NilArrayLength
 	}
 	o.WriteInt32(length)
 	for j := int32(0); j < length; j++ {
@@ -248,7 +248,7 @@ func (o *ObjectDataOutput) WriteUTFArray(v []string) {
 	if v != nil {
 		length = int32(len(v))
 	} else {
-		length = NilArrayLength
+		length = common.NilArrayLength
 	}
 	o.WriteInt32(length)
 	for j := int32(0); j < length; j++ {
@@ -262,10 +262,10 @@ func (o *ObjectDataOutput) WriteBytes(v string) {
 	}
 }
 
-func (o *ObjectDataOutput) WriteData(data IData) {
+func (o *ObjectDataOutput) WriteData(data serialization.IData) {
 	var length int32
 	if data == nil {
-		length = NilArrayLength
+		length = common.NilArrayLength
 	} else {
 		length = int32(data.TotalSize())
 	}
@@ -297,10 +297,10 @@ func (i *ObjectDataInput) Available() int32 {
 
 func (i *ObjectDataInput) AssertAvailable(k int) error {
 	if i.position < 0 {
-		return NewHazelcastIllegalArgumentError(fmt.Sprintf("negative pos -> %v", i.position), nil)
+		return core.NewHazelcastIllegalArgumentError(fmt.Sprintf("negative pos -> %v", i.position), nil)
 	}
 	if len(i.buffer) < int(i.position)+k {
-		return NewHazelcastEOFError(fmt.Sprintf("cannot read %v bytes", k), nil)
+		return core.NewHazelcastEOFError(fmt.Sprintf("cannot read %v bytes", k), nil)
 	}
 	return nil
 }
@@ -314,168 +314,168 @@ func (i *ObjectDataInput) SetPosition(pos int32) {
 }
 
 func (i *ObjectDataInput) ReadByte() (byte, error) {
-	var err error = i.AssertAvailable(ByteSizeInBytes)
+	var err error = i.AssertAvailable(common.ByteSizeInBytes)
 	var ret byte
 	if err == nil {
-		ret = ReadUInt8(i.buffer, i.position)
-		i.position += ByteSizeInBytes
+		ret = common.ReadUInt8(i.buffer, i.position)
+		i.position += common.ByteSizeInBytes
 		return ret, err
 	}
 	return ret, err
 }
 
 func (i *ObjectDataInput) ReadByteWithPosition(pos int32) (byte, error) {
-	var err error = i.AssertAvailable(ByteSizeInBytes)
+	var err error = i.AssertAvailable(common.ByteSizeInBytes)
 	var ret byte
 	if err == nil {
-		ret = ReadUInt8(i.buffer, pos)
+		ret = common.ReadUInt8(i.buffer, pos)
 		return ret, err
 	}
 	return ret, err
 }
 
 func (i *ObjectDataInput) ReadBool() (bool, error) {
-	var err error = i.AssertAvailable(BoolSizeInBytes)
+	var err error = i.AssertAvailable(common.BoolSizeInBytes)
 	var ret bool
 	if err == nil {
-		ret = ReadBool(i.buffer, i.position)
-		i.position += BoolSizeInBytes
+		ret = common.ReadBool(i.buffer, i.position)
+		i.position += common.BoolSizeInBytes
 		return ret, err
 	}
 	return ret, err
 }
 
 func (i *ObjectDataInput) ReadBoolWithPosition(pos int32) (bool, error) {
-	var err error = i.AssertAvailable(BoolSizeInBytes)
+	var err error = i.AssertAvailable(common.BoolSizeInBytes)
 	var ret bool
 	if err == nil {
-		ret = ReadBool(i.buffer, pos)
+		ret = common.ReadBool(i.buffer, pos)
 		return ret, err
 	}
 	return ret, err
 }
 
 func (i *ObjectDataInput) ReadUInt16() (uint16, error) {
-	var err error = i.AssertAvailable(Uint16SizeInBytes)
+	var err error = i.AssertAvailable(common.Uint16SizeInBytes)
 	var ret uint16
 	if err == nil {
-		ret = ReadUInt16(i.buffer, i.position, i.bigEndian)
-		i.position += Uint16SizeInBytes
+		ret = common.ReadUInt16(i.buffer, i.position, i.bigEndian)
+		i.position += common.Uint16SizeInBytes
 		return ret, err
 	}
 	return ret, err
 }
 
 func (i *ObjectDataInput) ReadUInt16WithPosition(pos int32) (uint16, error) {
-	var err error = i.AssertAvailable(Uint16SizeInBytes)
+	var err error = i.AssertAvailable(common.Uint16SizeInBytes)
 	var ret uint16
 	if err == nil {
-		ret = ReadUInt16(i.buffer, pos, i.bigEndian)
+		ret = common.ReadUInt16(i.buffer, pos, i.bigEndian)
 		return ret, err
 	}
 	return ret, err
 }
 
 func (i *ObjectDataInput) ReadInt16() (int16, error) {
-	var err error = i.AssertAvailable(Int16SizeInBytes)
+	var err error = i.AssertAvailable(common.Int16SizeInBytes)
 	var ret int16
 	if err == nil {
-		ret = ReadInt16(i.buffer, i.position, i.bigEndian)
-		i.position += Int16SizeInBytes
+		ret = common.ReadInt16(i.buffer, i.position, i.bigEndian)
+		i.position += common.Int16SizeInBytes
 		return ret, err
 	}
 	return ret, err
 }
 
 func (i *ObjectDataInput) ReadInt16WithPosition(pos int32) (int16, error) {
-	var err error = i.AssertAvailable(Int16SizeInBytes)
+	var err error = i.AssertAvailable(common.Int16SizeInBytes)
 	var ret int16
 	if err == nil {
-		ret = ReadInt16(i.buffer, pos, i.bigEndian)
+		ret = common.ReadInt16(i.buffer, pos, i.bigEndian)
 		return ret, err
 	}
 	return ret, err
 }
 
 func (i *ObjectDataInput) ReadInt32() (int32, error) {
-	var err error = i.AssertAvailable(Int32SizeInBytes)
+	var err error = i.AssertAvailable(common.Int32SizeInBytes)
 	var ret int32
 	if err == nil {
-		ret = ReadInt32(i.buffer, i.position, i.bigEndian)
-		i.position += Int32SizeInBytes
+		ret = common.ReadInt32(i.buffer, i.position, i.bigEndian)
+		i.position += common.Int32SizeInBytes
 		return ret, err
 	}
 	return ret, err
 }
 
 func (i *ObjectDataInput) ReadInt32WithPosition(pos int32) (int32, error) {
-	var err error = i.AssertAvailable(Int32SizeInBytes)
+	var err error = i.AssertAvailable(common.Int32SizeInBytes)
 	var ret int32
 	if err == nil {
-		ret = ReadInt32(i.buffer, pos, i.bigEndian)
+		ret = common.ReadInt32(i.buffer, pos, i.bigEndian)
 		return ret, err
 	}
 	return ret, err
 }
 
 func (i *ObjectDataInput) ReadInt64() (int64, error) {
-	var err error = i.AssertAvailable(Int64SizeInBytes)
+	var err error = i.AssertAvailable(common.Int64SizeInBytes)
 	var ret int64
 	if err == nil {
-		ret = ReadInt64(i.buffer, i.position, i.bigEndian)
-		i.position += Int64SizeInBytes
+		ret = common.ReadInt64(i.buffer, i.position, i.bigEndian)
+		i.position += common.Int64SizeInBytes
 		return ret, err
 	}
 	return ret, err
 }
 
 func (i *ObjectDataInput) ReadInt64WithPosition(pos int32) (int64, error) {
-	var err error = i.AssertAvailable(Int64SizeInBytes)
+	var err error = i.AssertAvailable(common.Int64SizeInBytes)
 	var ret int64
 	if err == nil {
-		ret = ReadInt64(i.buffer, pos, i.bigEndian)
+		ret = common.ReadInt64(i.buffer, pos, i.bigEndian)
 		return ret, err
 	}
 	return ret, err
 }
 
 func (i *ObjectDataInput) ReadFloat32() (float32, error) {
-	var err error = i.AssertAvailable(Float32SizeInBytes)
+	var err error = i.AssertAvailable(common.Float32SizeInBytes)
 	var ret float32
 	if err == nil {
-		ret = ReadFloat32(i.buffer, i.position, i.bigEndian)
-		i.position += Float32SizeInBytes
+		ret = common.ReadFloat32(i.buffer, i.position, i.bigEndian)
+		i.position += common.Float32SizeInBytes
 		return ret, err
 	}
 	return ret, err
 }
 
 func (i *ObjectDataInput) ReadFloat32WithPosition(pos int32) (float32, error) {
-	var err error = i.AssertAvailable(Float32SizeInBytes)
+	var err error = i.AssertAvailable(common.Float32SizeInBytes)
 	var ret float32
 	if err == nil {
-		ret = ReadFloat32(i.buffer, pos, i.bigEndian)
+		ret = common.ReadFloat32(i.buffer, pos, i.bigEndian)
 		return ret, err
 	}
 	return ret, err
 }
 
 func (i *ObjectDataInput) ReadFloat64() (float64, error) {
-	var err error = i.AssertAvailable(Float64SizeInBytes)
+	var err error = i.AssertAvailable(common.Float64SizeInBytes)
 	var ret float64
 	if err == nil {
-		ret = ReadFloat64(i.buffer, i.position, i.bigEndian)
-		i.position += Float64SizeInBytes
+		ret = common.ReadFloat64(i.buffer, i.position, i.bigEndian)
+		i.position += common.Float64SizeInBytes
 		return ret, err
 	}
 	return ret, err
 }
 
 func (i *ObjectDataInput) ReadFloat64WithPosition(pos int32) (float64, error) {
-	var err error = i.AssertAvailable(Float64SizeInBytes)
+	var err error = i.AssertAvailable(common.Float64SizeInBytes)
 	var ret float64
 	if err == nil {
-		ret = ReadFloat64(i.buffer, pos, i.bigEndian)
+		ret = common.ReadFloat64(i.buffer, pos, i.bigEndian)
 		return ret, err
 	}
 	return ret, err
@@ -483,7 +483,7 @@ func (i *ObjectDataInput) ReadFloat64WithPosition(pos int32) (float64, error) {
 
 func (i *ObjectDataInput) ReadUTF() (string, error) {
 	length, err := i.ReadInt32()
-	if err != nil || length == NilArrayLength {
+	if err != nil || length == common.NilArrayLength {
 		return "", err
 	}
 	var ret []rune = make([]rune, length)
@@ -497,10 +497,10 @@ func (i *ObjectDataInput) ReadUTF() (string, error) {
 
 func (i *ObjectDataInput) ReadUTFWithPosition(pos int32) (string, error) {
 	length, err := i.ReadInt32WithPosition(pos)
-	if err != nil || length == NilArrayLength {
+	if err != nil || length == common.NilArrayLength {
 		return "", err
 	}
-	pos += Int32SizeInBytes
+	pos += common.Int32SizeInBytes
 	var ret []rune = make([]rune, length)
 	for j := 0; j < int(length); j++ {
 		r, n := utf8.DecodeRune(i.buffer[pos:])
@@ -516,7 +516,7 @@ func (i *ObjectDataInput) ReadObject() (interface{}, error) {
 
 func (i *ObjectDataInput) ReadByteArray() ([]byte, error) {
 	length, err := i.ReadInt32()
-	if err != nil || length == NilArrayLength {
+	if err != nil || length == common.NilArrayLength {
 		return nil, err
 	}
 	var arr []byte = make([]byte, length)
@@ -533,7 +533,7 @@ func (i *ObjectDataInput) ReadByteArrayWithPosition(pos int32) ([]byte, error) {
 	backupPos := i.position
 	i.position = pos
 	length, err := i.ReadInt32()
-	if err != nil || length == NilArrayLength {
+	if err != nil || length == common.NilArrayLength {
 		return nil, err
 	}
 	var arr []byte = make([]byte, length)
@@ -549,7 +549,7 @@ func (i *ObjectDataInput) ReadByteArrayWithPosition(pos int32) ([]byte, error) {
 
 func (i *ObjectDataInput) ReadBoolArray() ([]bool, error) {
 	length, err := i.ReadInt32()
-	if err != nil || length == NilArrayLength {
+	if err != nil || length == common.NilArrayLength {
 		return nil, err
 	}
 	var arr []bool = make([]bool, length)
@@ -566,7 +566,7 @@ func (i *ObjectDataInput) ReadBoolArrayWithPosition(pos int32) ([]bool, error) {
 	backupPos := i.position
 	i.position = pos
 	length, err := i.ReadInt32()
-	if err != nil || length == NilArrayLength {
+	if err != nil || length == common.NilArrayLength {
 		return nil, err
 	}
 	var arr []bool = make([]bool, length)
@@ -582,7 +582,7 @@ func (i *ObjectDataInput) ReadBoolArrayWithPosition(pos int32) ([]bool, error) {
 
 func (i *ObjectDataInput) ReadUInt16Array() ([]uint16, error) {
 	length, err := i.ReadInt32()
-	if err != nil || length == NilArrayLength {
+	if err != nil || length == common.NilArrayLength {
 		return nil, err
 	}
 	var arr []uint16 = make([]uint16, length)
@@ -599,7 +599,7 @@ func (i *ObjectDataInput) ReadUInt16ArrayWithPosition(pos int32) ([]uint16, erro
 	backupPos := i.position
 	i.position = pos
 	length, err := i.ReadInt32()
-	if err != nil || length == NilArrayLength {
+	if err != nil || length == common.NilArrayLength {
 		return nil, err
 	}
 	var arr []uint16 = make([]uint16, length)
@@ -615,7 +615,7 @@ func (i *ObjectDataInput) ReadUInt16ArrayWithPosition(pos int32) ([]uint16, erro
 
 func (i *ObjectDataInput) ReadInt16Array() ([]int16, error) {
 	length, err := i.ReadInt32()
-	if err != nil || length == NilArrayLength {
+	if err != nil || length == common.NilArrayLength {
 		return nil, err
 	}
 	var arr []int16 = make([]int16, length)
@@ -632,7 +632,7 @@ func (i *ObjectDataInput) ReadInt16ArrayWithPosition(pos int32) ([]int16, error)
 	backupPos := i.position
 	i.position = pos
 	length, err := i.ReadInt32()
-	if err != nil || length == NilArrayLength {
+	if err != nil || length == common.NilArrayLength {
 		return nil, err
 	}
 	var arr []int16 = make([]int16, length)
@@ -648,7 +648,7 @@ func (i *ObjectDataInput) ReadInt16ArrayWithPosition(pos int32) ([]int16, error)
 
 func (i *ObjectDataInput) ReadInt32Array() ([]int32, error) {
 	length, err := i.ReadInt32()
-	if err != nil || length == NilArrayLength {
+	if err != nil || length == common.NilArrayLength {
 		return nil, err
 	}
 	var arr []int32 = make([]int32, length)
@@ -665,7 +665,7 @@ func (i *ObjectDataInput) ReadInt32ArrayWithPosition(pos int32) ([]int32, error)
 	backupPos := i.position
 	i.position = pos
 	length, err := i.ReadInt32()
-	if err != nil || length == NilArrayLength {
+	if err != nil || length == common.NilArrayLength {
 		return nil, err
 	}
 	var arr []int32 = make([]int32, length)
@@ -681,7 +681,7 @@ func (i *ObjectDataInput) ReadInt32ArrayWithPosition(pos int32) ([]int32, error)
 
 func (i *ObjectDataInput) ReadInt64Array() ([]int64, error) {
 	length, err := i.ReadInt32()
-	if err != nil || length == NilArrayLength {
+	if err != nil || length == common.NilArrayLength {
 		return nil, err
 	}
 	var arr []int64 = make([]int64, length)
@@ -698,7 +698,7 @@ func (i *ObjectDataInput) ReadInt64ArrayWithPosition(pos int32) ([]int64, error)
 	backupPos := i.position
 	i.position = pos
 	length, err := i.ReadInt32()
-	if err != nil || length == NilArrayLength {
+	if err != nil || length == common.NilArrayLength {
 		return nil, err
 	}
 	var arr []int64 = make([]int64, length)
@@ -714,7 +714,7 @@ func (i *ObjectDataInput) ReadInt64ArrayWithPosition(pos int32) ([]int64, error)
 
 func (i *ObjectDataInput) ReadFloat32Array() ([]float32, error) {
 	length, err := i.ReadInt32()
-	if err != nil || length == NilArrayLength {
+	if err != nil || length == common.NilArrayLength {
 		return nil, err
 	}
 	var arr []float32 = make([]float32, length)
@@ -731,7 +731,7 @@ func (i *ObjectDataInput) ReadFloat32ArrayWithPosition(pos int32) ([]float32, er
 	backupPos := i.position
 	i.position = pos
 	length, err := i.ReadInt32()
-	if err != nil || length == NilArrayLength {
+	if err != nil || length == common.NilArrayLength {
 		return nil, err
 	}
 	var arr []float32 = make([]float32, length)
@@ -747,7 +747,7 @@ func (i *ObjectDataInput) ReadFloat32ArrayWithPosition(pos int32) ([]float32, er
 
 func (i *ObjectDataInput) ReadFloat64Array() ([]float64, error) {
 	length, err := i.ReadInt32()
-	if err != nil || length == NilArrayLength {
+	if err != nil || length == common.NilArrayLength {
 		return nil, err
 	}
 	var arr []float64 = make([]float64, length)
@@ -764,7 +764,7 @@ func (i *ObjectDataInput) ReadFloat64ArrayWithPosition(pos int32) ([]float64, er
 	backupPos := i.position
 	i.position = pos
 	length, err := i.ReadInt32()
-	if err != nil || length == NilArrayLength {
+	if err != nil || length == common.NilArrayLength {
 		return nil, err
 	}
 	var arr []float64 = make([]float64, length)
@@ -780,7 +780,7 @@ func (i *ObjectDataInput) ReadFloat64ArrayWithPosition(pos int32) ([]float64, er
 
 func (i *ObjectDataInput) ReadUTFArray() ([]string, error) {
 	length, err := i.ReadInt32()
-	if err != nil || length == NilArrayLength {
+	if err != nil || length == common.NilArrayLength {
 		return nil, err
 	}
 	var arr []string = make([]string, length)
@@ -797,7 +797,7 @@ func (i *ObjectDataInput) ReadUTFArrayWithPosition(pos int32) ([]string, error) 
 	backupPos := i.position
 	i.position = pos
 	length, err := i.ReadInt32()
-	if err != nil || length == NilArrayLength {
+	if err != nil || length == common.NilArrayLength {
 		return nil, err
 	}
 	var arr []string = make([]string, length)
@@ -811,7 +811,7 @@ func (i *ObjectDataInput) ReadUTFArrayWithPosition(pos int32) ([]string, error) 
 	return arr, nil
 }
 
-func (i *ObjectDataInput) ReadData() (IData, error) {
+func (i *ObjectDataInput) ReadData() (serialization.IData, error) {
 	array, err := i.ReadByteArray()
 	if err != nil {
 		return nil, err
@@ -831,33 +831,33 @@ func NewPositionalObjectDataOutput(length int, service *SerializationService, bi
 }
 
 func (p *PositionalObjectDataOutput) PWriteByte(pos int32, v byte) {
-	WriteUInt8(p.buffer, pos, v)
+	common.WriteUInt8(p.buffer, pos, v)
 }
 
 func (p *PositionalObjectDataOutput) PWriteBool(pos int32, v bool) {
-	WriteBool(p.buffer, pos, v)
+	common.WriteBool(p.buffer, pos, v)
 }
 
 func (p *PositionalObjectDataOutput) PWriteUInt16(pos int32, v uint16) {
-	WriteUInt16(p.buffer, pos, v, p.bigEndian)
+	common.WriteUInt16(p.buffer, pos, v, p.bigEndian)
 }
 
 func (p *PositionalObjectDataOutput) PWriteInt16(pos int32, v int16) {
-	WriteInt16(p.buffer, pos, v, p.bigEndian)
+	common.WriteInt16(p.buffer, pos, v, p.bigEndian)
 }
 
 func (p *PositionalObjectDataOutput) PWriteInt32(pos int32, v int32) {
-	WriteInt32(p.buffer, pos, v, p.bigEndian)
+	common.WriteInt32(p.buffer, pos, v, p.bigEndian)
 }
 
 func (p *PositionalObjectDataOutput) PWriteInt64(pos int32, v int64) {
-	WriteInt64(p.buffer, pos, v, p.bigEndian)
+	common.WriteInt64(p.buffer, pos, v, p.bigEndian)
 }
 
 func (p *PositionalObjectDataOutput) PWriteFloat32(pos int32, v float32) {
-	WriteFloat32(p.buffer, pos, v, p.bigEndian)
+	common.WriteFloat32(p.buffer, pos, v, p.bigEndian)
 }
 
 func (p *PositionalObjectDataOutput) PWriteFloat64(pos int32, v float64) {
-	WriteFloat64(p.buffer, pos, v, p.bigEndian)
+	common.WriteFloat64(p.buffer, pos, v, p.bigEndian)
 }

--- a/internal/serialization/portable_serializer_test.go
+++ b/internal/serialization/portable_serializer_test.go
@@ -16,9 +16,9 @@ package serialization
 
 import (
 	"fmt"
-	. "github.com/hazelcast/hazelcast-go-client/config"
+	"github.com/hazelcast/hazelcast-go-client/config"
 	"github.com/hazelcast/hazelcast-go-client/core"
-	. "github.com/hazelcast/hazelcast-go-client/serialization"
+	"github.com/hazelcast/hazelcast-go-client/serialization"
 	"github.com/hazelcast/hazelcast-go-client/serialization/classdef"
 	"reflect"
 	"testing"
@@ -27,7 +27,7 @@ import (
 type PortableFactory1 struct {
 }
 
-func (*PortableFactory1) Create(classId int32) Portable {
+func (*PortableFactory1) Create(classId int32) serialization.Portable {
 	if classId == 1 {
 		return &student{}
 	} else if classId == 2 {
@@ -39,7 +39,7 @@ func (*PortableFactory1) Create(classId int32) Portable {
 type PortableFactory2 struct {
 }
 
-func (*PortableFactory2) Create(classId int32) Portable {
+func (*PortableFactory2) Create(classId int32) serialization.Portable {
 	if classId == 1 {
 		return &student2{}
 	}
@@ -60,14 +60,14 @@ func (*student) ClassId() int32 {
 	return 1
 }
 
-func (s *student) WritePortable(writer PortableWriter) error {
+func (s *student) WritePortable(writer serialization.PortableWriter) error {
 	writer.WriteInt16("id", s.id)
 	writer.WriteInt32("age", s.age)
 	writer.WriteUTF("name", s.name)
 	return nil
 }
 
-func (s *student) ReadPortable(reader PortableReader) error {
+func (s *student) ReadPortable(reader serialization.PortableReader) error {
 	s.id, _ = reader.ReadInt16("id")
 	s.age, _ = reader.ReadInt32("age")
 	s.name, _ = reader.ReadUTF("name")
@@ -92,14 +92,14 @@ func (*student2) Version() int32 {
 	return 1
 }
 
-func (s *student2) WritePortable(writer PortableWriter) error {
+func (s *student2) WritePortable(writer serialization.PortableWriter) error {
 	writer.WriteInt32("id", s.id)
 	writer.WriteInt32("age", s.age)
 	writer.WriteUTF("name", s.name)
 	return nil
 }
 
-func (s *student2) ReadPortable(reader PortableReader) error {
+func (s *student2) ReadPortable(reader serialization.PortableReader) error {
 	s.id, _ = reader.ReadInt32("id")
 	s.age, _ = reader.ReadInt32("age")
 	s.name, _ = reader.ReadUTF("name")
@@ -121,16 +121,16 @@ func (*student3) Version() int32 {
 	return 1
 }
 
-func (s *student3) WritePortable(writer PortableWriter) error {
+func (s *student3) WritePortable(writer serialization.PortableWriter) error {
 	return nil
 }
 
-func (s *student3) ReadPortable(reader PortableReader) error {
+func (s *student3) ReadPortable(reader serialization.PortableReader) error {
 	return nil
 }
 
 func TestPortableSerializer(t *testing.T) {
-	config := NewSerializationConfig()
+	config := config.NewSerializationConfig()
 	config.AddPortableFactory(2, &PortableFactory1{})
 	service := NewSerializationService(config)
 	expectedRet := &student{10, 22, "Furkan Şenharputlu"}
@@ -143,7 +143,7 @@ func TestPortableSerializer(t *testing.T) {
 }
 
 func TestPortableSerializer_NoFactory(t *testing.T) {
-	config := NewSerializationConfig()
+	config := config.NewSerializationConfig()
 	service := NewSerializationService(config)
 	expectedRet := &student3{}
 	data, _ := service.ToData(expectedRet)
@@ -155,7 +155,7 @@ func TestPortableSerializer_NoFactory(t *testing.T) {
 }
 
 func TestPortableSerializer_NilPortable(t *testing.T) {
-	config := NewSerializationConfig()
+	config := config.NewSerializationConfig()
 	service := NewSerializationService(config)
 	expectedRet := &student2{}
 	data, _ := service.ToData(expectedRet)
@@ -176,7 +176,7 @@ type fake struct {
 	f32          float32
 	f64          float64
 	utf          string
-	portable     Portable
+	portable     serialization.Portable
 	byt_arr      []byte
 	boo_arr      []bool
 	ui16_arr     []uint16
@@ -186,7 +186,7 @@ type fake struct {
 	f32_arr      []float32
 	f64_arr      []float64
 	utf_arr      []string
-	portable_arr []Portable
+	portable_arr []serialization.Portable
 }
 
 func (*fake) FactoryId() int32 {
@@ -197,7 +197,7 @@ func (*fake) ClassId() int32 {
 	return 2
 }
 
-func (f *fake) WritePortable(writer PortableWriter) error {
+func (f *fake) WritePortable(writer serialization.PortableWriter) error {
 	writer.WriteByte("byt", f.byt)
 	writer.WriteBool("boo", f.boo)
 	writer.WriteUInt16("ui16", f.ui16)
@@ -225,7 +225,7 @@ func (f *fake) WritePortable(writer PortableWriter) error {
 	return nil
 }
 
-func (f *fake) ReadPortable(reader PortableReader) error {
+func (f *fake) ReadPortable(reader serialization.PortableReader) error {
 	f.byt, _ = reader.ReadByte("byt")
 	f.boo, _ = reader.ReadBool("boo")
 	f.ui16, _ = reader.ReadUInt16("ui16")
@@ -250,7 +250,7 @@ func (f *fake) ReadPortable(reader PortableReader) error {
 }
 
 func TestPortableSerializer2(t *testing.T) {
-	config := NewSerializationConfig()
+	config := config.NewSerializationConfig()
 	config.AddPortableFactory(2, &PortableFactory1{})
 	service := NewSerializationService(config)
 
@@ -263,7 +263,7 @@ func TestPortableSerializer2(t *testing.T) {
 	var f32 float32 = -3.4E+38
 	var f64 float64 = -1.7E+308
 	var utf string = "Günaydın, こんにちは"
-	var portable Portable = &student{10, 22, "Furkan Şenharputlu"}
+	var portable serialization.Portable = &student{10, 22, "Furkan Şenharputlu"}
 	var byt_arr []byte = []byte{127, 128, 255, 0, 4, 6, 8, 121}
 	var boo_arr []bool = []bool{true, true, false, true, false, false, false, true, false, true}
 	var ui16_arr []uint16 = []uint16{65535, 65535, 65535, 1234, 23524, 13131, 9999}
@@ -273,7 +273,7 @@ func TestPortableSerializer2(t *testing.T) {
 	var f32_arr []float32 = []float32{-3.4E+38, 12.344, 21.2646, 3.4E+38}
 	var f64_arr []float64 = []float64{-1.7E+308, 1213.2342, 45345.9887, 1.7E+308}
 	var utf_arr []string = []string{"こんにちは", "ilköğretim", "FISTIKÇIŞAHAP"}
-	var portable_arr []Portable = []Portable{&student{10, 22, "Furkan Şenharputlu"}, &student{2, 20, "Micheal Micheal"}}
+	var portable_arr []serialization.Portable = []serialization.Portable{&student{10, 22, "Furkan Şenharputlu"}, &student{2, 20, "Micheal Micheal"}}
 
 	expectedRet := &fake{byt, boo, ui16, i16, i32, i64, f32, f64, utf, portable,
 		byt_arr, boo_arr, ui16_arr, i16_arr, i32_arr, i64_arr, f32_arr, f64_arr, utf_arr, portable_arr}
@@ -287,7 +287,7 @@ func TestPortableSerializer2(t *testing.T) {
 }
 
 func TestPortableSerializer3(t *testing.T) {
-	config := NewSerializationConfig()
+	config := config.NewSerializationConfig()
 	config.AddPortableFactory(2, &PortableFactory1{})
 	service := NewSerializationService(config)
 	service2 := NewSerializationService(config)
@@ -301,8 +301,9 @@ func TestPortableSerializer3(t *testing.T) {
 }
 
 func TestPortableSerializer4(t *testing.T) {
-	config := NewSerializationConfig()
-	config.AddPortableFactory(2, &PortableFactory1{})
+	config1 := config.NewSerializationConfig()
+	config2 := config.NewSerializationConfig()
+	config1.AddPortableFactory(2, &PortableFactory1{})
 	builder := classdef.NewClassDefinitionBuilder(2, 1, 0)
 	err := builder.AddInt16Field("id")
 	err = builder.AddInt32Field("age")
@@ -311,9 +312,9 @@ func TestPortableSerializer4(t *testing.T) {
 		t.Errorf("ClassDefinitionBuilder works wrong")
 	}
 	cd := builder.Build()
-	config.AddClassDefinition(cd)
+	config1.AddClassDefinition(cd)
 
-	service := NewSerializationService(config)
+	service := NewSerializationService(config1)
 
 	var byt byte = 255
 	var boo bool = true
@@ -333,7 +334,7 @@ func TestPortableSerializer4(t *testing.T) {
 	var f32_arr []float32 = []float32{-3.4E+38, 12.344, 21.2646, 3.4E+38}
 	var f64_arr []float64 = []float64{-1.7E+308, 1213.2342, 45345.9887, 1.7E+308}
 	var utf_arr []string = []string{"こんにちは", "ilköğretim", "FISTIKÇIŞAHAP"}
-	var portable_arr []Portable = []Portable{&student{10, 22, "Furkan Şenharputlu"}, &student{2, 20, "Micheal Micheal"}}
+	var portable_arr []serialization.Portable = []serialization.Portable{&student{10, 22, "Furkan Şenharputlu"}, &student{2, 20, "Micheal Micheal"}}
 
 	expectedRet := &fake{byt, boo, ui16, i16, i32, i64, f32, f64, utf, nil,
 		byt_arr, boo_arr, ui16_arr, i16_arr, i32_arr, i64_arr, f32_arr, f64_arr, utf_arr, portable_arr}
@@ -341,7 +342,6 @@ func TestPortableSerializer4(t *testing.T) {
 	data, _ := service.ToData(expectedRet)
 	ret, _ := service.ToObject(data)
 
-	config2 := NewSerializationConfig()
 	config2.AddPortableFactory(2, &PortableFactory1{})
 
 	if !reflect.DeepEqual(ret, expectedRet) {

--- a/internal/serialization/serialization_test.go
+++ b/internal/serialization/serialization_test.go
@@ -17,8 +17,8 @@ package serialization
 import (
 	"bytes"
 	"encoding/gob"
-	. "github.com/hazelcast/hazelcast-go-client/config"
-	. "github.com/hazelcast/hazelcast-go-client/serialization"
+	"github.com/hazelcast/hazelcast-go-client/config"
+	"github.com/hazelcast/hazelcast-go-client/serialization"
 	"reflect"
 	"testing"
 )
@@ -30,7 +30,7 @@ const (
 
 func TestSerializationService_LookUpDefaultSerializer(t *testing.T) {
 	var a int32 = 5
-	var id int32 = NewSerializationService(NewSerializationConfig()).lookUpDefaultSerializer(a).Id()
+	var id int32 = NewSerializationService(config.NewSerializationConfig()).lookUpDefaultSerializer(a).Id()
 	var expectedId int32 = -7
 	if id != expectedId {
 		t.Errorf("LookUpDefaultSerializer() returns ", id, " expected ", expectedId)
@@ -39,7 +39,7 @@ func TestSerializationService_LookUpDefaultSerializer(t *testing.T) {
 
 func TestSerializationService_ToData(t *testing.T) {
 	var expected int32 = 5
-	c := NewSerializationConfig()
+	c := config.NewSerializationConfig()
 	service := NewSerializationService(c)
 	data, _ := service.ToData(expected)
 	var ret int32
@@ -57,7 +57,7 @@ func (s *CustomArtistSerializer) Id() int32 {
 	return 10
 }
 
-func (s *CustomArtistSerializer) Read(input DataInput) (interface{}, error) {
+func (s *CustomArtistSerializer) Read(input serialization.DataInput) (interface{}, error) {
 	var network bytes.Buffer
 	typ, _ := input.ReadInt32()
 	data, _ := input.ReadData()
@@ -74,7 +74,7 @@ func (s *CustomArtistSerializer) Read(input DataInput) (interface{}, error) {
 	return v, nil
 }
 
-func (s *CustomArtistSerializer) Write(output DataOutput, obj interface{}) error {
+func (s *CustomArtistSerializer) Write(output serialization.DataOutput, obj interface{}) error {
 	var network bytes.Buffer
 	enc := gob.NewEncoder(&network)
 	err := enc.Encode(obj)
@@ -99,7 +99,7 @@ func (s *GlobalSerializer) Id() int32 {
 	return 123
 }
 
-func (s *GlobalSerializer) Read(input DataInput) (interface{}, error) {
+func (s *GlobalSerializer) Read(input serialization.DataInput) (interface{}, error) {
 	var network bytes.Buffer
 	data, _ := input.ReadData()
 	network.Write(data.Buffer())
@@ -109,7 +109,7 @@ func (s *GlobalSerializer) Read(input DataInput) (interface{}, error) {
 	return v, nil
 }
 
-func (s *GlobalSerializer) Write(output DataOutput, obj interface{}) error {
+func (s *GlobalSerializer) Write(output serialization.DataOutput, obj interface{}) error {
 	var network bytes.Buffer
 	enc := gob.NewEncoder(&network)
 	err := enc.Encode(obj)
@@ -147,7 +147,7 @@ func TestCustomSerializer(t *testing.T) {
 	m := &musician{"Furkan", "Şenharputlu"}
 	p := &painter{"Leonardo", "da Vinci"}
 	customSerializer := &CustomArtistSerializer{}
-	config := NewSerializationConfig()
+	config := config.NewSerializationConfig()
 
 	config.AddCustomSerializer(reflect.TypeOf((*artist)(nil)).Elem(), customSerializer)
 	service := NewSerializationService(config)
@@ -163,7 +163,7 @@ func TestCustomSerializer(t *testing.T) {
 
 func TestGlobalSerializer(t *testing.T) {
 	obj := &customObject{10, "Furkan Şenharputlu"}
-	config := NewSerializationConfig()
+	config := config.NewSerializationConfig()
 	config.SetGlobalSerializer(&GlobalSerializer{})
 	service := NewSerializationService(config)
 	data, _ := service.ToData(obj)
@@ -234,7 +234,7 @@ func TestGobSerializer(t *testing.T) {
 	expected := &fake2{aBoolean, aByte, aChar, aDouble, aShort, aFloat, anInt, aLong, aString,
 		bools, bytes, chars, doubles, shorts, floats, ints, longs, strings,
 		nil, nil, nil, nil, nil, nil, nil, nil, nil}
-	service := NewSerializationService(NewSerializationConfig())
+	service := NewSerializationService(config.NewSerializationConfig())
 	data, _ := service.ToData(expected)
 	ret, _ := service.ToObject(data)
 
@@ -246,7 +246,7 @@ func TestGobSerializer(t *testing.T) {
 
 func TestInt64SerializerWithInt(t *testing.T) {
 	var id int = 15
-	config := NewSerializationConfig()
+	config := config.NewSerializationConfig()
 	service := NewSerializationService(config)
 	data, _ := service.ToData(id)
 	ret, _ := service.ToObject(data)
@@ -258,7 +258,7 @@ func TestInt64SerializerWithInt(t *testing.T) {
 
 func TestInt64ArraySerializerWithIntArray(t *testing.T) {
 	var ids []int = []int{15, 10, 20, 12, 35}
-	config := NewSerializationConfig()
+	config := config.NewSerializationConfig()
 	service := NewSerializationService(config)
 	data, _ := service.ToData(ids)
 	ret, _ := service.ToObject(data)
@@ -275,7 +275,7 @@ func TestInt64ArraySerializerWithIntArray(t *testing.T) {
 
 func TestSerializeData(t *testing.T) {
 	data := NewData([]byte{10, 20, 0, 30, 5, 7, 6})
-	config := NewSerializationConfig()
+	config := config.NewSerializationConfig()
 	service := NewSerializationService(config)
 	serializedData, _ := service.ToData(data)
 	if !reflect.DeepEqual(data, serializedData) {

--- a/internal/set.go
+++ b/internal/set.go
@@ -15,8 +15,8 @@
 package internal
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/protocol"
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
 type SetProxy struct {
@@ -36,9 +36,9 @@ func (set *SetProxy) Add(item interface{}) (added bool, err error) {
 	if err != nil {
 		return false, err
 	}
-	request := SetAddEncodeRequest(set.name, itemData)
+	request := protocol.SetAddEncodeRequest(set.name, itemData)
 	responseMessage, err := set.invoke(request)
-	return set.decodeToBoolAndError(responseMessage, err, SetAddDecodeResponse)
+	return set.decodeToBoolAndError(responseMessage, err, protocol.SetAddDecodeResponse)
 }
 
 func (set *SetProxy) AddAll(items []interface{}) (changed bool, err error) {
@@ -46,25 +46,25 @@ func (set *SetProxy) AddAll(items []interface{}) (changed bool, err error) {
 	if err != nil {
 		return false, err
 	}
-	request := SetAddAllEncodeRequest(set.name, itemsData)
+	request := protocol.SetAddAllEncodeRequest(set.name, itemsData)
 	responseMessage, err := set.invoke(request)
-	return set.decodeToBoolAndError(responseMessage, err, SetAddAllDecodeResponse)
+	return set.decodeToBoolAndError(responseMessage, err, protocol.SetAddAllDecodeResponse)
 }
 
 func (set *SetProxy) AddItemListener(listener interface{}, includeValue bool) (registrationID *string, err error) {
-	request := SetAddListenerEncodeRequest(set.name, includeValue, false)
+	request := protocol.SetAddListenerEncodeRequest(set.name, includeValue, false)
 	eventHandler := set.createEventHandler(listener)
 	return set.client.ListenerService.registerListener(request, eventHandler,
-		func(registrationId *string) *ClientMessage {
-			return SetRemoveListenerEncodeRequest(set.name, registrationId)
-		}, func(clientMessage *ClientMessage) *string {
-			return SetAddListenerDecodeResponse(clientMessage)()
+		func(registrationId *string) *protocol.ClientMessage {
+			return protocol.SetRemoveListenerEncodeRequest(set.name, registrationId)
+		}, func(clientMessage *protocol.ClientMessage) *string {
+			return protocol.SetAddListenerDecodeResponse(clientMessage)()
 		})
 
 }
 
 func (set *SetProxy) Clear() (err error) {
-	request := SetClearEncodeRequest(set.name)
+	request := protocol.SetClearEncodeRequest(set.name)
 	_, err = set.invoke(request)
 	return err
 }
@@ -74,9 +74,9 @@ func (set *SetProxy) Contains(item interface{}) (found bool, err error) {
 	if err != nil {
 		return false, err
 	}
-	request := SetContainsEncodeRequest(set.name, itemData)
+	request := protocol.SetContainsEncodeRequest(set.name, itemData)
 	responseMessage, err := set.invoke(request)
-	return set.decodeToBoolAndError(responseMessage, err, SetContainsDecodeResponse)
+	return set.decodeToBoolAndError(responseMessage, err, protocol.SetContainsDecodeResponse)
 }
 
 func (set *SetProxy) ContainsAll(items []interface{}) (foundAll bool, err error) {
@@ -84,15 +84,15 @@ func (set *SetProxy) ContainsAll(items []interface{}) (foundAll bool, err error)
 	if err != nil {
 		return false, err
 	}
-	request := SetContainsAllEncodeRequest(set.name, itemsData)
+	request := protocol.SetContainsAllEncodeRequest(set.name, itemsData)
 	responseMessage, err := set.invoke(request)
-	return set.decodeToBoolAndError(responseMessage, err, SetContainsAllDecodeResponse)
+	return set.decodeToBoolAndError(responseMessage, err, protocol.SetContainsAllDecodeResponse)
 }
 
 func (set *SetProxy) IsEmpty() (empty bool, err error) {
-	request := SetIsEmptyEncodeRequest(set.name)
+	request := protocol.SetIsEmptyEncodeRequest(set.name)
 	responseMessage, err := set.invoke(request)
-	return set.decodeToBoolAndError(responseMessage, err, SetIsEmptyDecodeResponse)
+	return set.decodeToBoolAndError(responseMessage, err, protocol.SetIsEmptyDecodeResponse)
 }
 
 func (set *SetProxy) Remove(item interface{}) (removed bool, err error) {
@@ -100,9 +100,9 @@ func (set *SetProxy) Remove(item interface{}) (removed bool, err error) {
 	if err != nil {
 		return false, err
 	}
-	request := SetRemoveEncodeRequest(set.name, itemData)
+	request := protocol.SetRemoveEncodeRequest(set.name, itemData)
 	responseMessage, err := set.invoke(request)
-	return set.decodeToBoolAndError(responseMessage, err, SetRemoveDecodeResponse)
+	return set.decodeToBoolAndError(responseMessage, err, protocol.SetRemoveDecodeResponse)
 }
 
 func (set *SetProxy) RemoveAll(items []interface{}) (changed bool, err error) {
@@ -110,9 +110,9 @@ func (set *SetProxy) RemoveAll(items []interface{}) (changed bool, err error) {
 	if err != nil {
 		return false, err
 	}
-	request := SetCompareAndRemoveAllEncodeRequest(set.name, itemsData)
+	request := protocol.SetCompareAndRemoveAllEncodeRequest(set.name, itemsData)
 	responseMessage, err := set.invoke(request)
-	return set.decodeToBoolAndError(responseMessage, err, SetCompareAndRemoveAllDecodeResponse)
+	return set.decodeToBoolAndError(responseMessage, err, protocol.SetCompareAndRemoveAllDecodeResponse)
 }
 
 func (set *SetProxy) RetainAll(items []interface{}) (changed bool, err error) {
@@ -120,32 +120,32 @@ func (set *SetProxy) RetainAll(items []interface{}) (changed bool, err error) {
 	if err != nil {
 		return false, err
 	}
-	request := SetCompareAndRetainAllEncodeRequest(set.name, itemsData)
+	request := protocol.SetCompareAndRetainAllEncodeRequest(set.name, itemsData)
 	responseMessage, err := set.invoke(request)
-	return set.decodeToBoolAndError(responseMessage, err, SetCompareAndRetainAllDecodeResponse)
+	return set.decodeToBoolAndError(responseMessage, err, protocol.SetCompareAndRetainAllDecodeResponse)
 }
 
 func (set *SetProxy) Size() (size int32, err error) {
-	request := SetSizeEncodeRequest(set.name)
+	request := protocol.SetSizeEncodeRequest(set.name)
 	responseMessage, err := set.invoke(request)
-	return set.decodeToInt32AndError(responseMessage, err, SetSizeDecodeResponse)
+	return set.decodeToInt32AndError(responseMessage, err, protocol.SetSizeDecodeResponse)
 }
 
 func (set *SetProxy) RemoveItemListener(registrationID *string) (removed bool, err error) {
-	return set.client.ListenerService.deregisterListener(*registrationID, func(registrationId *string) *ClientMessage {
-		return SetRemoveListenerEncodeRequest(set.name, registrationId)
+	return set.client.ListenerService.deregisterListener(*registrationID, func(registrationId *string) *protocol.ClientMessage {
+		return protocol.SetRemoveListenerEncodeRequest(set.name, registrationId)
 	})
 }
 
 func (set *SetProxy) ToSlice() (items []interface{}, err error) {
-	request := SetGetAllEncodeRequest(set.name)
+	request := protocol.SetGetAllEncodeRequest(set.name)
 	responseMessage, err := set.invoke(request)
-	return set.decodeToInterfaceSliceAndError(responseMessage, err, SetGetAllDecodeResponse)
+	return set.decodeToInterfaceSliceAndError(responseMessage, err, protocol.SetGetAllDecodeResponse)
 }
 
-func (set *SetProxy) createEventHandler(listener interface{}) func(clientMessage *ClientMessage) {
-	return func(clientMessage *ClientMessage) {
-		SetAddListenerHandle(clientMessage, func(itemData *Data, uuid *string, eventType int32) {
+func (set *SetProxy) createEventHandler(listener interface{}) func(clientMessage *protocol.ClientMessage) {
+	return func(clientMessage *protocol.ClientMessage) {
+		protocol.SetAddListenerHandle(clientMessage, func(itemData *serialization.Data, uuid *string, eventType int32) {
 			onItemEvent := set.createOnItemEvent(listener)
 			onItemEvent(itemData, uuid, eventType)
 		})

--- a/internal/vector_clock.go
+++ b/internal/vector_clock.go
@@ -15,7 +15,7 @@
 package internal
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/internal/protocol"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol"
 	"github.com/hazelcast/hazelcast-go-client/serialization"
 	"sync"
 )
@@ -72,13 +72,13 @@ func (v *VectorClock) ReadData(input serialization.DataInput) error {
 	return nil
 }
 
-func (v *VectorClock) EntrySet() (entrySet []*Pair) {
+func (v *VectorClock) EntrySet() (entrySet []*protocol.Pair) {
 	v.mutex.RLock()
 	defer v.mutex.RUnlock()
-	entrySet = make([]*Pair, len(v.replicaTimestamps))
+	entrySet = make([]*protocol.Pair, len(v.replicaTimestamps))
 	i := 0
 	for key, value := range v.replicaTimestamps {
-		entrySet[i] = NewPair(key, value)
+		entrySet[i] = protocol.NewPair(key, value)
 		i += 1
 	}
 	return entrySet

--- a/samples/map_soak.go
+++ b/samples/map_soak.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hazelcast/hazelcast-go-client"
 	"github.com/hazelcast/hazelcast-go-client/core"
 	"github.com/hazelcast/hazelcast-go-client/core/predicates"
-	. "github.com/hazelcast/hazelcast-go-client/serialization"
+	"github.com/hazelcast/hazelcast-go-client/serialization"
 	"log"
 	"math/rand"
 	"strconv"
@@ -136,7 +136,7 @@ type identifiedFactory struct {
 	factoryId            int32
 }
 
-func (identifiedFactory *identifiedFactory) Create(id int32) IdentifiedDataSerializable {
+func (identifiedFactory *identifiedFactory) Create(id int32) serialization.IdentifiedDataSerializable {
 	if id == identifiedFactory.simpleEntryProcessor.classId {
 		return &simpleEntryProcessor{classId: 1}
 	} else {
@@ -144,13 +144,13 @@ func (identifiedFactory *identifiedFactory) Create(id int32) IdentifiedDataSeria
 	}
 }
 
-func (simpleEntryProcessor *simpleEntryProcessor) ReadData(input DataInput) error {
+func (simpleEntryProcessor *simpleEntryProcessor) ReadData(input serialization.DataInput) error {
 	var err error
 	simpleEntryProcessor.value, err = input.ReadUTF()
 	return err
 }
 
-func (simpleEntryProcessor *simpleEntryProcessor) WriteData(output DataOutput) error {
+func (simpleEntryProcessor *simpleEntryProcessor) WriteData(output serialization.DataOutput) error {
 	output.WriteUTF(simpleEntryProcessor.value)
 	return nil
 }

--- a/samples/org_website_samples/custom_serializer_sample.go
+++ b/samples/org_website_samples/custom_serializer_sample.go
@@ -15,8 +15,8 @@
 package org_website_samples
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client"
-	. "github.com/hazelcast/hazelcast-go-client/serialization"
+	"github.com/hazelcast/hazelcast-go-client"
+	"github.com/hazelcast/hazelcast-go-client/serialization"
 	"reflect"
 )
 
@@ -31,23 +31,23 @@ func (s *CustomSerializer) Id() int32 {
 	return 10
 }
 
-func (s *CustomSerializer) Read(input DataInput) (obj interface{}, err error) {
+func (s *CustomSerializer) Read(input serialization.DataInput) (obj interface{}, err error) {
 	array, err := input.ReadByteArray()
 	return &CustomSerializable{string(array)}, err
 }
 
-func (s *CustomSerializer) Write(output DataOutput, obj interface{}) (err error) {
+func (s *CustomSerializer) Write(output serialization.DataOutput, obj interface{}) (err error) {
 	array := []byte(obj.(CustomSerializable).value)
 	output.WriteByteArray(array)
 	return
 }
 
 func customSerializerSampleRun() {
-	clientConfig := NewHazelcastConfig()
+	clientConfig := hazelcast.NewHazelcastConfig()
 	clientConfig.SerializationConfig().AddCustomSerializer(reflect.TypeOf((*CustomSerializable)(nil)), &CustomSerializer{})
 
 	// Start the Hazelcast Client and connect to an already running Hazelcast Cluster on 127.0.0.1
-	hz, _ := NewHazelcastClientWithConfig(clientConfig)
+	hz, _ := hazelcast.NewHazelcastClientWithConfig(clientConfig)
 	// CustomSerializer will serialize/deserialize CustomSerializable objects
 
 	// Shutdown this hazelcast client

--- a/samples/org_website_samples/entry_processor_sample.go
+++ b/samples/org_website_samples/entry_processor_sample.go
@@ -28,11 +28,11 @@ const (
 type IncEntryProcessor struct {
 }
 
-func (simpleEntryProcessor *IncEntryProcessor) ReadData(input serialization.DataInput) error {
+func (simpleEntryProcessor *IncEntryProcessor) ReadData(input *serialization.DataInput) error {
 	return nil
 }
 
-func (simpleEntryProcessor *IncEntryProcessor) WriteData(output serialization.DataOutput) error {
+func (simpleEntryProcessor *IncEntryProcessor) WriteData(output *serialization.DataOutput) error {
 	return nil
 }
 

--- a/samples/org_website_samples/global_serializer_sample.go
+++ b/samples/org_website_samples/global_serializer_sample.go
@@ -15,9 +15,9 @@
 package org_website_samples
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client"
-	. "github.com/hazelcast/hazelcast-go-client/config"
-	. "github.com/hazelcast/hazelcast-go-client/serialization"
+	"github.com/hazelcast/hazelcast-go-client"
+	"github.com/hazelcast/hazelcast-go-client/config"
+	"github.com/hazelcast/hazelcast-go-client/serialization"
 )
 
 type GlobalSerializer struct {
@@ -27,21 +27,21 @@ func (*GlobalSerializer) Id() int32 {
 	return 20
 }
 
-func (*GlobalSerializer) Read(input DataInput) (obj interface{}, err error) {
+func (*GlobalSerializer) Read(input serialization.DataInput) (obj interface{}, err error) {
 	// return MyFavoriteSerializer.deserialize(in)
 	return
 }
 
-func (*GlobalSerializer) Write(output DataOutput, object interface{}) (err error) {
+func (*GlobalSerializer) Write(output serialization.DataOutput, object interface{}) (err error) {
 	// output.write(MyFavoriteSerializer.serialize(object))
 	return
 }
 
 func globalSerializerSampleRun() {
-	clientConfig := NewClientConfig()
+	clientConfig := config.NewClientConfig()
 	clientConfig.SerializationConfig().SetGlobalSerializer(&GlobalSerializer{})
 	// Start the Hazelcast Client and connect to an already running Hazelcast Cluster on 127.0.0.1
-	hz, _ := NewHazelcastClientWithConfig(clientConfig)
+	hz, _ := hazelcast.NewHazelcastClientWithConfig(clientConfig)
 
 	//GlobalSerializer will serialize/deserialize all non-builtin types
 

--- a/samples/org_website_samples/identified_data_serializable_sample.go
+++ b/samples/org_website_samples/identified_data_serializable_sample.go
@@ -15,9 +15,9 @@
 package org_website_samples
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client"
-	. "github.com/hazelcast/hazelcast-go-client/config"
-	. "github.com/hazelcast/hazelcast-go-client/serialization"
+	"github.com/hazelcast/hazelcast-go-client"
+	"github.com/hazelcast/hazelcast-go-client/config"
+	"github.com/hazelcast/hazelcast-go-client/serialization"
 )
 
 const (
@@ -38,7 +38,7 @@ func (e *Employee) FactoryId() int32 {
 	return sampleDataSerializableFactoryId
 }
 
-func (e *Employee) ReadData(input DataInput) (err error) {
+func (e *Employee) ReadData(input serialization.DataInput) (err error) {
 	e.id, err = input.ReadInt32()
 	if err != nil {
 		return
@@ -46,7 +46,7 @@ func (e *Employee) ReadData(input DataInput) (err error) {
 	e.name, err = input.ReadUTF()
 	return
 }
-func (e *Employee) WriteData(output DataOutput) (err error) {
+func (e *Employee) WriteData(output serialization.DataOutput) (err error) {
 	output.WriteInt32(e.id)
 	output.WriteUTF(e.name)
 	return
@@ -55,7 +55,7 @@ func (e *Employee) WriteData(output DataOutput) (err error) {
 type SampleDataSerializableFactory struct {
 }
 
-func (*SampleDataSerializableFactory) Create(classId int32) IdentifiedDataSerializable {
+func (*SampleDataSerializableFactory) Create(classId int32) serialization.IdentifiedDataSerializable {
 	if classId == classId {
 		return &Employee{}
 	}
@@ -63,10 +63,10 @@ func (*SampleDataSerializableFactory) Create(classId int32) IdentifiedDataSerial
 }
 
 func identifiedDataSerializableSampleRun() {
-	clientConfig := NewClientConfig()
+	clientConfig := config.NewClientConfig()
 	clientConfig.SerializationConfig().AddDataSerializableFactory(sampleDataSerializableFactoryId, &SampleDataSerializableFactory{})
 	// Start the Hazelcast Client and connect to an already running Hazelcast Cluster on 127.0.0.1
-	hz, _ := NewHazelcastClientWithConfig(clientConfig)
+	hz, _ := hazelcast.NewHazelcastClientWithConfig(clientConfig)
 
 	// Employee can be used here
 

--- a/samples/org_website_samples/portable_serializable_sample.go
+++ b/samples/org_website_samples/portable_serializable_sample.go
@@ -15,10 +15,10 @@
 package org_website_samples
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client"
-	. "github.com/hazelcast/hazelcast-go-client/config"
-	. "github.com/hazelcast/hazelcast-go-client/serialization"
-	. "time"
+	"github.com/hazelcast/hazelcast-go-client"
+	"github.com/hazelcast/hazelcast-go-client/config"
+	"github.com/hazelcast/hazelcast-go-client/serialization"
+	"time"
 )
 
 const (
@@ -29,7 +29,7 @@ const (
 type Customer struct {
 	name      string
 	id        int32
-	lastOrder Time
+	lastOrder time.Time
 }
 
 func (customer *Customer) FactoryId() int32 {
@@ -40,14 +40,14 @@ func (customer *Customer) ClassId() int32 {
 	return customerClassId
 }
 
-func (customer *Customer) WritePortable(writer PortableWriter) (err error) {
+func (customer *Customer) WritePortable(writer serialization.PortableWriter) (err error) {
 	writer.WriteInt32("id", customer.id)
 	writer.WriteUTF("name", customer.name)
-	writer.WriteInt64("lastOrder", customer.lastOrder.UnixNano()/int64(Millisecond))
+	writer.WriteInt64("lastOrder", customer.lastOrder.UnixNano()/int64(time.Millisecond))
 	return
 }
 
-func (customer *Customer) ReadPortable(reader PortableReader) (err error) {
+func (customer *Customer) ReadPortable(reader serialization.PortableReader) (err error) {
 	customer.id, err = reader.ReadInt32("id")
 	if err != nil {
 		return
@@ -60,14 +60,14 @@ func (customer *Customer) ReadPortable(reader PortableReader) (err error) {
 	if err != nil {
 		return
 	}
-	customer.lastOrder = Unix(0, t*int64(Millisecond))
+	customer.lastOrder = time.Unix(0, t*int64(time.Millisecond))
 	return
 }
 
 type SamplePortableFactory struct {
 }
 
-func (pf *SamplePortableFactory) Create(classId int32) Portable {
+func (pf *SamplePortableFactory) Create(classId int32) serialization.Portable {
 	if classId == samplePortableFactoryId {
 		return &Customer{}
 	}
@@ -75,10 +75,10 @@ func (pf *SamplePortableFactory) Create(classId int32) Portable {
 }
 
 func portableSerializableSampleRun() {
-	clientConfig := NewClientConfig()
+	clientConfig := config.NewClientConfig()
 	clientConfig.SerializationConfig().AddPortableFactory(samplePortableFactoryId, &SamplePortableFactory{})
 	// Start the Hazelcast Client and connect to an already running Hazelcast Cluster on 127.0.0.1
-	hz, _ := NewHazelcastClientWithConfig(clientConfig)
+	hz, _ := hazelcast.NewHazelcastClientWithConfig(clientConfig)
 	// Customer can be used here
 
 	// Shutdown this hazelcast client

--- a/samples/org_website_samples/query_sample.go
+++ b/samples/org_website_samples/query_sample.go
@@ -17,8 +17,8 @@ package org_website_samples
 import (
 	"fmt"
 	"github.com/hazelcast/hazelcast-go-client"
-	. "github.com/hazelcast/hazelcast-go-client/core"
-	. "github.com/hazelcast/hazelcast-go-client/core/predicates"
+	"github.com/hazelcast/hazelcast-go-client/core"
+	"github.com/hazelcast/hazelcast-go-client/core/predicates"
 	"github.com/hazelcast/hazelcast-go-client/serialization"
 )
 
@@ -83,7 +83,7 @@ func (portableFactory *ThePortableFactory) Create(classId int32) serialization.P
 	return nil
 }
 
-func generateUsers(users IMap) {
+func generateUsers(users core.IMap) {
 	users.Put("Rod", newUser("Rod", 19, true))
 	users.Put("Jane", newUser("Jane", 20, true))
 	users.Put("Freddy", newUser("Freddy", 23, true))
@@ -100,11 +100,11 @@ func querySampleRun() {
 	// Add some users to the Distributed Map
 	generateUsers(users)
 	// Create a Predicate from a String (a SQL like Where clause)
-	var sqlQuery = Sql("active AND age BETWEEN 18 AND 21)")
+	var sqlQuery = predicates.Sql("active AND age BETWEEN 18 AND 21)")
 	// Creating the same Predicate as above but with a builder
-	var criteriaQuery = And(
-		Equal("active", true),
-		Between("age", 18, 21))
+	var criteriaQuery = predicates.And(
+		predicates.Equal("active", true),
+		predicates.Between("age", 18, 21))
 
 	// Get result collections using the two different Predicates
 	result1, _ := users.ValuesWithPredicate(sqlQuery)

--- a/serialization/classdef/class_definition_builder.go
+++ b/serialization/classdef/class_definition_builder.go
@@ -3,21 +3,21 @@ package classdef
 import (
 	"fmt"
 	"github.com/hazelcast/hazelcast-go-client/core"
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization/classdef"
-	. "github.com/hazelcast/hazelcast-go-client/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization/classdef"
+	"github.com/hazelcast/hazelcast-go-client/serialization"
 )
 
 type ClassDefinitionBuilder struct {
 	factoryId        int32
 	classId          int32
 	version          int32
-	fieldDefinitions map[string]FieldDefinition
+	fieldDefinitions map[string]serialization.FieldDefinition
 	index            int32
 	done             bool
 }
 
 func NewClassDefinitionBuilder(factoryId int32, classId int32, version int32) *ClassDefinitionBuilder {
-	return &ClassDefinitionBuilder{factoryId, classId, version, make(map[string]FieldDefinition), 0, false}
+	return &ClassDefinitionBuilder{factoryId, classId, version, make(map[string]serialization.FieldDefinition), 0, false}
 }
 
 func (cdb *ClassDefinitionBuilder) AddByteField(fieldName string) error {
@@ -25,7 +25,7 @@ func (cdb *ClassDefinitionBuilder) AddByteField(fieldName string) error {
 	if err != nil {
 		return err
 	}
-	cdb.fieldDefinitions[fieldName] = NewFieldDefinitionImpl(cdb.index, fieldName, TypeByte, 0, 0, cdb.version)
+	cdb.fieldDefinitions[fieldName] = classdef.NewFieldDefinitionImpl(cdb.index, fieldName, classdef.TypeByte, 0, 0, cdb.version)
 	cdb.index++
 	return nil
 }
@@ -35,7 +35,7 @@ func (cdb *ClassDefinitionBuilder) AddBoolField(fieldName string) error {
 	if err != nil {
 		return err
 	}
-	cdb.fieldDefinitions[fieldName] = NewFieldDefinitionImpl(cdb.index, fieldName, TypeBool, 0, 0, cdb.version)
+	cdb.fieldDefinitions[fieldName] = classdef.NewFieldDefinitionImpl(cdb.index, fieldName, classdef.TypeBool, 0, 0, cdb.version)
 	cdb.index++
 	return nil
 }
@@ -45,7 +45,7 @@ func (cdb *ClassDefinitionBuilder) AddUInt16Field(fieldName string) error {
 	if err != nil {
 		return err
 	}
-	cdb.fieldDefinitions[fieldName] = NewFieldDefinitionImpl(cdb.index, fieldName, TypeUint16, 0, 0, cdb.version)
+	cdb.fieldDefinitions[fieldName] = classdef.NewFieldDefinitionImpl(cdb.index, fieldName, classdef.TypeUint16, 0, 0, cdb.version)
 	cdb.index++
 	return nil
 }
@@ -55,7 +55,7 @@ func (cdb *ClassDefinitionBuilder) AddInt16Field(fieldName string) error {
 	if err != nil {
 		return err
 	}
-	cdb.fieldDefinitions[fieldName] = NewFieldDefinitionImpl(cdb.index, fieldName, TypeInt16, 0, 0, cdb.version)
+	cdb.fieldDefinitions[fieldName] = classdef.NewFieldDefinitionImpl(cdb.index, fieldName, classdef.TypeInt16, 0, 0, cdb.version)
 	cdb.index++
 	return nil
 }
@@ -65,7 +65,7 @@ func (cdb *ClassDefinitionBuilder) AddInt32Field(fieldName string) error {
 	if err != nil {
 		return err
 	}
-	cdb.fieldDefinitions[fieldName] = NewFieldDefinitionImpl(cdb.index, fieldName, TypeInt32, 0, 0, cdb.version)
+	cdb.fieldDefinitions[fieldName] = classdef.NewFieldDefinitionImpl(cdb.index, fieldName, classdef.TypeInt32, 0, 0, cdb.version)
 	cdb.index++
 	return nil
 }
@@ -75,7 +75,7 @@ func (cdb *ClassDefinitionBuilder) AddInt64Field(fieldName string) error {
 	if err != nil {
 		return err
 	}
-	cdb.fieldDefinitions[fieldName] = NewFieldDefinitionImpl(cdb.index, fieldName, TypeInt64, 0, 0, cdb.version)
+	cdb.fieldDefinitions[fieldName] = classdef.NewFieldDefinitionImpl(cdb.index, fieldName, classdef.TypeInt64, 0, 0, cdb.version)
 	cdb.index++
 	return nil
 }
@@ -85,7 +85,7 @@ func (cdb *ClassDefinitionBuilder) AddFloat32Field(fieldName string) error {
 	if err != nil {
 		return err
 	}
-	cdb.fieldDefinitions[fieldName] = NewFieldDefinitionImpl(cdb.index, fieldName, TypeFloat32, 0, 0, cdb.version)
+	cdb.fieldDefinitions[fieldName] = classdef.NewFieldDefinitionImpl(cdb.index, fieldName, classdef.TypeFloat32, 0, 0, cdb.version)
 	cdb.index++
 	return nil
 }
@@ -95,7 +95,7 @@ func (cdb *ClassDefinitionBuilder) AddFloat64Field(fieldName string) error {
 	if err != nil {
 		return err
 	}
-	cdb.fieldDefinitions[fieldName] = NewFieldDefinitionImpl(cdb.index, fieldName, TypeFloat64, 0, 0, cdb.version)
+	cdb.fieldDefinitions[fieldName] = classdef.NewFieldDefinitionImpl(cdb.index, fieldName, classdef.TypeFloat64, 0, 0, cdb.version)
 	cdb.index++
 	return nil
 }
@@ -105,12 +105,12 @@ func (cdb *ClassDefinitionBuilder) AddUTFField(fieldName string) error {
 	if err != nil {
 		return err
 	}
-	cdb.fieldDefinitions[fieldName] = NewFieldDefinitionImpl(cdb.index, fieldName, TypeUTF, 0, 0, cdb.version)
+	cdb.fieldDefinitions[fieldName] = classdef.NewFieldDefinitionImpl(cdb.index, fieldName, classdef.TypeUTF, 0, 0, cdb.version)
 	cdb.index++
 	return nil
 }
 
-func (cdb *ClassDefinitionBuilder) AddPortableField(fieldName string, def ClassDefinition) error {
+func (cdb *ClassDefinitionBuilder) AddPortableField(fieldName string, def serialization.ClassDefinition) error {
 	err := cdb.check()
 	if err != nil {
 		return err
@@ -119,7 +119,7 @@ func (cdb *ClassDefinitionBuilder) AddPortableField(fieldName string, def ClassD
 		return core.NewHazelcastIllegalArgumentError("Portable class id cannot be zero", nil)
 	}
 
-	cdb.fieldDefinitions[fieldName] = NewFieldDefinitionImpl(cdb.index, fieldName, TypePortable, def.FactoryId(), def.ClassId(), cdb.version)
+	cdb.fieldDefinitions[fieldName] = classdef.NewFieldDefinitionImpl(cdb.index, fieldName, classdef.TypePortable, def.FactoryId(), def.ClassId(), cdb.version)
 	cdb.index++
 	return nil
 }
@@ -129,7 +129,7 @@ func (cdb *ClassDefinitionBuilder) AddByteArrayField(fieldName string) error {
 	if err != nil {
 		return err
 	}
-	cdb.fieldDefinitions[fieldName] = NewFieldDefinitionImpl(cdb.index, fieldName, TypeByteArray, 0, 0, cdb.version)
+	cdb.fieldDefinitions[fieldName] = classdef.NewFieldDefinitionImpl(cdb.index, fieldName, classdef.TypeByteArray, 0, 0, cdb.version)
 	cdb.index++
 	return nil
 }
@@ -139,7 +139,7 @@ func (cdb *ClassDefinitionBuilder) AddBoolArrayField(fieldName string) error {
 	if err != nil {
 		return err
 	}
-	cdb.fieldDefinitions[fieldName] = NewFieldDefinitionImpl(cdb.index, fieldName, TypeBoolArray, 0, 0, cdb.version)
+	cdb.fieldDefinitions[fieldName] = classdef.NewFieldDefinitionImpl(cdb.index, fieldName, classdef.TypeBoolArray, 0, 0, cdb.version)
 	cdb.index++
 	return nil
 }
@@ -149,7 +149,7 @@ func (cdb *ClassDefinitionBuilder) AddUInt16ArrayField(fieldName string) error {
 	if err != nil {
 		return err
 	}
-	cdb.fieldDefinitions[fieldName] = NewFieldDefinitionImpl(cdb.index, fieldName, TypeUint16Array, 0, 0, cdb.version)
+	cdb.fieldDefinitions[fieldName] = classdef.NewFieldDefinitionImpl(cdb.index, fieldName, classdef.TypeUint16Array, 0, 0, cdb.version)
 	cdb.index++
 	return nil
 }
@@ -159,7 +159,7 @@ func (cdb *ClassDefinitionBuilder) AddInt16ArrayField(fieldName string) error {
 	if err != nil {
 		return err
 	}
-	cdb.fieldDefinitions[fieldName] = NewFieldDefinitionImpl(cdb.index, fieldName, TypeInt16Array, 0, 0, cdb.version)
+	cdb.fieldDefinitions[fieldName] = classdef.NewFieldDefinitionImpl(cdb.index, fieldName, classdef.TypeInt16Array, 0, 0, cdb.version)
 	cdb.index++
 	return nil
 }
@@ -169,7 +169,7 @@ func (cdb *ClassDefinitionBuilder) AddInt32ArrayField(fieldName string) error {
 	if err != nil {
 		return err
 	}
-	cdb.fieldDefinitions[fieldName] = NewFieldDefinitionImpl(cdb.index, fieldName, TypeInt32Array, 0, 0, cdb.version)
+	cdb.fieldDefinitions[fieldName] = classdef.NewFieldDefinitionImpl(cdb.index, fieldName, classdef.TypeInt32Array, 0, 0, cdb.version)
 	cdb.index++
 	return nil
 }
@@ -179,7 +179,7 @@ func (cdb *ClassDefinitionBuilder) AddInt64ArrayField(fieldName string) error {
 	if err != nil {
 		return err
 	}
-	cdb.fieldDefinitions[fieldName] = NewFieldDefinitionImpl(cdb.index, fieldName, TypeInt64Array, 0, 0, cdb.version)
+	cdb.fieldDefinitions[fieldName] = classdef.NewFieldDefinitionImpl(cdb.index, fieldName, classdef.TypeInt64Array, 0, 0, cdb.version)
 	cdb.index++
 	return nil
 }
@@ -189,7 +189,7 @@ func (cdb *ClassDefinitionBuilder) AddFloat32ArrayField(fieldName string) error 
 	if err != nil {
 		return err
 	}
-	cdb.fieldDefinitions[fieldName] = NewFieldDefinitionImpl(cdb.index, fieldName, TypeFloat32Array, 0, 0, cdb.version)
+	cdb.fieldDefinitions[fieldName] = classdef.NewFieldDefinitionImpl(cdb.index, fieldName, classdef.TypeFloat32Array, 0, 0, cdb.version)
 	cdb.index++
 	return nil
 }
@@ -199,7 +199,7 @@ func (cdb *ClassDefinitionBuilder) AddFloat64ArrayField(fieldName string) error 
 	if err != nil {
 		return err
 	}
-	cdb.fieldDefinitions[fieldName] = NewFieldDefinitionImpl(cdb.index, fieldName, TypeFloat64Array, 0, 0, cdb.version)
+	cdb.fieldDefinitions[fieldName] = classdef.NewFieldDefinitionImpl(cdb.index, fieldName, classdef.TypeFloat64Array, 0, 0, cdb.version)
 	cdb.index++
 	return nil
 }
@@ -209,12 +209,12 @@ func (cdb *ClassDefinitionBuilder) AddUTFArrayField(fieldName string) error {
 	if err != nil {
 		return err
 	}
-	cdb.fieldDefinitions[fieldName] = NewFieldDefinitionImpl(cdb.index, fieldName, TypeUTFArray, 0, 0, cdb.version)
+	cdb.fieldDefinitions[fieldName] = classdef.NewFieldDefinitionImpl(cdb.index, fieldName, classdef.TypeUTFArray, 0, 0, cdb.version)
 	cdb.index++
 	return nil
 }
 
-func (cdb *ClassDefinitionBuilder) AddPortableArrayField(fieldName string, def ClassDefinition) error {
+func (cdb *ClassDefinitionBuilder) AddPortableArrayField(fieldName string, def serialization.ClassDefinition) error {
 	err := cdb.check()
 	if err != nil {
 		return err
@@ -223,12 +223,12 @@ func (cdb *ClassDefinitionBuilder) AddPortableArrayField(fieldName string, def C
 		return core.NewHazelcastIllegalArgumentError("Portable class id cannot be zero", nil)
 	}
 
-	cdb.fieldDefinitions[fieldName] = NewFieldDefinitionImpl(cdb.index, fieldName, TypePortableArray, def.FactoryId(), def.ClassId(), cdb.version)
+	cdb.fieldDefinitions[fieldName] = classdef.NewFieldDefinitionImpl(cdb.index, fieldName, classdef.TypePortableArray, def.FactoryId(), def.ClassId(), cdb.version)
 	cdb.index++
 	return nil
 }
 
-func (cdb *ClassDefinitionBuilder) AddField(fieldDefinition FieldDefinition) error {
+func (cdb *ClassDefinitionBuilder) AddField(fieldDefinition serialization.FieldDefinition) error {
 	err := cdb.check()
 	if err != nil {
 		return err
@@ -241,9 +241,9 @@ func (cdb *ClassDefinitionBuilder) AddField(fieldDefinition FieldDefinition) err
 	return nil
 }
 
-func (cdb *ClassDefinitionBuilder) Build() ClassDefinition {
+func (cdb *ClassDefinitionBuilder) Build() serialization.ClassDefinition {
 	cdb.done = true
-	cd := NewClassDefinitionImpl(cdb.factoryId, cdb.classId, cdb.version)
+	cd := classdef.NewClassDefinitionImpl(cdb.factoryId, cdb.classId, cdb.version)
 	for _, fd := range cdb.fieldDefinitions {
 		cd.AddFieldDefinition(fd)
 	}

--- a/tests/cluster_test.go
+++ b/tests/cluster_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hazelcast/hazelcast-go-client/core"
 	"github.com/hazelcast/hazelcast-go-client/internal"
 	"github.com/hazelcast/hazelcast-go-client/internal/protocol"
-	. "github.com/hazelcast/hazelcast-go-client/rc"
+	"github.com/hazelcast/hazelcast-go-client/rc"
 	"log"
 	"sync"
 	"testing"
@@ -37,11 +37,11 @@ func (membershipListener *membershipListener) MemberRemoved(member core.IMember)
 	membershipListener.wg.Done()
 }
 
-var remoteController *RemoteControllerClient
-var cluster *Cluster
+var remoteController *rc.RemoteControllerClient
+var cluster *rc.Cluster
 
 func TestMain(m *testing.M) {
-	rc, err := NewRemoteControllerClient("localhost:9701")
+	rc, err := rc.NewRemoteControllerClient("localhost:9701")
 	remoteController = rc
 	if remoteController == nil || err != nil {
 		log.Fatal("create remote controller failed:", err)

--- a/tests/compatibility/adata_serializable_factory.go
+++ b/tests/compatibility/adata_serializable_factory.go
@@ -14,11 +14,11 @@
 
 package compatibility
 
-import . "github.com/hazelcast/hazelcast-go-client/serialization"
+import "github.com/hazelcast/hazelcast-go-client/serialization"
 
 type aDataSerializableFactory struct{}
 
-func (*aDataSerializableFactory) Create(classId int32) IdentifiedDataSerializable {
+func (*aDataSerializableFactory) Create(classId int32) serialization.IdentifiedDataSerializable {
 	if classId == dataSerializableClassId {
 		return &anIdentifiedDataSerializable{}
 	}

--- a/tests/compatibility/anidentified_data_serializable.go
+++ b/tests/compatibility/anidentified_data_serializable.go
@@ -14,7 +14,7 @@
 
 package compatibility
 
-import . "github.com/hazelcast/hazelcast-go-client/serialization"
+import "github.com/hazelcast/hazelcast-go-client/serialization"
 
 type anIdentifiedDataSerializable struct {
 	bool bool
@@ -47,8 +47,8 @@ type anIdentifiedDataSerializable struct {
 	longsNull    []int64
 	stringsNull  []string
 
-	portableObject                   Portable
-	identifiedDataSerializableObject IdentifiedDataSerializable
+	portableObject                   serialization.Portable
+	identifiedDataSerializableObject serialization.IdentifiedDataSerializable
 }
 
 func (*anIdentifiedDataSerializable) ClassId() int32 {
@@ -59,7 +59,7 @@ func (*anIdentifiedDataSerializable) FactoryId() int32 {
 	return identifiedDataSerializableFactoryID
 }
 
-func (i *anIdentifiedDataSerializable) WriteData(output DataOutput) error {
+func (i *anIdentifiedDataSerializable) WriteData(output serialization.DataOutput) error {
 	output.WriteBool(i.bool)
 	output.WriteByte(i.b)
 	output.WriteUInt16(i.c)
@@ -96,7 +96,7 @@ func (i *anIdentifiedDataSerializable) WriteData(output DataOutput) error {
 	return nil
 }
 
-func (i *anIdentifiedDataSerializable) ReadData(input DataInput) error {
+func (i *anIdentifiedDataSerializable) ReadData(input serialization.DataInput) error {
 	i.bool, _ = input.ReadBool()
 	i.b, _ = input.ReadByte()
 	i.c, _ = input.ReadUInt16()
@@ -130,14 +130,14 @@ func (i *anIdentifiedDataSerializable) ReadData(input DataInput) error {
 	temp, _ := input.ReadObject()
 
 	if temp != nil {
-		i.portableObject = temp.(Portable)
+		i.portableObject = temp.(serialization.Portable)
 	} else {
 		i.portableObject = nil
 	}
 
 	temp, _ = input.ReadObject()
 	if temp != nil {
-		i.identifiedDataSerializableObject = temp.(IdentifiedDataSerializable)
+		i.identifiedDataSerializableObject = temp.(serialization.IdentifiedDataSerializable)
 	} else {
 		i.identifiedDataSerializableObject = nil
 	}

--- a/tests/compatibility/aninner_portable.go
+++ b/tests/compatibility/aninner_portable.go
@@ -14,7 +14,7 @@
 
 package compatibility
 
-import . "github.com/hazelcast/hazelcast-go-client/serialization"
+import "github.com/hazelcast/hazelcast-go-client/serialization"
 
 type AnInnerPortable struct {
 	anInt  int32
@@ -29,13 +29,13 @@ func (*AnInnerPortable) ClassId() int32 {
 	return innerPortableClassId
 }
 
-func (ip *AnInnerPortable) WritePortable(writer PortableWriter) error {
+func (ip *AnInnerPortable) WritePortable(writer serialization.PortableWriter) error {
 	writer.WriteInt32("i", ip.anInt)
 	writer.WriteFloat32("f", ip.aFloat)
 	return nil
 }
 
-func (ip *AnInnerPortable) ReadPortable(reader PortableReader) error {
+func (ip *AnInnerPortable) ReadPortable(reader serialization.PortableReader) error {
 	ip.anInt, _ = reader.ReadInt32("i")
 	ip.aFloat, _ = reader.ReadFloat32("f")
 	return nil

--- a/tests/compatibility/aportable.go
+++ b/tests/compatibility/aportable.go
@@ -15,7 +15,7 @@
 package compatibility
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/serialization"
+	"github.com/hazelcast/hazelcast-go-client/serialization"
 )
 
 type aPortable struct {
@@ -28,7 +28,7 @@ type aPortable struct {
 	i    int32
 	l    int64
 	str  string
-	p    Portable
+	p    serialization.Portable
 
 	booleans  []bool
 	bytes     []byte
@@ -39,7 +39,7 @@ type aPortable struct {
 	ints      []int32
 	longs     []int64
 	strings   []string
-	portables []Portable
+	portables []serialization.Portable
 
 	booleansNull []bool
 	bytesNull    []byte
@@ -60,7 +60,7 @@ func (*aPortable) FactoryId() int32 {
 	return portableFactoryId
 }
 
-func (p *aPortable) WritePortable(writer PortableWriter) error {
+func (p *aPortable) WritePortable(writer serialization.PortableWriter) error {
 	writer.WriteBool("bool", p.bool)
 	writer.WriteByte("b", p.b)
 	writer.WriteUInt16("c", p.c)
@@ -99,7 +99,7 @@ func (p *aPortable) WritePortable(writer PortableWriter) error {
 	return nil
 }
 
-func (p *aPortable) ReadPortable(reader PortableReader) error {
+func (p *aPortable) ReadPortable(reader serialization.PortableReader) error {
 	p.bool, _ = reader.ReadBool("bool")
 	p.b, _ = reader.ReadByte("b")
 	p.c, _ = reader.ReadUInt16("c")

--- a/tests/compatibility/aportable_factory.go
+++ b/tests/compatibility/aportable_factory.go
@@ -14,11 +14,11 @@
 
 package compatibility
 
-import . "github.com/hazelcast/hazelcast-go-client/serialization"
+import "github.com/hazelcast/hazelcast-go-client/serialization"
 
 type aPortableFactory struct{}
 
-func (pf *aPortableFactory) Create(classId int32) Portable {
+func (pf *aPortableFactory) Create(classId int32) serialization.Portable {
 	if classId == portableClassId {
 		return &aPortable{}
 	} else if classId == innerPortableClassId {

--- a/tests/compatibility/binary_compatibility_test.go
+++ b/tests/compatibility/binary_compatibility_test.go
@@ -16,7 +16,7 @@ package compatibility
 
 import (
 	"github.com/hazelcast/hazelcast-go-client/config"
-	. "github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/common"
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 	"io/ioutil"
 	"reflect"
@@ -81,7 +81,7 @@ func TestBinaryCompatibility(t *testing.T) {
 	for i.Available() != 0 {
 		objectKey, _ := i.ReadUTF()
 		length, _ := i.ReadInt32()
-		if length != NilArrayLength {
+		if length != common.NilArrayLength {
 			payload := dat[i.Position() : i.Position()+length]
 			i.SetPosition(i.Position() + length)
 			if supporteds[index] == objectKey {

--- a/tests/compatibility/reference_objects.go
+++ b/tests/compatibility/reference_objects.go
@@ -14,7 +14,7 @@
 
 package compatibility
 
-import . "github.com/hazelcast/hazelcast-go-client/serialization"
+import "github.com/hazelcast/hazelcast-go-client/serialization"
 
 const (
 	//PORTABLE IDS
@@ -56,7 +56,7 @@ type allTestObjects struct {
 	strings []*string
 
 	anInnerPortable *AnInnerPortable
-	portables       []Portable
+	portables       []serialization.Portable
 	anIdentified    *anIdentifiedDataSerializable
 	aPortable       *aPortable
 }
@@ -89,7 +89,7 @@ func (allTestObjects) getAllTestObjects() []interface{} {
 	var strings []string = []string{w1, w2, w3}
 
 	anInnerPortable := &AnInnerPortable{anInt, aFloat}
-	var portables []Portable = []Portable{anInnerPortable, anInnerPortable, anInnerPortable}
+	var portables []serialization.Portable = []serialization.Portable{anInnerPortable, anInnerPortable, anInnerPortable}
 	anIdentified := &anIdentifiedDataSerializable{aBoolean, aByte, aChar, aDouble, aShort, aFloat, anInt, aLong, aString,
 		booleans, bytes, chars, doubles, shorts, floats, ints, longs, strings,
 		nil, nil, nil, nil, nil, nil, nil, nil, nil, anInnerPortable,

--- a/tests/proxy/flake_id_generator/flake_id_generator_test.go
+++ b/tests/proxy/flake_id_generator/flake_id_generator_test.go
@@ -16,9 +16,9 @@ package flake_id_generator
 
 import (
 	"github.com/hazelcast/hazelcast-go-client"
-	. "github.com/hazelcast/hazelcast-go-client/config"
+	"github.com/hazelcast/hazelcast-go-client/config"
 	"github.com/hazelcast/hazelcast-go-client/core"
-	. "github.com/hazelcast/hazelcast-go-client/rc"
+	"github.com/hazelcast/hazelcast-go-client/rc"
 	. "github.com/hazelcast/hazelcast-go-client/tests"
 	"log"
 	"strconv"
@@ -38,18 +38,18 @@ const (
 	idsInRoutine            = 100000
 )
 
-var remoteController RemoteController
+var remoteController rc.RemoteController
 
 func TestMain(m *testing.M) {
 	var err error
-	remoteController, err = NewRemoteControllerClient("localhost:9701")
+	remoteController, err = rc.NewRemoteControllerClient("localhost:9701")
 	if remoteController == nil || err != nil {
 		log.Fatal("create remote controller failed:", err)
 	}
 	m.Run()
 }
 
-func asssignOverFlowId(clusterId string, instanceNum int) (r *Response, err error) {
+func asssignOverFlowId(clusterId string, instanceNum int) (r *rc.Response, err error) {
 	script := "function assignOverflowedNodeId() {" +
 		"   instance_" + strconv.Itoa(instanceNum) + ".getCluster().getLocalMember().setMemberListJoinVersion(100000);" +
 		"   return instance_" + strconv.Itoa(instanceNum) + ".getCluster().getLocalMember().getMemberListJoinVersion();" +
@@ -64,7 +64,7 @@ func TestFlakeIdGeneratorProxy_ConfigTest(t *testing.T) {
 	remoteController.StartMember(cluster.ID)
 	var myBatchSize int32 = shortTermBatchSize
 	config := hazelcast.NewHazelcastConfig().
-		AddFlakeIdGeneratorConfig(NewFlakeIdGeneratorConfig("gen").SetPrefetchCount(myBatchSize).
+		AddFlakeIdGeneratorConfig(config.NewFlakeIdGeneratorConfig("gen").SetPrefetchCount(myBatchSize).
 			SetPrefetchValidityMillis(shortTermValidityMillis))
 	client, _ = hazelcast.NewHazelcastClientWithConfig(config)
 	defer client.Shutdown()

--- a/tests/proxy/list/list_test.go
+++ b/tests/proxy/list/list_test.go
@@ -17,7 +17,7 @@ package list
 import (
 	"github.com/hazelcast/hazelcast-go-client"
 	"github.com/hazelcast/hazelcast-go-client/core"
-	. "github.com/hazelcast/hazelcast-go-client/rc"
+	"github.com/hazelcast/hazelcast-go-client/rc"
 	. "github.com/hazelcast/hazelcast-go-client/tests"
 	"log"
 	"sync"
@@ -29,7 +29,7 @@ var client hazelcast.IHazelcastInstance
 var testElement = "testElement"
 
 func TestMain(m *testing.M) {
-	remoteController, err := NewRemoteControllerClient("localhost:9701")
+	remoteController, err := rc.NewRemoteControllerClient("localhost:9701")
 	if remoteController == nil || err != nil {
 		log.Fatal("create remote controller failed:", err)
 	}

--- a/tests/proxy/map/map_member_down/map_member_down_test.go
+++ b/tests/proxy/map/map_member_down/map_member_down_test.go
@@ -16,9 +16,9 @@ package map_member_down
 
 import (
 	"github.com/hazelcast/hazelcast-go-client"
-	. "github.com/hazelcast/hazelcast-go-client/core"
-	. "github.com/hazelcast/hazelcast-go-client/core/predicates"
-	. "github.com/hazelcast/hazelcast-go-client/rc"
+	"github.com/hazelcast/hazelcast-go-client/core"
+	"github.com/hazelcast/hazelcast-go-client/core/predicates"
+	"github.com/hazelcast/hazelcast-go-client/rc"
 	. "github.com/hazelcast/hazelcast-go-client/tests"
 	"log"
 	"testing"
@@ -26,10 +26,10 @@ import (
 )
 
 var client hazelcast.IHazelcastInstance
-var mp IMap
+var mp core.IMap
 
 func TestMain(m *testing.M) {
-	remoteController, err := NewRemoteControllerClient("localhost:9701")
+	remoteController, err := rc.NewRemoteControllerClient("localhost:9701")
 	if remoteController == nil || err != nil {
 		log.Fatal("create remote controller failed:", err)
 	}
@@ -64,7 +64,7 @@ func TestMapRemoveIfSameWhenMemberDown(t *testing.T) {
 }
 
 func TestMapRemoveAllWhenMemberDown(t *testing.T) {
-	err := mp.RemoveAll(GreaterThan("this", int32(40)))
+	err := mp.RemoveAll(predicates.GreaterThan("this", int32(40)))
 	AssertErrorNotNil(t, err, "removeAll should have returned an error when member is down")
 }
 
@@ -181,7 +181,7 @@ func TestMapKeySetWhenMemberDown(t *testing.T) {
 }
 
 func TestMapKeySetWithPredicateWhenMemberDown(t *testing.T) {
-	_, err := mp.KeySetWithPredicate(GreaterThan("this", 5))
+	_, err := mp.KeySetWithPredicate(predicates.GreaterThan("this", 5))
 	AssertErrorNotNil(t, err, "keySetWithPredicate should have returned an error when member is down")
 }
 
@@ -191,7 +191,7 @@ func TestMapValuesWhenMemberDown(t *testing.T) {
 }
 
 func TestMapValuesWithPredicateWhenMemberDown(t *testing.T) {
-	_, err := mp.ValuesWithPredicate(GreaterThan("this", 5))
+	_, err := mp.ValuesWithPredicate(predicates.GreaterThan("this", 5))
 	AssertErrorNotNil(t, err, "valuesWithPredicate should have returned an error when member is down")
 }
 
@@ -201,7 +201,7 @@ func TestMapEntrySetWhenMemberDown(t *testing.T) {
 }
 
 func TestMapEntrySetWithPredicateWhenMemberDown(t *testing.T) {
-	_, err := mp.EntrySetWithPredicate(GreaterThan("this", 5))
+	_, err := mp.EntrySetWithPredicate(predicates.GreaterThan("this", 5))
 	AssertErrorNotNil(t, err, "entrySetWithPredicate should have returned an error when member is down")
 }
 
@@ -258,12 +258,12 @@ func TestMapAddEntryListenerToKeyWhenMemberDown(t *testing.T) {
 }
 
 func TestMapAddEntryListenerToKeyWithPredicateWhenMemberDown(t *testing.T) {
-	_, err := mp.AddEntryListenerToKeyWithPredicate(nil, GreaterThan("this", 5), "key", false)
+	_, err := mp.AddEntryListenerToKeyWithPredicate(nil, predicates.GreaterThan("this", 5), "key", false)
 	AssertErrorNotNil(t, err, "entryListenerToKeyWithPredicate should have returned an error when member is down")
 }
 
 func TestMapAddEntryListenerWithPredicateWhenMemberDown(t *testing.T) {
-	_, err := mp.AddEntryListenerWithPredicate(nil, GreaterThan("this", 5), false)
+	_, err := mp.AddEntryListenerWithPredicate(nil, predicates.GreaterThan("this", 5), false)
 	AssertErrorNotNil(t, err, "entryListenerWithPredicate should have returned an error when member is down")
 }
 
@@ -273,7 +273,7 @@ func TestMapExecuteOnKeyWhenMemberDown(t *testing.T) {
 }
 
 func TestMapExecuteOnEntriesWithPredicateWhenMemberDown(t *testing.T) {
-	_, err := mp.ExecuteOnEntriesWithPredicate(nil, GreaterThan("this", 5))
+	_, err := mp.ExecuteOnEntriesWithPredicate(nil, predicates.GreaterThan("this", 5))
 	AssertErrorNotNil(t, err, "executeOnEntriesWithPredicate should have returned an error when member is down")
 }
 

--- a/tests/proxy/map/map_test.go
+++ b/tests/proxy/map/map_test.go
@@ -16,11 +16,11 @@ package _map
 
 import (
 	"github.com/hazelcast/hazelcast-go-client"
-	. "github.com/hazelcast/hazelcast-go-client/core"
+	"github.com/hazelcast/hazelcast-go-client/core"
 	"github.com/hazelcast/hazelcast-go-client/core/predicates"
 	"github.com/hazelcast/hazelcast-go-client/internal/common"
-	. "github.com/hazelcast/hazelcast-go-client/rc"
-	. "github.com/hazelcast/hazelcast-go-client/serialization"
+	"github.com/hazelcast/hazelcast-go-client/rc"
+	"github.com/hazelcast/hazelcast-go-client/serialization"
 	. "github.com/hazelcast/hazelcast-go-client/tests"
 	"log"
 	"reflect"
@@ -31,12 +31,12 @@ import (
 	"time"
 )
 
-var mp IMap
-var mp2 IMap
+var mp core.IMap
+var mp2 core.IMap
 var client hazelcast.IHazelcastInstance
 
 func TestMain(m *testing.M) {
-	remoteController, err := NewRemoteControllerClient("localhost:9701")
+	remoteController, err := rc.NewRemoteControllerClient("localhost:9701")
 	if remoteController == nil || err != nil {
 		log.Fatal("create remote controller failed:", err)
 	}
@@ -801,33 +801,33 @@ func TestMapProxy_GetEntryViewWithNilKey(t *testing.T) {
 
 type entryListener struct {
 	wg       *sync.WaitGroup
-	event    IEntryEvent
-	mapEvent IMapEvent
+	event    core.IEntryEvent
+	mapEvent core.IMapEvent
 }
 
-func (entryListener *entryListener) EntryAdded(event IEntryEvent) {
+func (entryListener *entryListener) EntryAdded(event core.IEntryEvent) {
 	entryListener.event = event
 	entryListener.wg.Done()
 }
 
-func (entryListener *entryListener) EntryUpdated(event IEntryEvent) {
+func (entryListener *entryListener) EntryUpdated(event core.IEntryEvent) {
 	entryListener.wg.Done()
 }
 
-func (entryListener *entryListener) EntryRemoved(event IEntryEvent) {
+func (entryListener *entryListener) EntryRemoved(event core.IEntryEvent) {
 	entryListener.wg.Done()
 }
 
-func (entryListener *entryListener) EntryEvicted(event IEntryEvent) {
+func (entryListener *entryListener) EntryEvicted(event core.IEntryEvent) {
 	entryListener.wg.Done()
 }
 
-func (entryListener *entryListener) EntryEvictAll(event IMapEvent) {
+func (entryListener *entryListener) EntryEvictAll(event core.IMapEvent) {
 	entryListener.mapEvent = event
 	entryListener.wg.Done()
 }
 
-func (entryListener *entryListener) EntryClearAll(event IMapEvent) {
+func (entryListener *entryListener) EntryClearAll(event core.IMapEvent) {
 	entryListener.wg.Done()
 }
 
@@ -1120,7 +1120,7 @@ type identifiedFactory struct {
 	factoryId            int32
 }
 
-func (identifiedFactory *identifiedFactory) Create(id int32) IdentifiedDataSerializable {
+func (identifiedFactory *identifiedFactory) Create(id int32) serialization.IdentifiedDataSerializable {
 	if id == identifiedFactory.simpleEntryProcessor.classId {
 		return &simpleEntryProcessor{classId: 1}
 	} else {
@@ -1128,13 +1128,13 @@ func (identifiedFactory *identifiedFactory) Create(id int32) IdentifiedDataSeria
 	}
 }
 
-func (simpleEntryProcessor *simpleEntryProcessor) ReadData(input DataInput) error {
+func (simpleEntryProcessor *simpleEntryProcessor) ReadData(input serialization.DataInput) error {
 	var err error
 	simpleEntryProcessor.value, err = input.ReadUTF()
 	return err
 }
 
-func (simpleEntryProcessor *simpleEntryProcessor) WriteData(output DataOutput) error {
+func (simpleEntryProcessor *simpleEntryProcessor) WriteData(output serialization.DataOutput) error {
 	output.WriteUTF(simpleEntryProcessor.value)
 	return nil
 }

--- a/tests/proxy/map/predicates_test.go
+++ b/tests/proxy/map/predicates_test.go
@@ -15,16 +15,16 @@
 package _map
 
 import (
-	. "github.com/hazelcast/hazelcast-go-client/config"
+	"github.com/hazelcast/hazelcast-go-client/config"
 	"github.com/hazelcast/hazelcast-go-client/core/predicates"
-	. "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 	"log"
 	"reflect"
 	"strconv"
 	"testing"
 )
 
-var serializationService *SerializationService
+var serializationService *serialization.SerializationService
 
 func predicateTestInit() {
 	defineSerializationService()
@@ -32,8 +32,8 @@ func predicateTestInit() {
 }
 
 func defineSerializationService() {
-	config := NewSerializationConfig()
-	serializationService = NewSerializationService(config)
+	config := config.NewSerializationConfig()
+	serializationService = serialization.NewSerializationService(config)
 }
 
 func fillMapForPredicates() {

--- a/tests/proxy/multi_map/multi_map_test.go
+++ b/tests/proxy/multi_map/multi_map_test.go
@@ -16,8 +16,8 @@ package multi_map
 
 import (
 	"github.com/hazelcast/hazelcast-go-client"
-	. "github.com/hazelcast/hazelcast-go-client/core"
-	. "github.com/hazelcast/hazelcast-go-client/rc"
+	"github.com/hazelcast/hazelcast-go-client/core"
+	"github.com/hazelcast/hazelcast-go-client/rc"
 	. "github.com/hazelcast/hazelcast-go-client/tests"
 	"log"
 	"strconv"
@@ -26,14 +26,14 @@ import (
 	"time"
 )
 
-var multiMap MultiMap
+var multiMap core.MultiMap
 var client hazelcast.IHazelcastInstance
 var testKey = "testKey"
 var testValue = "testValue"
 var testValue2 = "testValue2"
 
 func TestMain(m *testing.M) {
-	remoteController, err := NewRemoteControllerClient("localhost:9701")
+	remoteController, err := rc.NewRemoteControllerClient("localhost:9701")
 	if remoteController == nil || err != nil {
 		log.Fatal("create remote controller failed:", err)
 	}
@@ -402,32 +402,32 @@ func TestMultiMapProxy_ForceUnlockWithNil(t *testing.T) {
 
 type EntryListener struct {
 	wg       *sync.WaitGroup
-	event    IEntryEvent
-	mapEvent IMapEvent
+	event    core.IEntryEvent
+	mapEvent core.IMapEvent
 }
 
-func (entryListener *EntryListener) EntryAdded(event IEntryEvent) {
+func (entryListener *EntryListener) EntryAdded(event core.IEntryEvent) {
 	entryListener.event = event
 	entryListener.wg.Done()
 }
 
-func (entryListener *EntryListener) EntryUpdated(event IEntryEvent) {
+func (entryListener *EntryListener) EntryUpdated(event core.IEntryEvent) {
 	entryListener.wg.Done()
 }
 
-func (entryListener *EntryListener) EntryRemoved(event IEntryEvent) {
+func (entryListener *EntryListener) EntryRemoved(event core.IEntryEvent) {
 	entryListener.wg.Done()
 }
 
-func (entryListener *EntryListener) EntryEvicted(event IEntryEvent) {
+func (entryListener *EntryListener) EntryEvicted(event core.IEntryEvent) {
 	entryListener.wg.Done()
 }
 
-func (entryListener *EntryListener) EntryEvictAll(event IMapEvent) {
+func (entryListener *EntryListener) EntryEvictAll(event core.IMapEvent) {
 	entryListener.mapEvent = event
 	entryListener.wg.Done()
 }
 
-func (entryListener *EntryListener) EntryClearAll(event IMapEvent) {
+func (entryListener *EntryListener) EntryClearAll(event core.IMapEvent) {
 	entryListener.wg.Done()
 }

--- a/tests/proxy/pn_counter/pn_counter_test.go
+++ b/tests/proxy/pn_counter/pn_counter_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hazelcast/hazelcast-go-client/core"
 	"github.com/hazelcast/hazelcast-go-client/internal"
 	"github.com/hazelcast/hazelcast-go-client/internal/common"
-	. "github.com/hazelcast/hazelcast-go-client/rc"
+	"github.com/hazelcast/hazelcast-go-client/rc"
 	. "github.com/hazelcast/hazelcast-go-client/tests"
 	"log"
 	"sync"
@@ -31,12 +31,12 @@ var client hazelcast.IHazelcastInstance
 
 const counterName = "myPNCounter"
 
-var remoteController *RemoteControllerClient
-var cluster *Cluster
+var remoteController *rc.RemoteControllerClient
+var cluster *rc.Cluster
 var err error
 
 func TestMain(m *testing.M) {
-	remoteController, err = NewRemoteControllerClient("localhost:9701")
+	remoteController, err = rc.NewRemoteControllerClient("localhost:9701")
 	if remoteController == nil || err != nil {
 		log.Fatal("create remote controller failed:", err)
 	}

--- a/tests/proxy/queue/queue_test.go
+++ b/tests/proxy/queue/queue_test.go
@@ -17,7 +17,7 @@ package queue
 import (
 	"github.com/hazelcast/hazelcast-go-client"
 	"github.com/hazelcast/hazelcast-go-client/core"
-	. "github.com/hazelcast/hazelcast-go-client/rc"
+	"github.com/hazelcast/hazelcast-go-client/rc"
 	. "github.com/hazelcast/hazelcast-go-client/tests"
 	"log"
 	"sync"
@@ -31,7 +31,7 @@ var testElement = "testElement"
 var queueName = "ClientQueueTest"
 
 func TestMain(m *testing.M) {
-	remoteController, err := NewRemoteControllerClient("localhost:9701")
+	remoteController, err := rc.NewRemoteControllerClient("localhost:9701")
 	if remoteController == nil || err != nil {
 		log.Fatal("create remote controller failed:", err)
 	}

--- a/tests/proxy/replicated_map/replicated_map_test.go
+++ b/tests/proxy/replicated_map/replicated_map_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hazelcast/hazelcast-go-client"
 	"github.com/hazelcast/hazelcast-go-client/core"
 	"github.com/hazelcast/hazelcast-go-client/core/predicates"
-	. "github.com/hazelcast/hazelcast-go-client/rc"
+	"github.com/hazelcast/hazelcast-go-client/rc"
 	. "github.com/hazelcast/hazelcast-go-client/tests"
 	"log"
 	"reflect"
@@ -33,7 +33,7 @@ var rmp core.ReplicatedMap
 var client hazelcast.IHazelcastInstance
 
 func TestMain(m *testing.M) {
-	remoteController, err := NewRemoteControllerClient("localhost:9701")
+	remoteController, err := rc.NewRemoteControllerClient("localhost:9701")
 	if remoteController == nil || err != nil {
 		log.Fatal("create remote controller failed:", err)
 	}

--- a/tests/proxy/ringbuffer/ringbuffer_test.go
+++ b/tests/proxy/ringbuffer/ringbuffer_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hazelcast/hazelcast-go-client"
 	"github.com/hazelcast/hazelcast-go-client/core"
 	"github.com/hazelcast/hazelcast-go-client/internal/common"
-	. "github.com/hazelcast/hazelcast-go-client/rc"
+	"github.com/hazelcast/hazelcast-go-client/rc"
 	. "github.com/hazelcast/hazelcast-go-client/tests"
 	"log"
 	"testing"
@@ -31,7 +31,7 @@ const capacity int64 = 10
 const ringbufferName = "ClientRingbufferTestWithTTL"
 
 func TestMain(m *testing.M) {
-	remoteController, err := NewRemoteControllerClient("localhost:9701")
+	remoteController, err := rc.NewRemoteControllerClient("localhost:9701")
 	if remoteController == nil || err != nil {
 		log.Fatal("create remote controller failed:", err)
 	}

--- a/tests/proxy/set/set_test.go
+++ b/tests/proxy/set/set_test.go
@@ -17,7 +17,7 @@ package set
 import (
 	"github.com/hazelcast/hazelcast-go-client"
 	"github.com/hazelcast/hazelcast-go-client/core"
-	. "github.com/hazelcast/hazelcast-go-client/rc"
+	"github.com/hazelcast/hazelcast-go-client/rc"
 	. "github.com/hazelcast/hazelcast-go-client/tests"
 	"log"
 	"sync"
@@ -29,7 +29,7 @@ var client hazelcast.IHazelcastInstance
 var testElement = "testElement"
 
 func TestMain(m *testing.M) {
-	remoteController, err := NewRemoteControllerClient("localhost:9701")
+	remoteController, err := rc.NewRemoteControllerClient("localhost:9701")
 	if remoteController == nil || err != nil {
 		log.Fatal("create remote controller failed:", err)
 	}

--- a/tests/proxy/topic/topic_test.go
+++ b/tests/proxy/topic/topic_test.go
@@ -17,7 +17,7 @@ package topic
 import (
 	"github.com/hazelcast/hazelcast-go-client"
 	"github.com/hazelcast/hazelcast-go-client/core"
-	. "github.com/hazelcast/hazelcast-go-client/rc"
+	"github.com/hazelcast/hazelcast-go-client/rc"
 	. "github.com/hazelcast/hazelcast-go-client/tests"
 	"log"
 	"sync"
@@ -28,7 +28,7 @@ var topic core.ITopic
 var client hazelcast.IHazelcastInstance
 
 func TestMain(m *testing.M) {
-	remoteController, err := NewRemoteControllerClient("localhost:9701")
+	remoteController, err := rc.NewRemoteControllerClient("localhost:9701")
 	if remoteController == nil || err != nil {
 		log.Fatal("create remote controller failed:", err)
 	}


### PR DESCRIPTION
This PR removes dot imports.

This is from https://github.com/golang/go/wiki/CodeReviewComments#import-dot:

In this case, the test file cannot be in package foo because it uses bar/testutil, which imports foo. So we use the 'import .form to let the file pretend to be part of package foo even though it is not. Except for this one case, ```do not use import . in your programs. It makes the programs much harder to read because it is unclear whether a name like Quux is a top-level identifier in the current package or in an imported package.```