### PR TITLE
remove I prefix from interface names

### DIFF
--- a/core/api.go
+++ b/core/api.go
@@ -17,8 +17,8 @@ package core
 
 import "time"
 
-// IAddress represents an address of a member in the cluster.
-type IAddress interface {
+// Address represents an address of a member in the cluster.
+type Address interface {
 	// Host returns host of the member.
 	Host() string
 
@@ -26,10 +26,10 @@ type IAddress interface {
 	Port() int
 }
 
-// IMember represents a member in the cluster with its address, uuid, lite member status and attributes.
-type IMember interface {
+// Member represents a member in the cluster with its address, uuid, lite member status and attributes.
+type Member interface {
 	// Address returns the address of this member.
-	Address() IAddress
+	Address() Address
 
 	// UUID returns the uuid of this member.
 	UUID() string
@@ -41,8 +41,8 @@ type IMember interface {
 	Attributes() map[string]string
 }
 
-// IPair represents IMap entry pair.
-type IPair interface {
+// Pair represents Map entry pair.
+type Pair interface {
 	// Key returns key of entry.
 	Key() interface{}
 
@@ -50,8 +50,8 @@ type IPair interface {
 	Value() interface{}
 }
 
-// IDistributedObjectInfo contains name and service name of distributed objects.
-type IDistributedObjectInfo interface {
+// DistributedObjectInfo contains name and service name of distributed objects.
+type DistributedObjectInfo interface {
 	// Name returns the name of distributed object.
 	Name() string
 
@@ -59,8 +59,8 @@ type IDistributedObjectInfo interface {
 	ServiceName() string
 }
 
-// IError contains error information that occurred in the server.
-type IError interface {
+// Error contains error information that occurred in the server.
+type Error interface {
 	// ErrorCode returns the error code.
 	ErrorCode() int32
 
@@ -71,7 +71,7 @@ type IError interface {
 	Message() string
 
 	// StackTrace returns a slice of StackTraceElement.
-	StackTrace() []IStackTraceElement
+	StackTrace() []StackTraceElement
 
 	// CauseErrorCode returns the cause error code.
 	CauseErrorCode() int32
@@ -80,7 +80,7 @@ type IError interface {
 	CauseClassName() string
 }
 
-type IStackTraceElement interface {
+type StackTraceElement interface {
 	// DeclaringClass returns the fully qualified name of the class containing
 	// the execution point represented by the stack trace element.
 	DeclaringClass() string
@@ -102,8 +102,8 @@ type IStackTraceElement interface {
 	LineNumber() int32
 }
 
-// IEntryView represents a readonly view of a map entry.
-type IEntryView interface {
+// EntryView represents a readonly view of a map entry.
+type EntryView interface {
 	// Key returns the key of the entry.
 	Key() interface{}
 
@@ -141,8 +141,8 @@ type IEntryView interface {
 	TTL() time.Duration
 }
 
-// IEntryEvent is map entry event.
-type IEntryEvent interface {
+// EntryEvent is map entry event.
+type EntryEvent interface {
 	// KeyData returns the key of the entry event.
 	Key() interface{}
 
@@ -162,9 +162,9 @@ type IEntryEvent interface {
 	UUID() *string
 }
 
-// IItemEvent is IList, ISet and IQueue events common contract.
-type IItemEvent interface {
-	// Name returns the name of IList, ISet or IQueue
+// ItemEvent is List, Set and Queue events common contract.
+type ItemEvent interface {
+	// Name returns the name of List, Set or Queue
 	Name() string
 
 	// Item returns the item of the event.
@@ -174,11 +174,11 @@ type IItemEvent interface {
 	EventType() int32
 
 	// Member is the member that sent the event.
-	Member() IMember
+	Member() Member
 }
 
-// IMapEvent is map events common contract.
-type IMapEvent interface {
+// MapEvent is map events common contract.
+type MapEvent interface {
 	// EventType returns the event type.
 	EventType() int32
 
@@ -190,89 +190,89 @@ type IMapEvent interface {
 	NumberOfAffectedEntries() int32
 }
 
-// IEntryAddedListener is invoked upon addition of an entry.
-type IEntryAddedListener interface {
+// EntryAddedListener is invoked upon addition of an entry.
+type EntryAddedListener interface {
 	// EntryAdded is invoked upon addition of an entry.
-	EntryAdded(IEntryEvent)
+	EntryAdded(EntryEvent)
 }
 
-// IEntryRemovedListener invoked upon removal of an entry.
-type IEntryRemovedListener interface {
+// EntryRemovedListener invoked upon removal of an entry.
+type EntryRemovedListener interface {
 	// EntryRemoved invoked upon removal of an entry.
-	EntryRemoved(IEntryEvent)
+	EntryRemoved(EntryEvent)
 }
 
-// IEntryUpdatedListener is invoked upon update of an entry.
-type IEntryUpdatedListener interface {
+// EntryUpdatedListener is invoked upon update of an entry.
+type EntryUpdatedListener interface {
 	// EntryUpdated is invoked upon update of an entry.
-	EntryUpdated(IEntryEvent)
+	EntryUpdated(EntryEvent)
 }
 
-// IEntryEvictedListener is invoked upon eviction of an entry.
-type IEntryEvictedListener interface {
+// EntryEvictedListener is invoked upon eviction of an entry.
+type EntryEvictedListener interface {
 	// EntryEvicted is invoked upon eviction of an entry.
-	EntryEvicted(IEntryEvent)
+	EntryEvicted(EntryEvent)
 }
 
-// IEntryEvictAllListener is invoked when all entries are evicted
-// by IMap.EvictAll() method.
-type IEntryEvictAllListener interface {
+// EntryEvictAllListener is invoked when all entries are evicted
+// by Map.EvictAll method.
+type EntryEvictAllListener interface {
 	// EntryEvictAll is invoked when all entries are evicted
-	// by IMap.EvictAll() method.
-	EntryEvictAll(IMapEvent)
+	// by Map.EvictAll method.
+	EntryEvictAll(MapEvent)
 }
 
-// IEntryClearAllListener is invoked when all entries are removed
-// by Imap.Clear() method.
-type IEntryClearAllListener interface {
+// EntryClearAllListener is invoked when all entries are removed
+// by Map.Clear method.
+type EntryClearAllListener interface {
 	// EntryClearAll is invoked when all entries are removed
-	// by Imap.Clear() method.
-	EntryClearAll(IMapEvent)
+	// by Map.Clear method.
+	EntryClearAll(MapEvent)
 }
 
-// IEntryMergedListener is invoked after WAN replicated entry is merged.
-type IEntryMergedListener interface {
+// EntryMergedListener is invoked after WAN replicated entry is merged.
+type EntryMergedListener interface {
 	// EntryMerged is invoked after WAN replicated entry is merged.
-	EntryMerged(IEntryEvent)
+	EntryMerged(EntryEvent)
 }
 
-// IEntryExpiredListener which is notified after removal of an entry due to the expiration-based-eviction.
-type IEntryExpiredListener interface {
+// EntryExpiredListener which is notified after removal of an entry due to the expiration-based-eviction.
+type EntryExpiredListener interface {
 	// EntryExpired is invoked upon expiration of an entry.
-	EntryExpired(IEntryEvent)
+	EntryExpired(EntryEvent)
 }
 
-// IMemberAddedListener is invoked when a new member is added to the cluster.
-type IMemberAddedListener interface {
+// MemberAddedListener is invoked when a new member is added to the cluster.
+type MemberAddedListener interface {
 	// MemberAdded is invoked when a new member is added to the cluster.
-	MemberAdded(member IMember)
+	MemberAdded(member Member)
 }
 
-// IMemberRemovedListener is invoked when an existing member leaves the cluster.
-type IMemberRemovedListener interface {
+// MemberRemovedListener is invoked when an existing member leaves the cluster.
+type MemberRemovedListener interface {
 	// MemberRemoved is invoked when an existing member leaves the cluster.
-	MemberRemoved(member IMember)
+	MemberRemoved(member Member)
 }
 
-// ILifecycleListener is a listener object for listening to lifecycle events of the Hazelcast instance.
-type ILifecycleListener interface {
+// LifecycleListener is a listener object for listening to lifecycle events of the Hazelcast instance.
+type LifecycleListener interface {
 	// LifecycleStateChanged is called when instance's state changes. No blocking calls should be made in this method.
 	LifecycleStateChanged(string)
 }
 
-// TopicMessageListener is a listener for ITopic.
+// TopicMessageListener is a listener for Topic.
 // Provided that a TopicMessageListener is not registered twice, a TopicMessageListener will never be called concurrently.
 // So there is no need to provide thread-safety on internal state in the TopicMessageListener. Also there is no need to enforce
-// safe publication, the ITopic is responsible for the memory consistency effects. In other words, there is no need to make
+// safe publication, the Topic is responsible for the memory consistency effects. In other words, there is no need to make
 // internal fields of the TopicMessageListener volatile or access them using synchronized blocks.
 type TopicMessageListener interface {
 	// OnMessage is invoked when a message is received for the added topic. Note that topic guarantees message ordering.
 	// Therefore there is only one thread invoking OnMessage.
-	OnMessage(message ITopicMessage)
+	OnMessage(message TopicMessage)
 }
 
-// ITopicMessage is a message for ITopic.
-type ITopicMessage interface {
+// TopicMessage is a message for Topic.
+type TopicMessage interface {
 	// MessageObject returns the published message.
 	MessageObject() interface{}
 
@@ -283,15 +283,15 @@ type ITopicMessage interface {
 	// The member can be nil if:
 	//    - The message was sent by a client and not a member.
 	//    - The member, that sent the message, left the cluster before the message was processed.
-	PublishingMember() IMember
+	PublishingMember() Member
 }
 
 // ItemAddedListener is invoked when an item is added.
 type ItemAddedListener interface {
-	ItemAdded(event IItemEvent)
+	ItemAdded(event ItemEvent)
 }
 
 // ItemRemovedListener is invoked when an item is removed.
 type ItemRemovedListener interface {
-	ItemRemoved(event IItemEvent)
+	ItemRemoved(event ItemEvent)
 }

--- a/core/cluster.go
+++ b/core/cluster.go
@@ -14,8 +14,8 @@
 
 package core
 
-// ICluster is a cluster service for Hazelcast clients.
-type ICluster interface {
+// Cluster is a cluster service for Hazelcast clients.
+type Cluster interface {
 	// AddListener registers the given listener.
 	// AddListener returns uuid which will be used to remove the listener.
 	AddListener(listener interface{}) *string
@@ -25,11 +25,11 @@ type ICluster interface {
 	RemoveListener(registrationID *string) bool
 
 	// GetMemberList returns a slice of members.
-	GetMemberList() []IMember
+	GetMemberList() []Member
 
 	// GetMember gets the member with the given address.
-	GetMember(address IAddress) IMember
+	GetMember(address Address) Member
 
 	// GetMemberByUUID gets the member with the given uuid.
-	GetMemberByUUID(uuid string) IMember
+	GetMemberByUUID(uuid string) Member
 }

--- a/core/distributed_object.go
+++ b/core/distributed_object.go
@@ -14,17 +14,17 @@
 
 package core
 
-// IDistributedObject is the base interface for all distributed objects.
-type IDistributedObject interface {
+// DistributedObject is the base interface for all distributed objects.
+type DistributedObject interface {
 	// Destroy destroys this object cluster-wide.
 	// Destroy clears and releases all resources for this object.
 	Destroy() (bool, error)
 
-	// Name returns the unique name for this IDistributedObject. Returned value will never be nil.
+	// Name returns the unique name for this DistributedObject. Returned value will never be nil.
 	Name() string
 
-	// PartitionKey returns the key of partition this IDistributedObject is assigned to. The returned value only has meaning
-	// for a non partitioned data structure like an IAtomicLong. For a partitioned data structure like an IMap
+	// PartitionKey returns the key of partition this DistributedObject is assigned to. The returned value only has meaning
+	// for a non partitioned data structure like an IAtomicLong. For a partitioned data structure like an Map
 	// the returned value will not be nil, but otherwise undefined.
 	PartitionKey() string
 

--- a/core/flake_id_generator.go
+++ b/core/flake_id_generator.go
@@ -38,8 +38,8 @@ package core
 // FlakeIDGenerator requires Hazelcast 3.10.
 type FlakeIDGenerator interface {
 
-	// IDistributedObject is the base interface for all distributed objects.
-	IDistributedObject
+	// DistributedObject is the base interface for all distributed objects.
+	DistributedObject
 
 	// NewID generates and returns a cluster-wide unique ID.
 	//

--- a/core/lifecycle.go
+++ b/core/lifecycle.go
@@ -14,8 +14,8 @@
 
 package core
 
-// ILifecycle is a lifecycle service for Hazelcast clients.
-type ILifecycle interface {
+// Lifecycle is a lifecycle service for Hazelcast clients.
+type Lifecycle interface {
 	// AddListener adds a listener object to listen for lifecycle events.
 	// AddListener returns the registrationID.
 	AddListener(listener interface{}) string

--- a/core/list.go
+++ b/core/list.go
@@ -14,17 +14,17 @@
 
 package core
 
-// IList is a concurrent, distributed, ordered collection. The user of this
+// List is a concurrent, distributed, ordered collection. The user of this
 // interface has precise control over where in the list each element is
 // inserted.  The user can access elements by their integer index (position in the list),
 // and search for elements in the list.
 //
 // The Hazelcast List is not a partitioned data-structure. So all the content of the List is stored in a single
 // machine (and in the backup). So the List will not scale by adding more members in the cluster.
-type IList interface {
+type List interface {
 
-	// IDistributedObject is the base interface for all distributed objects.
-	IDistributedObject
+	// DistributedObject is the base interface for all distributed objects.
+	DistributedObject
 
 	// Add appends the specified element to the end of this list.
 	// Add returns true if the list has changed as a result of this operation, false otherwise.

--- a/core/map.go
+++ b/core/map.go
@@ -18,14 +18,14 @@ import (
 	"time"
 )
 
-// IMap is Hazelcast Map client proxy to access the map on the cluster.
+// Map is Hazelcast Map client proxy to access the map on the cluster.
 // Concurrent, distributed, observable and queryable map.
 // This map is sync (blocking). Blocking calls return the value of the call and block
 // the execution until the return value is calculated.
 // This map does not allow nil to be used as a key or value.
-type IMap interface {
-	// IDistributedObject is the base interface for all distributed objects.
-	IDistributedObject
+type Map interface {
+	// DistributedObject is the base interface for all distributed objects.
+	DistributedObject
 
 	// Put associates the specified value with the specified key in this map. If the map previously contained a mapping for
 	// the key, the old value is replaced by the specified value.
@@ -245,14 +245,14 @@ type IMap interface {
 	// The slice is NOT backed by the map, so changes to the map are NOT reflected in the slice, and vice-versa.
 	ValuesWithPredicate(predicate interface{}) (values []interface{}, err error)
 
-	// EntrySet returns a slice of IPairs clone of the mappings contained in this map.
+	// EntrySet returns a slice of Pairs clone of the mappings contained in this map.
 	// The slice is NOT backed by the map, so changes to the map are NOT reflected in the slice, and vice-versa.
-	EntrySet() (resultPairs []IPair, err error)
+	EntrySet() (resultPairs []Pair, err error)
 
 	// EntrySetWithPredicate queries the map based on the specified predicate and returns the matching entries.
 	// Specified predicate runs on all members in parallel.
 	// The slice is NOT backed by the map, so changes to the map are NOT reflected in the slice, and vice-versa.
-	EntrySetWithPredicate(predicate interface{}) (resultPairs []IPair, err error)
+	EntrySetWithPredicate(predicate interface{}) (resultPairs []Pair, err error)
 
 	// TryLock tries to acquire the lock for the specified key.
 	// If the lock is not available then the current thread
@@ -295,10 +295,10 @@ type IMap interface {
 	// so changes to the original map are NOT reflected in the returned map, and vice-versa.
 	GetAll(keys []interface{}) (entryMap map[interface{}]interface{}, err error)
 
-	// GetEntryView returns the IEntryView for the specified key.
+	// GetEntryView returns the EntryView for the specified key.
 	// GetEntryView returns a clone of original mapping, modifying the returned value does not change
 	// the actual value in the map. One should put modified value back to make changes visible to all nodes.
-	GetEntryView(key interface{}) (entryView IEntryView, err error)
+	GetEntryView(key interface{}) (entryView EntryView, err error)
 
 	// PutTransient operates same as Put(), but
 	// the entry will expire and get evicted after the TTL. If the TTL is 0,
@@ -308,25 +308,25 @@ type IMap interface {
 
 	// AddEntryListener adds a continuous entry listener for this map.
 	// To receive an event, you should implement a corresponding interface for that event such as
-	// IEntryAddedListener, IEntryRemovedListener, IEntryUpdatedListener.
+	// EntryAddedListener, EntryRemovedListener, EntryUpdatedListener.
 	// AddEntryListener returns uuid which is used as a key to remove the listener.
 	AddEntryListener(listener interface{}, includeValue bool) (registrationID *string, err error)
 
 	// AddEntryListenerWithPredicate adds a continuous entry listener for this map filtered with the given predicate.
 	// To receive an event, you should implement a corresponding interface for that event such as
-	// IEntryAddedListener, IEntryRemovedListener, IEntryUpdatedListener etc.
+	// EntryAddedListener, EntryRemovedListener, EntryUpdatedListener etc.
 	// AddEntryListenerWithPredicate returns uuid which is used as a key to remove the listener.
 	AddEntryListenerWithPredicate(listener interface{}, predicate interface{}, includeValue bool) (registrationID *string, err error)
 
 	// AddEntryListenerToKey adds a continuous entry listener for this map filtered with the given key.
 	// To receive an event, you should implement a corresponding interface for that event such as
-	// IEntryAddedListener, IEntryRemovedListener, IEntryUpdatedListener.
+	// EntryAddedListener, EntryRemovedListener, EntryUpdatedListener.
 	// AddEntryListenerToKey returns uuid which is used as a key to remove the listener.
 	AddEntryListenerToKey(listener interface{}, key interface{}, includeValue bool) (registrationID *string, err error)
 
 	// AddEntryListenerToKeyWithPredicate adds a continuous entry listener for this map filtered with the given key and predicate.
 	// To receive an event, you should implement a corresponding interface for that event such as
-	// IEntryAddedListener, IEntryRemovedListener, IEntryUpdatedListener.
+	// EntryAddedListener, EntryRemovedListener, EntryUpdatedListener.
 	// AddEntryListenerToKeyWithPredicate returns uuid which is used as a key to remove the listener.
 	AddEntryListenerToKeyWithPredicate(listener interface{}, predicate interface{}, key interface{}, includeValue bool) (
 		registrationID *string, err error)
@@ -350,7 +350,7 @@ type IMap interface {
 	// on the server side.
 	// This struct must have a serializable EntryProcessor counter part registered on server side with the actual
 	// org.hazelcast.map.EntryProcessor implementation.
-	ExecuteOnKeys(keys []interface{}, entryProcessor interface{}) (keyToResultPairs []IPair, err error)
+	ExecuteOnKeys(keys []interface{}, entryProcessor interface{}) (keyToResultPairs []Pair, err error)
 
 	// ExecuteOnEntries applies the user defined EntryProcessor to all the entries in the map.
 	// Returns the results mapped by each key in the map.
@@ -358,7 +358,7 @@ type IMap interface {
 	// on the server side.
 	// This struct must have a serializable EntryProcessor counter part registered on server side with the actual
 	// org.hazelcast.map.EntryProcessor implementation.
-	ExecuteOnEntries(entryProcessor interface{}) (keyToResultPairs []IPair, err error)
+	ExecuteOnEntries(entryProcessor interface{}) (keyToResultPairs []Pair, err error)
 
 	// ExecuteOnEntriesWithPredicate applies the user defined EntryProcessor to entries in the map which satisfies
 	// the predicate.
@@ -367,5 +367,5 @@ type IMap interface {
 	// on the server side.
 	// This struct must have a serializable EntryProcessor counter part registered on server side with the actual
 	// org.hazelcast.map.EntryProcessor implementation.
-	ExecuteOnEntriesWithPredicate(entryProcessor interface{}, predicate interface{}) (keyToResultPairs []IPair, err error)
+	ExecuteOnEntriesWithPredicate(entryProcessor interface{}, predicate interface{}) (keyToResultPairs []Pair, err error)
 }

--- a/core/member_selector.go
+++ b/core/member_selector.go
@@ -22,7 +22,7 @@ package core
 type MemberSelector interface {
 	// Select decides if the given member will be part of an operation or not.
 	// Select returns true if the member should take part in the operation, false otherwise.
-	Select(member IMember) (selected bool)
+	Select(member Member) (selected bool)
 }
 
 // MemberSelectors is a utility variable to get MemberSelector instances.
@@ -33,7 +33,7 @@ var MemberSelectors = &selectors{
 type dataMemberSelector struct {
 }
 
-func (*dataMemberSelector) Select(member IMember) (selected bool) {
+func (*dataMemberSelector) Select(member Member) (selected bool) {
 	return !member.IsLiteMember()
 }
 

--- a/core/multi_map.go
+++ b/core/multi_map.go
@@ -18,8 +18,8 @@ import "time"
 
 // MultiMap is a specialized map whose keys can be associated with multiple values.
 type MultiMap interface {
-	// IDistributedObject is the base interface for all distributed objects.
-	IDistributedObject
+	// DistributedObject is the base interface for all distributed objects.
+	DistributedObject
 
 	// Put stores a key-value pair in the multi-map.
 	// It returns true if size of the multi-map is increased, false if the multi-map
@@ -67,7 +67,7 @@ type MultiMap interface {
 
 	// EntrySet returns all entries in this multi-map. If a certain key has multiple values associated with it,
 	// then one pair will be returned for each value.
-	EntrySet() (resultPairs []IPair, err error)
+	EntrySet() (resultPairs []Pair, err error)
 
 	// AddEntryListener adds an entry listener to this multi-map.
 	// It returns registration ID for this entry listener.

--- a/core/pn_counter.go
+++ b/core/pn_counter.go
@@ -50,8 +50,8 @@ package core
 //
 // PNCounter requires Hazelcast 3.10.
 type PNCounter interface {
-	// IDistributedObject is the base interface for all distributed objects.
-	IDistributedObject
+	// DistributedObject is the base interface for all distributed objects.
+	DistributedObject
 
 	// Get returns the current value of the counter.
 	// It returns HazelcastNoDataMemberInClusterError if the cluster does not contain any data members,

--- a/core/queue.go
+++ b/core/queue.go
@@ -16,12 +16,12 @@ package core
 
 import "time"
 
-// IQueue is a concurrent, blocking, distributed, observable queue. Queue is not a partitioned data-structure.
+// Queue is a concurrent, blocking, distributed, observable queue. Queue is not a partitioned data-structure.
 // All of the Queue content is stored in a single machine (and in the backup).
 // Queue will not scale by adding more members in the cluster.
-type IQueue interface {
-	// IDistributedObject is the base interface for all distributed objects.
-	IDistributedObject
+type Queue interface {
+	// DistributedObject is the base interface for all distributed objects.
+	DistributedObject
 
 	// AddAll adds all the items. If items slice changes during this operation, behavior is unspecified.
 	// AddAll returns true if the queue has changed, false otherwise.

--- a/core/replicated_map.go
+++ b/core/replicated_map.go
@@ -28,8 +28,8 @@ import (
 // When a new node joins the cluster, the new node initially will request existing
 // values from older nodes and replicate them locally.
 type ReplicatedMap interface {
-	// IDistributedObject is the base interface for all distributed objects.
-	IDistributedObject
+	// DistributedObject is the base interface for all distributed objects.
+	DistributedObject
 
 	// Put associates a given value to the specified key and replicates it to the
 	// cluster. If there is an old value, it will be replaced by the specified
@@ -88,7 +88,7 @@ type ReplicatedMap interface {
 	KeySet() (keySet []interface{}, err error)
 
 	// EntrySet returns entries as a slice of key-value pairs.
-	EntrySet() (resultPairs []IPair, err error)
+	EntrySet() (resultPairs []Pair, err error)
 
 	// AddEntryListener adds an entry listener for this map. The listener will be notified for all
 	// map add/remove/update/evict events.

--- a/core/ringbuffer.go
+++ b/core/ringbuffer.go
@@ -28,8 +28,8 @@ package core
 // If data is read from a ringbuffer with a sequence that is smaller than the headSequence, it means that the data
 // is not available anymore.
 type Ringbuffer interface {
-	// IDistributedObject is the base interface for all distributed objects.
-	IDistributedObject
+	// DistributedObject is the base interface for all distributed objects.
+	DistributedObject
 
 	// Capacity returns capacity of this ringbuffer.
 	Capacity() (capacity int64, err error)

--- a/core/set.go
+++ b/core/set.go
@@ -14,11 +14,11 @@
 
 package core
 
-// ISet is the concurrent, distributed implementation of collection that contains no duplicate elements.
+// Set is the concurrent, distributed implementation of collection that contains no duplicate elements.
 // As implied by its name, this interface models the mathematical 'set' abstraction.
-type ISet interface {
-	// IDistributedObject is the base interface for all distributed objects.
-	IDistributedObject
+type Set interface {
+	// DistributedObject is the base interface for all distributed objects.
+	DistributedObject
 
 	// Add adds the specified item to this set if not already present.
 	// Add returns true if the item was added, false otherwise.

--- a/core/topic.go
+++ b/core/topic.go
@@ -14,16 +14,16 @@
 
 package core
 
-// ITopic is a distribution mechanism for publishing messages that are delivered to multiple subscribers, which
+// Topic is a distribution mechanism for publishing messages that are delivered to multiple subscribers, which
 // is also known as a publish/subscribe (pub/sub) messaging model. Publish and subscriptions are cluster-wide. When a
 // member subscribes for a topic, it is actually registering for messages published by any member in the cluster,
 // including the new members joined after you added the listener.
 //
 // Messages are ordered, meaning that listeners(subscribers) will process the messages in the order they are actually
 // published.
-type ITopic interface {
-	// IDistributedObject is the base interface for all distributed objects.
-	IDistributedObject
+type Topic interface {
+	// DistributedObject is the base interface for all distributed objects.
+	DistributedObject
 
 	// AddMessageListener subscribes to this topic. When someone publishes a message on this topic.
 	// OnMessage() function of the given messageListener is called. More than one message listener can be

--- a/hazelcast.go
+++ b/hazelcast.go
@@ -21,23 +21,23 @@ import (
 	"github.com/hazelcast/hazelcast-go-client/internal"
 )
 
-// NewHazelcastClient creates and returns a new IHazelcastInstance.
-// IHazelcast instance enables you to do all Hazelcast operations without
+// NewHazelcastClient creates and returns a new Instance.
+// Hazelcast instance enables you to do all Hazelcast operations without
 // being a member of the cluster. It connects to one of the
 // cluster members and delegates all cluster wide operations to it.
 // When the connected cluster member dies, client will
 // automatically switch to another live member.
-func NewHazelcastClient() (IHazelcastInstance, error) {
+func NewHazelcastClient() (Instance, error) {
 	return NewHazelcastClientWithConfig(config.NewClientConfig())
 }
 
-// NewHazelcastClientWithConfig creates and returns a new IHazelcastInstance with the given config.
-// IHazelcast instance enables you to do all Hazelcast operations without
+// NewHazelcastClientWithConfig creates and returns a new Instance with the given config.
+// Hazelcast instance enables you to do all Hazelcast operations without
 // being a member of the cluster. It connects to one of the
 // cluster members and delegates all cluster wide operations to it.
 // When the connected cluster member dies, client will
 // automatically switch to another live member.
-func NewHazelcastClientWithConfig(config *config.ClientConfig) (IHazelcastInstance, error) {
+func NewHazelcastClientWithConfig(config *config.ClientConfig) (Instance, error) {
 	return internal.NewHazelcastClient(config)
 }
 
@@ -46,22 +46,22 @@ func NewHazelcastConfig() *config.ClientConfig {
 	return config.NewClientConfig()
 }
 
-// IHazelcastInstance is a Hazelcast instance. Each Hazelcast instance is a member (node) in a cluster.
+// Instance is a Hazelcast instance. Each Hazelcast instance is a member (node) in a cluster.
 // Multiple Hazelcast instances can be created.
 // Each Hazelcast instance has its own socket, goroutines.
-type IHazelcastInstance interface {
+type Instance interface {
 
 	// GetMap returns the distributed map instance with the specified name.
-	GetMap(name string) (core.IMap, error)
+	GetMap(name string) (core.Map, error)
 
 	// GetList returns the distributed list instance with the specified name.
-	GetList(name string) (core.IList, error)
+	GetList(name string) (core.List, error)
 
 	// GetSet returns the distributed set instance with the specified name.
-	GetSet(name string) (core.ISet, error)
+	GetSet(name string) (core.Set, error)
 
 	// GetTopic returns the distributed topic instance with the specified name.
-	GetTopic(name string) (core.ITopic, error)
+	GetTopic(name string) (core.Topic, error)
 
 	// GetMultiMap returns the distributed multi-map instance with the specified name.
 	GetMultiMap(name string) (core.MultiMap, error)
@@ -70,7 +70,7 @@ type IHazelcastInstance interface {
 	GetReplicatedMap(name string) (core.ReplicatedMap, error)
 
 	// GetQueue returns the distributed queue instance with the specified name.
-	GetQueue(name string) (core.IQueue, error)
+	GetQueue(name string) (core.Queue, error)
 
 	// GetRingbuffer returns the distributed ringbuffer instance with the specified name.
 	GetRingbuffer(name string) (core.Ringbuffer, error)
@@ -81,19 +81,19 @@ type IHazelcastInstance interface {
 	// GetFlakeIDGenerator returns the distributed flakeIDGenerator instance with the specified name.
 	GetFlakeIDGenerator(name string) (core.FlakeIDGenerator, error)
 
-	// GetDistributedObject returns IDistributedObject created by the service with the specified name.
-	GetDistributedObject(serviceName string, name string) (core.IDistributedObject, error)
+	// GetDistributedObject returns DistributedObject created by the service with the specified name.
+	GetDistributedObject(serviceName string, name string) (core.DistributedObject, error)
 
-	// Shutdown shuts down this IHazelcastInstance.
+	// Shutdown shuts down this Instance.
 	Shutdown()
 
-	// GetCluster returns the ICluster this instance is part of.
-	// ICluster interface allows you to add listener for membership
+	// GetCluster returns the Cluster this instance is part of.
+	// Cluster interface allows you to add listener for membership
 	// events and learn more about the cluster this Hazelcast
 	// instance is part of.
-	GetCluster() core.ICluster
+	GetCluster() core.Cluster
 
-	// GetLifecycle returns the lifecycle service for this instance. ILifecycleService allows you
+	// GetLifecycle returns the lifecycle service for this instance. Lifecycle service allows you
 	// to listen for the lifecycle events.
-	GetLifecycle() core.ILifecycle
+	GetLifecycle() core.Lifecycle
 }

--- a/internal/client.go
+++ b/internal/client.go
@@ -41,28 +41,28 @@ func NewHazelcastClient(config *config.ClientConfig) (*HazelcastClient, error) {
 	return &client, err
 }
 
-func (c *HazelcastClient) GetMap(name string) (core.IMap, error) {
+func (c *HazelcastClient) GetMap(name string) (core.Map, error) {
 	mp, err := c.GetDistributedObject(common.ServiceNameMap, name)
 	if err != nil {
 		return nil, err
 	}
-	return mp.(core.IMap), nil
+	return mp.(core.Map), nil
 }
 
-func (c *HazelcastClient) GetList(name string) (core.IList, error) {
+func (c *HazelcastClient) GetList(name string) (core.List, error) {
 	list, err := c.GetDistributedObject(common.ServiceNameList, name)
 	if err != nil {
 		return nil, err
 	}
-	return list.(core.IList), nil
+	return list.(core.List), nil
 }
 
-func (c *HazelcastClient) GetSet(name string) (core.ISet, error) {
+func (c *HazelcastClient) GetSet(name string) (core.Set, error) {
 	set, err := c.GetDistributedObject(common.ServiceNameSet, name)
 	if err != nil {
 		return nil, err
 	}
-	return set.(core.ISet), nil
+	return set.(core.Set), nil
 }
 
 func (c *HazelcastClient) GetReplicatedMap(name string) (core.ReplicatedMap, error) {
@@ -89,20 +89,20 @@ func (c *HazelcastClient) GetFlakeIDGenerator(name string) (core.FlakeIDGenerato
 	return flakeIDGenerator.(core.FlakeIDGenerator), err
 }
 
-func (c *HazelcastClient) GetTopic(name string) (core.ITopic, error) {
+func (c *HazelcastClient) GetTopic(name string) (core.Topic, error) {
 	topic, err := c.GetDistributedObject(common.ServiceNameTopic, name)
 	if err != nil {
 		return nil, err
 	}
-	return topic.(core.ITopic), nil
+	return topic.(core.Topic), nil
 }
 
-func (c *HazelcastClient) GetQueue(name string) (core.IQueue, error) {
+func (c *HazelcastClient) GetQueue(name string) (core.Queue, error) {
 	queue, err := c.GetDistributedObject(common.ServiceNameQueue, name)
 	if err != nil {
 		return nil, err
 	}
-	return queue.(core.IQueue), nil
+	return queue.(core.Queue), nil
 }
 
 func (c *HazelcastClient) GetRingbuffer(name string) (core.Ringbuffer, error) {
@@ -121,7 +121,7 @@ func (c *HazelcastClient) GetPNCounter(name string) (core.PNCounter, error) {
 	return counter.(core.PNCounter), nil
 }
 
-func (c *HazelcastClient) GetDistributedObject(serviceName string, name string) (core.IDistributedObject, error) {
+func (c *HazelcastClient) GetDistributedObject(serviceName string, name string) (core.DistributedObject, error) {
 	var clientProxy, err = c.ProxyManager.getOrCreateProxy(serviceName, name)
 	if err != nil {
 		return nil, err
@@ -129,11 +129,11 @@ func (c *HazelcastClient) GetDistributedObject(serviceName string, name string) 
 	return clientProxy, nil
 }
 
-func (c *HazelcastClient) GetCluster() core.ICluster {
+func (c *HazelcastClient) GetCluster() core.Cluster {
 	return c.ClusterService
 }
 
-func (c *HazelcastClient) GetLifecycle() core.ILifecycle {
+func (c *HazelcastClient) GetLifecycle() core.Lifecycle {
 	return c.LifecycleService
 }
 

--- a/internal/cluster.go
+++ b/internal/cluster.go
@@ -325,29 +325,29 @@ func (cs *clusterService) memberRemoved(member *protocol.Member) {
 	}
 }
 
-func (cs *clusterService) GetMemberList() []core.IMember {
+func (cs *clusterService) GetMemberList() []core.Member {
 	membersList := cs.members.Load().([]*protocol.Member)
-	members := make([]core.IMember, len(membersList))
+	members := make([]core.Member, len(membersList))
 	for index := 0; index < len(membersList); index++ {
-		members[index] = core.IMember(membersList[index])
+		members[index] = core.Member(membersList[index])
 	}
 	return members
 }
 
-func (cs *clusterService) GetMembersWithSelector(selector core.MemberSelector) (members []core.IMember) {
+func (cs *clusterService) GetMembersWithSelector(selector core.MemberSelector) (members []core.Member) {
 	if selector == nil {
 		return cs.GetMemberList()
 	}
 	membersList := cs.members.Load().([]*protocol.Member)
 	for _, member := range membersList {
 		if selector.Select(member) {
-			members = append(members, core.IMember(member))
+			members = append(members, core.Member(member))
 		}
 	}
 	return
 }
 
-func (cs *clusterService) GetMember(address core.IAddress) core.IMember {
+func (cs *clusterService) GetMember(address core.Address) core.Member {
 	membersList := cs.members.Load().([]*protocol.Member)
 	for _, member := range membersList {
 		if *member.Address().(*protocol.Address) == *address.(*protocol.Address) {
@@ -358,7 +358,7 @@ func (cs *clusterService) GetMember(address core.IAddress) core.IMember {
 	return nil
 }
 
-func (cs *clusterService) GetMemberByUUID(uuid string) core.IMember {
+func (cs *clusterService) GetMemberByUUID(uuid string) core.Member {
 	membersList := cs.members.Load().([]*protocol.Member)
 	for _, member := range membersList {
 		if member.UUID() == uuid {

--- a/internal/common/collection/util.go
+++ b/internal/common/collection/util.go
@@ -54,8 +54,8 @@ func DataToObjectCollection(dataSlice []*serialization.Data, service *serializat
 	return elements, nil
 }
 
-func DataToObjectPairCollection(dataSlice []*protocol.Pair, service *serialization.Service) (pairSlice []core.IPair, err error) {
-	pairSlice = make([]core.IPair, len(dataSlice))
+func DataToObjectPairCollection(dataSlice []*protocol.Pair, service *serialization.Service) (pairSlice []core.Pair, err error) {
+	pairSlice = make([]core.Pair, len(dataSlice))
 	for index, pairData := range dataSlice {
 		key, err := service.ToObject(pairData.Key().(*serialization.Data))
 		if err != nil {
@@ -65,7 +65,7 @@ func DataToObjectPairCollection(dataSlice []*protocol.Pair, service *serializati
 		if err != nil {
 			return nil, err
 		}
-		pairSlice[index] = core.IPair(protocol.NewPair(key, value))
+		pairSlice[index] = core.Pair(protocol.NewPair(key, value))
 	}
 	return
 }

--- a/internal/connection.go
+++ b/internal/connection.go
@@ -51,7 +51,7 @@ type Connection struct {
 	connectionManager      *connectionManager
 }
 
-func newConnection(address core.IAddress, responseChannel chan *protocol.ClientMessage, sendingError chan int64,
+func newConnection(address core.Address, responseChannel chan *protocol.ClientMessage, sendingError chan int64,
 	connectionID int64, connectionManager *connectionManager) *Connection {
 	connection := Connection{pending: make(chan *protocol.ClientMessage, 1),
 		received: make(chan *protocol.ClientMessage, 1),

--- a/internal/connection_manager.go
+++ b/internal/connection_manager.go
@@ -63,7 +63,7 @@ func (cm *connectionManager) addListener(listener connectionListener) {
 	}
 }
 
-func (cm *connectionManager) getActiveConnection(address core.IAddress) *Connection {
+func (cm *connectionManager) getActiveConnection(address core.Address) *Connection {
 	if address == nil {
 		return nil
 	}
@@ -105,7 +105,7 @@ func (cm *connectionManager) connectionClosed(connection *Connection, cause erro
 	}
 }
 
-func (cm *connectionManager) getOrConnect(address core.IAddress, asOwner bool) (chan *Connection, chan error) {
+func (cm *connectionManager) getOrConnect(address core.Address, asOwner bool) (chan *Connection, chan error) {
 	ch := make(chan *Connection, 1)
 	err := make(chan error, 1)
 	go func() {
@@ -138,7 +138,7 @@ func (cm *connectionManager) ConnectionCount() int32 {
 	return int32(len(cm.connections))
 }
 
-func (cm *connectionManager) openNewConnection(address core.IAddress, resp chan *Connection, asOwner bool) error {
+func (cm *connectionManager) openNewConnection(address core.Address, resp chan *Connection, asOwner bool) error {
 	if !asOwner && cm.client.ClusterService.ownerConnectionAddress.Load().(*protocol.Address).Host() == "" {
 		return core.NewHazelcastIllegalStateError("ownerConnection is not active", nil)
 	}

--- a/internal/lifecycle.go
+++ b/internal/lifecycle.go
@@ -44,7 +44,7 @@ func newLifecycleService(config *config.ClientConfig) *lifecycleService {
 	newLifecycle.isLive.Store(true)
 	newLifecycle.listeners.Store(make(map[string]interface{})) //Initialize
 	for _, listener := range config.LifecycleListeners() {
-		if _, ok := listener.(core.ILifecycleListener); ok {
+		if _, ok := listener.(core.LifecycleListener); ok {
 			newLifecycle.AddListener(listener)
 		}
 	}
@@ -88,8 +88,8 @@ func (ls *lifecycleService) fireLifecycleEvent(newState string) {
 	}
 	listeners := ls.listeners.Load().(map[string]interface{})
 	for _, listener := range listeners {
-		if _, ok := listener.(core.ILifecycleListener); ok {
-			listener.(core.ILifecycleListener).LifecycleStateChanged(newState)
+		if _, ok := listener.(core.LifecycleListener); ok {
+			listener.(core.LifecycleListener).LifecycleStateChanged(newState)
 		}
 	}
 	log.Println("New State : ", newState)

--- a/internal/map.go
+++ b/internal/map.go
@@ -355,13 +355,13 @@ func (mp *mapProxy) ValuesWithPredicate(predicate interface{}) (values []interfa
 	return mp.decodeToInterfaceSliceAndError(responseMessage, err, protocol.MapValuesWithPredicateDecodeResponse)
 }
 
-func (mp *mapProxy) EntrySet() (resultPairs []core.IPair, err error) {
+func (mp *mapProxy) EntrySet() (resultPairs []core.Pair, err error) {
 	request := protocol.MapEntrySetEncodeRequest(mp.name)
 	responseMessage, err := mp.invokeOnRandomTarget(request)
 	return mp.decodeToPairSliceAndError(responseMessage, err, protocol.MapEntrySetDecodeResponse)
 }
 
-func (mp *mapProxy) EntrySetWithPredicate(predicate interface{}) (resultPairs []core.IPair, err error) {
+func (mp *mapProxy) EntrySetWithPredicate(predicate interface{}) (resultPairs []core.Pair, err error) {
 	predicateData, err := mp.validateAndSerializePredicate(predicate)
 	if err != nil {
 		return nil, err
@@ -407,7 +407,7 @@ func (mp *mapProxy) GetAll(keys []interface{}) (entryMap map[interface{}]interfa
 	return entryMap, nil
 }
 
-func (mp *mapProxy) GetEntryView(key interface{}) (entryView core.IEntryView, err error) {
+func (mp *mapProxy) GetEntryView(key interface{}) (entryView core.EntryView, err error) {
 	keyData, err := mp.validateAndSerialize(key)
 	if err != nil {
 		return nil, err
@@ -564,7 +564,7 @@ func (mp *mapProxy) ExecuteOnKey(key interface{}, entryProcessor interface{}) (r
 	return mp.decodeToObjectAndError(responseMessage, err, protocol.MapExecuteOnKeyDecodeResponse)
 }
 
-func (mp *mapProxy) ExecuteOnKeys(keys []interface{}, entryProcessor interface{}) (keyToResultPairs []core.IPair, err error) {
+func (mp *mapProxy) ExecuteOnKeys(keys []interface{}, entryProcessor interface{}) (keyToResultPairs []core.Pair, err error) {
 	keysData := make([]*serialization.Data, len(keys))
 	for index, key := range keys {
 		keyData, err := mp.validateAndSerialize(key)
@@ -582,7 +582,7 @@ func (mp *mapProxy) ExecuteOnKeys(keys []interface{}, entryProcessor interface{}
 	return mp.decodeToPairSliceAndError(responseMessage, err, protocol.MapExecuteOnKeysDecodeResponse)
 }
 
-func (mp *mapProxy) ExecuteOnEntries(entryProcessor interface{}) (keyToResultPairs []core.IPair, err error) {
+func (mp *mapProxy) ExecuteOnEntries(entryProcessor interface{}) (keyToResultPairs []core.Pair, err error) {
 	entryProcessorData, err := mp.validateAndSerialize(entryProcessor)
 	if err != nil {
 		return nil, err
@@ -593,7 +593,7 @@ func (mp *mapProxy) ExecuteOnEntries(entryProcessor interface{}) (keyToResultPai
 }
 
 func (mp *mapProxy) ExecuteOnEntriesWithPredicate(entryProcessor interface{},
-	predicate interface{}) (keyToResultPairs []core.IPair, err error) {
+	predicate interface{}) (keyToResultPairs []core.Pair, err error) {
 	predicateData, err := mp.validateAndSerializePredicate(predicate)
 	if err != nil {
 		return nil, err

--- a/internal/multi_map.go
+++ b/internal/multi_map.go
@@ -136,7 +136,7 @@ func (mmp *multiMapProxy) KeySet() (keySet []interface{}, err error) {
 	return mmp.decodeToInterfaceSliceAndError(responseMessage, err, protocol.MultiMapKeySetDecodeResponse)
 }
 
-func (mmp *multiMapProxy) EntrySet() (resultPairs []core.IPair, err error) {
+func (mmp *multiMapProxy) EntrySet() (resultPairs []core.Pair, err error) {
 	request := protocol.MultiMapEntrySetEncodeRequest(mmp.name)
 	responseMessage, err := mmp.invokeOnRandomTarget(request)
 	return mmp.decodeToPairSliceAndError(responseMessage, err, protocol.MultiMapEntrySetDecodeResponse)

--- a/internal/protocol/core.go
+++ b/internal/protocol/core.go
@@ -58,7 +58,7 @@ func NewMember(address Address, uuid string, isLiteMember bool, attributes map[s
 	return &Member{address: address, uuid: uuid, isLiteMember: isLiteMember, attributes: attributes}
 }
 
-func (m *Member) Address() core.IAddress {
+func (m *Member) Address() core.Address {
 	return &m.address
 }
 
@@ -314,12 +314,12 @@ func (e *Error) Message() string {
 	return e.message
 }
 
-func (e *Error) StackTrace() []core.IStackTraceElement {
-	iStackTrace := make([]core.IStackTraceElement, len(e.stackTrace))
+func (e *Error) StackTrace() []core.StackTraceElement {
+	stackTrace := make([]core.StackTraceElement, len(e.stackTrace))
 	for i, v := range e.stackTrace {
-		iStackTrace[i] = core.IStackTraceElement(v)
+		stackTrace[i] = core.StackTraceElement(v)
 	}
-	return iStackTrace
+	return stackTrace
 }
 
 func (e *Error) CauseErrorCode() int32 {
@@ -424,7 +424,7 @@ func (e *ItemEvent) EventType() int32 {
 	return e.eventType
 }
 
-func (e *ItemEvent) Member() core.IMember {
+func (e *ItemEvent) Member() core.Member {
 	return e.member
 }
 
@@ -445,45 +445,45 @@ func NewMapEvent(eventType int32, uuid *string, numberOfAffectedEntries int32) *
 }
 
 type EntryAddedListener interface {
-	EntryAdded(core.IEntryEvent)
+	EntryAdded(core.EntryEvent)
 }
 
 type EntryRemovedListener interface {
-	EntryRemoved(core.IEntryEvent)
+	EntryRemoved(core.EntryEvent)
 }
 
 type EntryUpdatedListener interface {
-	EntryUpdated(core.IEntryEvent)
+	EntryUpdated(core.EntryEvent)
 }
 
 type EntryEvictedListener interface {
-	EntryEvicted(core.IEntryEvent)
+	EntryEvicted(core.EntryEvent)
 }
 
 type EntryEvictAllListener interface {
-	EntryEvictAll(core.IMapEvent)
+	EntryEvictAll(core.MapEvent)
 }
 
 type EntryClearAllListener interface {
-	EntryClearAll(core.IMapEvent)
+	EntryClearAll(core.MapEvent)
 }
 
 type EntryMergedListener interface {
-	EntryMerged(core.IEntryEvent)
+	EntryMerged(core.EntryEvent)
 }
 
 type EntryExpiredListener interface {
-	EntryExpired(core.IEntryEvent)
+	EntryExpired(core.EntryEvent)
 }
 
 type DecodeListenerResponse func(message *ClientMessage) *string
 type EncodeListenerRemoveRequest func(registrationID *string) *ClientMessage
 type MemberAddedListener interface {
-	MemberAdded(member core.IMember)
+	MemberAdded(member core.Member)
 }
 
 type MemberRemovedListener interface {
-	MemberRemoved(member core.IMember)
+	MemberRemoved(member core.Member)
 }
 
 // Helper function to get flags for listeners
@@ -538,6 +538,6 @@ func (m *TopicMessage) PublishTime() time.Time {
 	return m.publishTime
 }
 
-func (m *TopicMessage) PublishingMember() core.IMember {
+func (m *TopicMessage) PublishingMember() core.Member {
 	return m.publishingMember
 }

--- a/internal/proxy.go
+++ b/internal/proxy.go
@@ -179,7 +179,7 @@ func (p *proxy) decodeToInterfaceSliceAndError(responseMessage *protocol.ClientM
 }
 
 func (p *proxy) decodeToPairSliceAndError(responseMessage *protocol.ClientMessage, inputError error,
-	decodeFunc func(*protocol.ClientMessage) func() []*protocol.Pair) (response []core.IPair, err error) {
+	decodeFunc func(*protocol.ClientMessage) func() []*protocol.Pair) (response []core.Pair, err error) {
 	if inputError != nil {
 		return nil, inputError
 	}

--- a/internal/proxy_manager.go
+++ b/internal/proxy_manager.go
@@ -27,14 +27,14 @@ type proxyManager struct {
 	ReferenceID int64
 	client      *HazelcastClient
 	mu          sync.RWMutex // guards proxies
-	proxies     map[string]core.IDistributedObject
+	proxies     map[string]core.DistributedObject
 }
 
 func newProxyManager(client *HazelcastClient) *proxyManager {
 	return &proxyManager{
 		ReferenceID: 0,
 		client:      client,
-		proxies:     make(map[string]core.IDistributedObject),
+		proxies:     make(map[string]core.DistributedObject),
 	}
 }
 
@@ -42,7 +42,7 @@ func (pm *proxyManager) nextReferenceID() int64 {
 	return atomic.AddInt64(&pm.ReferenceID, 1)
 }
 
-func (pm *proxyManager) getOrCreateProxy(serviceName string, name string) (core.IDistributedObject, error) {
+func (pm *proxyManager) getOrCreateProxy(serviceName string, name string) (core.DistributedObject, error) {
 	var ns = serviceName + name
 	pm.mu.RLock()
 	if _, ok := pm.proxies[ns]; ok {
@@ -60,7 +60,7 @@ func (pm *proxyManager) getOrCreateProxy(serviceName string, name string) (core.
 	return proxy, nil
 }
 
-func (pm *proxyManager) createProxy(serviceName *string, name *string) (core.IDistributedObject, error) {
+func (pm *proxyManager) createProxy(serviceName *string, name *string) (core.DistributedObject, error) {
 	message := protocol.ClientCreateProxyEncodeRequest(name, serviceName, pm.findNextProxyAddress())
 	_, err := pm.client.InvocationService.invokeOnRandomTarget(message).Result()
 	if err != nil {
@@ -92,7 +92,7 @@ func (pm *proxyManager) findNextProxyAddress() *protocol.Address {
 	return pm.client.LoadBalancer.nextAddress()
 }
 
-func (pm *proxyManager) getProxyByNameSpace(serviceName *string, name *string) (core.IDistributedObject, error) {
+func (pm *proxyManager) getProxyByNameSpace(serviceName *string, name *string) (core.DistributedObject, error) {
 	if common.ServiceNameMap == *serviceName {
 		return newMapProxy(pm.client, serviceName, name)
 	} else if common.ServiceNameList == *serviceName {

--- a/internal/replicated_map.go
+++ b/internal/replicated_map.go
@@ -141,7 +141,7 @@ func (rmp *replicatedMapProxy) KeySet() (keySet []interface{}, err error) {
 	return rmp.decodeToInterfaceSliceAndError(responseMessage, err, protocol.ReplicatedMapKeySetDecodeResponse)
 }
 
-func (rmp *replicatedMapProxy) EntrySet() (resultPairs []core.IPair, err error) {
+func (rmp *replicatedMapProxy) EntrySet() (resultPairs []core.Pair, err error) {
 	request := protocol.ReplicatedMapEntrySetEncodeRequest(rmp.name)
 	responseMessage, err := rmp.invokeOnPartition(request, rmp.tarGetPartitionID)
 	return rmp.decodeToPairSliceAndError(responseMessage, err, protocol.ReplicatedMapEntrySetDecodeResponse)

--- a/samples/map/listener/map_listener_example.go
+++ b/samples/map/listener/map_listener_example.go
@@ -26,7 +26,7 @@ type entryListener struct {
 	wg *sync.WaitGroup
 }
 
-func (l *entryListener) EntryAdded(event core.IEntryEvent) {
+func (l *entryListener) EntryAdded(event core.EntryEvent) {
 	fmt.Println("Got an event, key: ", event.Key(), " value: ", event.Value())
 	l.wg.Done()
 }

--- a/samples/map_soak.go
+++ b/samples/map_soak.go
@@ -105,19 +105,19 @@ func startMapSoak() {
 type simpleListener struct {
 }
 
-func (l *simpleListener) EntryAdded(event core.IEntryEvent) {
+func (l *simpleListener) EntryAdded(event core.EntryEvent) {
 	event.Key()
 	event.Value()
 	event.OldValue()
 }
 
-func (l *simpleListener) EntryUpdated(event core.IEntryEvent) {
+func (l *simpleListener) EntryUpdated(event core.EntryEvent) {
 	event.Key()
 	event.Value()
 	event.OldValue()
 }
 
-func (l *simpleListener) EntryRemoved(event core.IEntryEvent) {
+func (l *simpleListener) EntryRemoved(event core.EntryEvent) {
 	event.Key()
 	event.Value()
 	event.OldValue()

--- a/samples/org_website_samples/query_sample.go
+++ b/samples/org_website_samples/query_sample.go
@@ -81,7 +81,7 @@ func (pf *ThePortableFactory) Create(classID int32) serialization.Portable {
 	return nil
 }
 
-func generateUsers(users core.IMap) {
+func generateUsers(users core.Map) {
 	users.Put("Rod", newUser("Rod", 19, true))
 	users.Put("Jane", newUser("Jane", 20, true))
 	users.Put("Freddy", newUser("Freddy", 23, true))

--- a/samples/org_website_samples/topic_sample.go
+++ b/samples/org_website_samples/topic_sample.go
@@ -24,7 +24,7 @@ import (
 type topicMessageListener struct {
 }
 
-func (*topicMessageListener) OnMessage(message core.ITopicMessage) {
+func (*topicMessageListener) OnMessage(message core.TopicMessage) {
 	fmt.Println("Got message: ", message.MessageObject())
 }
 

--- a/samples/topic/topic_example.go
+++ b/samples/topic/topic_example.go
@@ -56,7 +56,7 @@ type topicMessageListener struct {
 	wg *sync.WaitGroup
 }
 
-func (l *topicMessageListener) OnMessage(message core.ITopicMessage) {
+func (l *topicMessageListener) OnMessage(message core.TopicMessage) {
 	fmt.Println("Got message: ", message.MessageObject())
 	fmt.Println("Publishing Time: ", message.PublishTime())
 	l.wg.Done()

--- a/tests/assert/assertions.go
+++ b/tests/assert/assertions.go
@@ -60,7 +60,7 @@ func ErrorNil(t *testing.T, err error) {
 	}
 }
 
-func MapEqualPairSlice(t *testing.T, err error, mp map[interface{}]interface{}, pairSlice []core.IPair, message string) {
+func MapEqualPairSlice(t *testing.T, err error, mp map[interface{}]interface{}, pairSlice []core.Pair, message string) {
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/cluster_test.go
+++ b/tests/cluster_test.go
@@ -32,11 +32,11 @@ type membershipListener struct {
 	wg *sync.WaitGroup
 }
 
-func (l *membershipListener) MemberAdded(member core.IMember) {
+func (l *membershipListener) MemberAdded(member core.Member) {
 	l.wg.Done()
 }
 
-func (l *membershipListener) MemberRemoved(member core.IMember) {
+func (l *membershipListener) MemberRemoved(member core.Member) {
 	l.wg.Done()
 }
 
@@ -257,6 +257,6 @@ type mapListener struct {
 	wg *sync.WaitGroup
 }
 
-func (l *mapListener) EntryAdded(event core.IEntryEvent) {
+func (l *mapListener) EntryAdded(event core.EntryEvent) {
 	l.wg.Done()
 }

--- a/tests/proxy/flake_id_generator/flake_id_generator_test.go
+++ b/tests/proxy/flake_id_generator/flake_id_generator_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 var flakeIDGenerator core.FlakeIDGenerator
-var client hazelcast.IHazelcastInstance
+var client hazelcast.Instance
 
 const (
 	flakeIDStep             = 1 << 16

--- a/tests/proxy/list/list_test.go
+++ b/tests/proxy/list/list_test.go
@@ -26,8 +26,8 @@ import (
 	"github.com/hazelcast/hazelcast-go-client/tests/assert"
 )
 
-var list core.IList
-var client hazelcast.IHazelcastInstance
+var list core.List
+var client hazelcast.Instance
 var testElement = "testElement"
 
 func TestMain(m *testing.M) {
@@ -383,15 +383,15 @@ func TestListProxy_AddItemItemRemovedListener(t *testing.T) {
 
 type itemListener struct {
 	wg    *sync.WaitGroup
-	event core.IItemEvent
+	event core.ItemEvent
 }
 
-func (l *itemListener) ItemAdded(event core.IItemEvent) {
+func (l *itemListener) ItemAdded(event core.ItemEvent) {
 	l.event = event
 	l.wg.Done()
 }
 
-func (l *itemListener) ItemRemoved(event core.IItemEvent) {
+func (l *itemListener) ItemRemoved(event core.ItemEvent) {
 	l.event = event
 	l.wg.Done()
 }

--- a/tests/proxy/map/map_member_down/map_member_down_test.go
+++ b/tests/proxy/map/map_member_down/map_member_down_test.go
@@ -27,8 +27,8 @@ import (
 	"github.com/hazelcast/hazelcast-go-client/tests/assert"
 )
 
-var client hazelcast.IHazelcastInstance
-var mp core.IMap
+var client hazelcast.Instance
+var mp core.Map
 
 func TestMain(m *testing.M) {
 	remoteController, err := rc.NewRemoteControllerClient("localhost:9701")

--- a/tests/proxy/map/map_test.go
+++ b/tests/proxy/map/map_test.go
@@ -33,9 +33,9 @@ import (
 	"github.com/hazelcast/hazelcast-go-client/tests/assert"
 )
 
-var mp core.IMap
-var mp2 core.IMap
-var client hazelcast.IHazelcastInstance
+var mp core.Map
+var mp2 core.Map
+var client hazelcast.Instance
 
 func TestMain(m *testing.M) {
 	remoteController, err := rc.NewRemoteControllerClient("localhost:9701")
@@ -804,33 +804,33 @@ func TestMapProxy_GetEntryViewWithNilKey(t *testing.T) {
 
 type entryListener struct {
 	wg       *sync.WaitGroup
-	event    core.IEntryEvent
-	mapEvent core.IMapEvent
+	event    core.EntryEvent
+	mapEvent core.MapEvent
 }
 
-func (l *entryListener) EntryAdded(event core.IEntryEvent) {
+func (l *entryListener) EntryAdded(event core.EntryEvent) {
 	l.event = event
 	l.wg.Done()
 }
 
-func (l *entryListener) EntryUpdated(event core.IEntryEvent) {
+func (l *entryListener) EntryUpdated(event core.EntryEvent) {
 	l.wg.Done()
 }
 
-func (l *entryListener) EntryRemoved(event core.IEntryEvent) {
+func (l *entryListener) EntryRemoved(event core.EntryEvent) {
 	l.wg.Done()
 }
 
-func (l *entryListener) EntryEvicted(event core.IEntryEvent) {
+func (l *entryListener) EntryEvicted(event core.EntryEvent) {
 	l.wg.Done()
 }
 
-func (l *entryListener) EntryEvictAll(event core.IMapEvent) {
+func (l *entryListener) EntryEvictAll(event core.MapEvent) {
 	l.mapEvent = event
 	l.wg.Done()
 }
 
-func (l *entryListener) EntryClearAll(event core.IMapEvent) {
+func (l *entryListener) EntryClearAll(event core.MapEvent) {
 	l.wg.Done()
 }
 

--- a/tests/proxy/multi_map/multi_map_test.go
+++ b/tests/proxy/multi_map/multi_map_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 var multiMap core.MultiMap
-var client hazelcast.IHazelcastInstance
+var client hazelcast.Instance
 var testKey = "testKey"
 var testValue = "testValue"
 var testValue2 = "testValue2"
@@ -404,32 +404,32 @@ func TestMultiMapProxy_ForceUnlockWithNil(t *testing.T) {
 
 type EntryListener struct {
 	wg       *sync.WaitGroup
-	event    core.IEntryEvent
-	mapEvent core.IMapEvent
+	event    core.EntryEvent
+	mapEvent core.MapEvent
 }
 
-func (l *EntryListener) EntryAdded(event core.IEntryEvent) {
+func (l *EntryListener) EntryAdded(event core.EntryEvent) {
 	l.event = event
 	l.wg.Done()
 }
 
-func (l *EntryListener) EntryUpdated(event core.IEntryEvent) {
+func (l *EntryListener) EntryUpdated(event core.EntryEvent) {
 	l.wg.Done()
 }
 
-func (l *EntryListener) EntryRemoved(event core.IEntryEvent) {
+func (l *EntryListener) EntryRemoved(event core.EntryEvent) {
 	l.wg.Done()
 }
 
-func (l *EntryListener) EntryEvicted(event core.IEntryEvent) {
+func (l *EntryListener) EntryEvicted(event core.EntryEvent) {
 	l.wg.Done()
 }
 
-func (l *EntryListener) EntryEvictAll(event core.IMapEvent) {
+func (l *EntryListener) EntryEvictAll(event core.MapEvent) {
 	l.mapEvent = event
 	l.wg.Done()
 }
 
-func (l *EntryListener) EntryClearAll(event core.IMapEvent) {
+func (l *EntryListener) EntryClearAll(event core.MapEvent) {
 	l.wg.Done()
 }

--- a/tests/proxy/pn_counter/pn_counter_test.go
+++ b/tests/proxy/pn_counter/pn_counter_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 var counter core.PNCounter
-var client hazelcast.IHazelcastInstance
+var client hazelcast.Instance
 
 const counterName = "myPNCounter"
 

--- a/tests/proxy/queue/queue_test.go
+++ b/tests/proxy/queue/queue_test.go
@@ -27,8 +27,8 @@ import (
 	"github.com/hazelcast/hazelcast-go-client/tests/assert"
 )
 
-var queue core.IQueue
-var client hazelcast.IHazelcastInstance
+var queue core.Queue
+var client hazelcast.Instance
 var testElement = "testElement"
 var queueName = "ClientQueueTest"
 
@@ -409,15 +409,15 @@ func TestListProxy_AddItemItemRemovedListener(t *testing.T) {
 
 type itemListener struct {
 	wg    *sync.WaitGroup
-	event core.IItemEvent
+	event core.ItemEvent
 }
 
-func (l *itemListener) ItemAdded(event core.IItemEvent) {
+func (l *itemListener) ItemAdded(event core.ItemEvent) {
 	l.event = event
 	l.wg.Done()
 }
 
-func (l *itemListener) ItemRemoved(event core.IItemEvent) {
+func (l *itemListener) ItemRemoved(event core.ItemEvent) {
 	l.event = event
 	l.wg.Done()
 }

--- a/tests/proxy/replicated_map/replicated_map_test.go
+++ b/tests/proxy/replicated_map/replicated_map_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 var rmp core.ReplicatedMap
-var client hazelcast.IHazelcastInstance
+var client hazelcast.Instance
 
 func TestMain(m *testing.M) {
 	remoteController, err := rc.NewRemoteControllerClient("localhost:9701")
@@ -411,26 +411,26 @@ func TestReplicatedMapProxy_AddEntryListenerToKeyWithPredicate(t *testing.T) {
 
 type entryListener struct {
 	wg    *sync.WaitGroup
-	event core.IEntryEvent
+	event core.EntryEvent
 }
 
-func (l *entryListener) EntryAdded(event core.IEntryEvent) {
+func (l *entryListener) EntryAdded(event core.EntryEvent) {
 	l.event = event
 	l.wg.Done()
 }
 
-func (l *entryListener) EntryUpdated(event core.IEntryEvent) {
+func (l *entryListener) EntryUpdated(event core.EntryEvent) {
 	l.wg.Done()
 }
 
-func (l *entryListener) EntryRemoved(event core.IEntryEvent) {
+func (l *entryListener) EntryRemoved(event core.EntryEvent) {
 	l.wg.Done()
 }
 
-func (l *entryListener) EntryEvicted(event core.IEntryEvent) {
+func (l *entryListener) EntryEvicted(event core.EntryEvent) {
 	l.wg.Done()
 }
 
-func (l *entryListener) EntryClearAll(event core.IMapEvent) {
+func (l *entryListener) EntryClearAll(event core.MapEvent) {
 	l.wg.Done()
 }

--- a/tests/proxy/ringbuffer/ringbuffer_test.go
+++ b/tests/proxy/ringbuffer/ringbuffer_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 var ringbuffer core.Ringbuffer
-var client hazelcast.IHazelcastInstance
+var client hazelcast.Instance
 
 const capacity int64 = 10
 const ringbufferName = "ClientRingbufferTestWithTTL"

--- a/tests/proxy/set/set_test.go
+++ b/tests/proxy/set/set_test.go
@@ -26,8 +26,8 @@ import (
 	"github.com/hazelcast/hazelcast-go-client/tests/assert"
 )
 
-var set core.ISet
-var client hazelcast.IHazelcastInstance
+var set core.Set
+var client hazelcast.Instance
 var testElement = "testElement"
 
 func TestMain(m *testing.M) {
@@ -219,15 +219,15 @@ func TestSetProxy_AddItemItemRemovedListener(t *testing.T) {
 
 type itemListener struct {
 	wg    *sync.WaitGroup
-	event core.IItemEvent
+	event core.ItemEvent
 }
 
-func (l *itemListener) ItemAdded(event core.IItemEvent) {
+func (l *itemListener) ItemAdded(event core.ItemEvent) {
 	l.event = event
 	l.wg.Done()
 }
 
-func (l *itemListener) ItemRemoved(event core.IItemEvent) {
+func (l *itemListener) ItemRemoved(event core.ItemEvent) {
 	l.event = event
 	l.wg.Done()
 }

--- a/tests/proxy/topic/topic_test.go
+++ b/tests/proxy/topic/topic_test.go
@@ -27,8 +27,8 @@ import (
 	"github.com/hazelcast/hazelcast-go-client/tests/assert"
 )
 
-var topic core.ITopic
-var client hazelcast.IHazelcastInstance
+var topic core.Topic
+var client hazelcast.Instance
 
 func TestMain(m *testing.M) {
 	remoteController, err := rc.NewRemoteControllerClient("localhost:9701")
@@ -79,7 +79,7 @@ type topicMessageListener struct {
 	publishTime time.Time
 }
 
-func (l *topicMessageListener) OnMessage(message core.ITopicMessage) {
+func (l *topicMessageListener) OnMessage(message core.TopicMessage) {
 	l.msg = message.MessageObject()
 	l.publishTime = message.PublishTime()
 	l.wg.Done()


### PR DESCRIPTION
This pr removes `I` prefix from some interface names. We decided to make Go Client more compatible with Go conventions.
#245 