### PR TITLE
Time related API's converted to use time.* types.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -26,7 +26,7 @@ import (
 const (
 	DefaultGroupName         = "dev"
 	DefaultGroupPassword     = "dev-pass"
-	DefaultInvocationTimeout = 120 * time.Second //secs
+	DefaultInvocationTimeout = 120 * time.Second
 )
 
 // ClientConfig is the main configuration to setup a Hazelcast client.
@@ -46,11 +46,11 @@ type ClientConfig struct {
 	// serializationConfig is the serialization configuration of the client.
 	serializationConfig *SerializationConfig
 
-	// heartbeatTimeoutInSeconds is the timeout value for heartbeat in seconds.
-	heartbeatTimeoutInSeconds int32
+	// heartbeatTimeout is the timeout value for heartbeat.
+	heartbeatTimeout time.Duration
 
-	// heartbeatIntervalInSeconds is heartbeat internal in seconds.
-	heartbeatIntervalInSeconds int32
+	// heartbeatInterval is heartbeat internal.
+	heartbeatInterval time.Duration
 
 	// flakeIdGeneratorConfigMap is mapping of names to flakeIdGeneratorConfigs
 	flakeIdGeneratorConfigMap map[string]*FlakeIdGeneratorConfig
@@ -93,27 +93,25 @@ func (cc *ClientConfig) SerializationConfig() *SerializationConfig {
 }
 
 // SetHeartbeatTimeout sets the heartbeat timeout value to given timeout value.
-// timeout value is in seconds.
-func (cc *ClientConfig) SetHeartbeatTimeoutInSeconds(timeoutInSeconds int32) *ClientConfig {
-	cc.heartbeatTimeoutInSeconds = timeoutInSeconds
+func (cc *ClientConfig) SetHeartbeatTimeout(heartbeatTimeout time.Duration) *ClientConfig {
+	cc.heartbeatTimeout = heartbeatTimeout
 	return cc
 }
 
-// HeartbeatTimeout returns heartbeat timeout in seconds.
-func (cc *ClientConfig) HeartbeatTimeout() int32 {
-	return cc.heartbeatTimeoutInSeconds
+// HeartbeatTimeout returns heartbeat timeout
+func (cc *ClientConfig) HeartbeatTimeout() time.Duration {
+	return cc.heartbeatTimeout
 }
 
-// SetHeartbeatIntervalInSeconds sets the heartbeat timeout value to given interval value.
-// interval value is in seconds.
-func (cc *ClientConfig) SetHeartbeatIntervalInSeconds(intervalInSeconds int32) *ClientConfig {
-	cc.heartbeatIntervalInSeconds = intervalInSeconds
+// SetHeartbeatInterval sets the heartbeat timeout value to given interval value.
+func (cc *ClientConfig) SetHeartbeatInterval(heartbeatInterval time.Duration) *ClientConfig {
+	cc.heartbeatInterval = heartbeatInterval
 	return cc
 }
 
-// HeartbeatInterval returns heartbeat interval in seconds.
-func (cc *ClientConfig) HeartbeatInterval() int32 {
-	return cc.heartbeatIntervalInSeconds
+// HeartbeatInterval returns heartbeat interval.
+func (cc *ClientConfig) HeartbeatInterval() time.Duration {
+	return cc.heartbeatInterval
 }
 
 // GetFlakeIdGeneratorConfig returns the FlakeIdGeneratorConfig for the given name, creating one
@@ -328,11 +326,11 @@ type ClientNetworkConfig struct {
 	connectionAttemptLimit int32
 
 	// connectionAttemptPeriod is the period for the next attempt to find a member to connect.
-	connectionAttemptPeriod int32
+	connectionAttemptPeriod time.Duration
 
-	// Socket connection timeout is an int32, given in seconds.
+	// Socket connection timeout.
 	// Setting a timeout of zero disables the timeout feature and is equivalent to block the socket until it connects.
-	connectionTimeout int32
+	connectionTimeout time.Duration
 
 	// If true, client will redo the operations that were executing on the server when client recovers the connection after a failure.
 	// This can be because of network, or simply because the member died. However it is not clear whether the
@@ -346,18 +344,18 @@ type ClientNetworkConfig struct {
 	smartRouting bool
 
 	// The invocation timeout for sending invocation.
-	invocationTimeoutInSeconds time.Duration
+	invocationTimeout time.Duration
 }
 
 func NewClientNetworkConfig() *ClientNetworkConfig {
 	return &ClientNetworkConfig{
-		addresses:                  make([]string, 0),
-		connectionAttemptLimit:     2,
-		connectionAttemptPeriod:    3,
-		connectionTimeout:          5,
-		redoOperation:              false,
-		smartRouting:               true,
-		invocationTimeoutInSeconds: DefaultInvocationTimeout,
+		addresses:               make([]string, 0),
+		connectionAttemptLimit:  2,
+		connectionAttemptPeriod: 3 * time.Second,
+		connectionTimeout:       5 * time.Second,
+		redoOperation:           false,
+		smartRouting:            true,
+		invocationTimeout:       DefaultInvocationTimeout,
 	}
 }
 
@@ -372,12 +370,12 @@ func (nc *ClientNetworkConfig) ConnectionAttemptLimit() int32 {
 }
 
 // ConnectionAttemptPeriod returns the period for the next attempt to find a member to connect.
-func (nc *ClientNetworkConfig) ConnectionAttemptPeriod() int32 {
+func (nc *ClientNetworkConfig) ConnectionAttemptPeriod() time.Duration {
 	return nc.connectionAttemptPeriod
 }
 
-// ConnectionTimeout returns the timeout value in seconds for nodes to accept client connection requests.
-func (nc *ClientNetworkConfig) ConnectionTimeout() int32 {
+// ConnectionTimeout returns the timeout value for nodes to accept client connection requests.
+func (nc *ClientNetworkConfig) ConnectionTimeout() time.Duration {
 	return nc.connectionTimeout
 }
 
@@ -391,9 +389,9 @@ func (nc *ClientNetworkConfig) IsSmartRouting() bool {
 	return nc.smartRouting
 }
 
-// InvocationTimeout returns the invocation timeout in seconds.
+// InvocationTimeout returns the invocation timeout
 func (nc *ClientNetworkConfig) InvocationTimeout() time.Duration {
-	return nc.invocationTimeoutInSeconds
+	return nc.invocationTimeout
 }
 
 // AddAddress adds given addresses to candidate address list that client will use to establish initial connection.
@@ -419,17 +417,17 @@ func (nc *ClientNetworkConfig) SetConnectionAttemptLimit(connectionAttemptLimit 
 	return nc
 }
 
-// SetConnectionAttemptPeriod sets the period for the next attempt to find a member to connect in seconds.
+// SetConnectionAttemptPeriod sets the period for the next attempt to find a member to connect
 // SetConnectionAttemptPeriod returns the configured ClientNetworkConfig for chaining.
-func (nc *ClientNetworkConfig) SetConnectionAttemptPeriod(connectionAttemptPeriod int32) *ClientNetworkConfig {
+func (nc *ClientNetworkConfig) SetConnectionAttemptPeriod(connectionAttemptPeriod time.Duration) *ClientNetworkConfig {
 	nc.connectionAttemptPeriod = connectionAttemptPeriod
 	return nc
 }
 
-// Socket connection timeout is an int32, given in seconds.
+// Socket connection timeout
 // Setting a timeout of zero disables the timeout feature and is equivalent to block the socket until it connects.
 // SetConnectionTimeout returns the configured ClientNetworkConfig for chaining.
-func (nc *ClientNetworkConfig) SetConnectionTimeout(connectionTimeout int32) *ClientNetworkConfig {
+func (nc *ClientNetworkConfig) SetConnectionTimeout(connectionTimeout time.Duration) *ClientNetworkConfig {
 	nc.connectionTimeout = connectionTimeout
 	return nc
 }
@@ -454,9 +452,9 @@ func (nc *ClientNetworkConfig) SetSmartRouting(smartRouting bool) *ClientNetwork
 	return nc
 }
 
-// SetInvocationTimeoutInSeconds sets the invocation timeout for sending invocation.
-// SetInvocationTimeoutInSeconds returns the configured ClientNetworkConfig for chaining.
-func (nc *ClientNetworkConfig) SetInvocationTimeoutInSeconds(invocationTimeoutInSeconds int32) *ClientNetworkConfig {
-	nc.invocationTimeoutInSeconds = time.Duration(invocationTimeoutInSeconds) * time.Second
+// SetInvocationTimeout sets the invocation timeout for sending invocation.
+// SetInvocationTimeout returns the configured ClientNetworkConfig for chaining.
+func (nc *ClientNetworkConfig) SetInvocationTimeout(invocationTimeout time.Duration) *ClientNetworkConfig {
+	nc.invocationTimeout = invocationTimeout
 	return nc
 }

--- a/core/api.go
+++ b/core/api.go
@@ -14,6 +14,8 @@
 
 package core
 
+import "time"
+
 // IAddress represents an address of a member in the cluster.
 type IAddress interface {
 	// Host returns host of the member.
@@ -111,22 +113,22 @@ type IEntryView interface {
 	Cost() int64
 
 	// CreationTime returns the creation time of the entry.
-	CreationTime() int64
+	CreationTime() time.Time
 
 	// ExpirationTime returns the expiration time of the entry.
-	ExpirationTime() int64
+	ExpirationTime() time.Time
 
 	// Hits returns the number of hits of the entry.
 	Hits() int64
 
 	// LastAccessTime returns the last access time for the entry.
-	LastAccessTime() int64
+	LastAccessTime() time.Time
 
 	// LastStoredTime returns the last store time for the value.
-	LastStoredTime() int64
+	LastStoredTime() time.Time
 
 	// LastUpdateTime returns the last time the value was updated.
-	LastUpdateTime() int64
+	LastUpdateTime() time.Time
 
 	// Version returns the version of the entry.
 	Version() int64
@@ -135,7 +137,7 @@ type IEntryView interface {
 	EvictionCriteriaNumber() int64
 
 	// Ttl returns the last set time to live second.
-	Ttl() int64
+	Ttl() time.Duration
 }
 
 type IEntryEvent interface {
@@ -276,7 +278,7 @@ type ITopicMessage interface {
 	MessageObject() interface{}
 
 	// PublishTime returns the time in milliseconds when the message is published.
-	PublishTime() int64
+	PublishTime() time.Time
 
 	// PublishMember returns the member that published the message.
 	// The member can be nil if:

--- a/core/map.go
+++ b/core/map.go
@@ -148,7 +148,7 @@ type IMap interface {
 	// Acquired lock is only for the key in this map.
 	// Locks are re-entrant, so if the key is locked N times then
 	// it should be unlocked N times before another thread can acquire it.
-	LockWithLeaseTime(key interface{}, lease int64, leaseTimeUnit time.Duration) (err error)
+	LockWithLeaseTime(key interface{}, lease time.Duration) (err error)
 
 	// Unlock releases the lock for the specified key. It never blocks and returns immediately.
 	// If the current thread is the holder of this lock,
@@ -199,11 +199,11 @@ type IMap interface {
 	// then the entry lives forever. If the TTL is negative, then the TTL
 	// from the map configuration will be used (default: forever).
 	// For example:
-	// 	mp.SetWithTtl("testingKey1", "testingValue1", 5, time.Second)
+	// 	mp.SetWithTtl("testingKey1", "testingValue1", 5 * time. Second)
 	// will expire and get evicted after 5 seconds whereas
-	// mp.SetWithTtl("testingKey1", "testingValue1", 5, time.Millisecond)
+	// mp.SetWithTtl("testingKey1", "testingValue1", 5 * time. Millisecond)
 	// will expire and get evicted after 5 milliseconds.
-	SetWithTtl(key interface{}, value interface{}, ttl int64, ttlTimeUnit time.Duration) (err error)
+	SetWithTtl(key interface{}, value interface{}, ttl time.Duration) (err error)
 
 	// PutIfAbsent associates the specified key with the given value
 	// if it is not already associated.
@@ -267,7 +267,7 @@ type IMap interface {
 	//	the lock is acquired by the current thread, or
 	//	the specified waiting time elapses.
 	// TryLcokWithTimeout returns true if lock is acquired, false otherwise.
-	TryLockWithTimeout(key interface{}, timeout int64, timeoutTimeUnit time.Duration) (locked bool, err error)
+	TryLockWithTimeout(key interface{}, timeout time.Duration) (locked bool, err error)
 
 	// TryLockWithTimeoutAndLease tries to acquire the lock for the specified key for the specified lease time.
 	// After lease time, the lock will be released.
@@ -277,7 +277,7 @@ type IMap interface {
 	//	the lock is acquired by the current thread, or
 	//	the specified waiting time elapses.
 	// TryLcokWithTimeoutAndLease returns true if lock is acquired, false otherwise.
-	TryLockWithTimeoutAndLease(key interface{}, timeout int64, timeoutTimeUnit time.Duration, lease int64, leaseTimeUnit time.Duration) (locked bool, err error)
+	TryLockWithTimeoutAndLease(key interface{}, timeout time.Duration, lease time.Duration) (locked bool, err error)
 
 	// TryPut tries to put the given key and value into this map and returns immediately.
 	// TryPut returns true if the put is successful, false otherwise.
@@ -288,7 +288,7 @@ type IMap interface {
 	// thread and/or member, then this operation will wait the timeout
 	// amount for acquiring the lock.
 	// TryRemove returns true if the remove is successful, false otherwise.
-	TryRemove(key interface{}, timeout int64, timeoutTimeUnit time.Duration) (ok bool, err error)
+	TryRemove(key interface{}, timeout time.Duration) (ok bool, err error)
 
 	// GetAll returns the entries for the given keys.
 	// The returned map is NOT backed by the original map,
@@ -304,7 +304,7 @@ type IMap interface {
 	// the entry will expire and get evicted after the TTL. If the TTL is 0,
 	// then the entry lives forever. If the TTL is negative, then the TTL
 	// from the configuration will be used (default: forever).
-	PutTransient(key interface{}, value interface{}, ttl int64, ttlTimeUnit time.Duration) (err error)
+	PutTransient(key interface{}, value interface{}, ttl time.Duration) (err error)
 
 	// AddEntryListener adds a continuous entry listener for this map.
 	// To receive an event, you should implement a corresponding interface for that event such as

--- a/core/multi_map.go
+++ b/core/multi_map.go
@@ -105,7 +105,7 @@ type MultiMap interface {
 	//
 	// Locks are re-entrant, so if the key is locked N times, then
 	// it should be unlocked N times before another thread can acquire it.
-	LockWithLeaseTime(key interface{}, lease int64, leaseTimeUnit time.Duration) (err error)
+	LockWithLeaseTime(key interface{}, lease time.Duration) (err error)
 
 	// IsLocked returns true if this key is locked, false otherwise.
 	IsLocked(key interface{}) (locked bool, err error)
@@ -121,7 +121,7 @@ type MultiMap interface {
 	// purposes and lies dormant until one of two things happens:
 	// the lock is acquired by the current thread, or
 	// the specified waiting time elapses.
-	TryLockWithTimeout(key interface{}, timeout int64, timeoutTimeUnit time.Duration) (locked bool, err error)
+	TryLockWithTimeout(key interface{}, timeout time.Duration) (locked bool, err error)
 
 	// Tries to acquire the lock for the specified key for the specified lease time.
 	// After lease time, the lock will be released.
@@ -131,7 +131,7 @@ type MultiMap interface {
 	// purposes and lies dormant until one of two things happens:
 	// the lock is acquired by the current thread, or
 	// the specified waiting time elapses.
-	TryLockWithTimeoutAndLease(key interface{}, timeout int64, timeoutTimeUnit time.Duration, lease int64, leaseTimeUnit time.Duration) (locked bool, err error)
+	TryLockWithTimeoutAndLease(key interface{}, timeout time.Duration, lease time.Duration) (locked bool, err error)
 
 	// Unlock unlocks the specified key.
 	Unlock(key interface{}) (err error)

--- a/core/queue.go
+++ b/core/queue.go
@@ -61,7 +61,7 @@ type IQueue interface {
 	// OfferWithTimeout inserts the given item to the end of the queue if there is room, otherwise
 	// it waits for timeout with timeoutUnit before returning false.
 	// OfferWithTimeout returns true if the item is added, false otherwise.
-	OfferWithTimeout(item interface{}, timeout int64, timeoutUnit time.Duration) (added bool, err error)
+	OfferWithTimeout(item interface{}, timeout time.Duration) (added bool, err error)
 
 	// Peek retrieves, but does not remove the head of this queue.
 	// Peek returns the head of this queue, nil if the queue is empty.
@@ -74,7 +74,7 @@ type IQueue interface {
 	// PollWithTimeout retrieves and removes the head of this queue,
 	// if the queue is empty it waits timeout with timeoutUnit before returning nil.
 	// PollWithTimeout returns the head of this queue, nil if the queue is empty after timeoutInMilliSeconds milliseconds.
-	PollWithTimeout(timeout int64, timeoutUnit time.Duration) (item interface{}, err error)
+	PollWithTimeout(timeout time.Duration) (item interface{}, err error)
 
 	// Put inserts the item at the end of this queue.
 	// It blocks until there is available room in the queue, if necessary.

--- a/core/replicated_map.go
+++ b/core/replicated_map.go
@@ -41,7 +41,7 @@ type ReplicatedMap interface {
 	// one and returned from the call. In addition, you have to specify a ttl and its time unit
 	// to define when the value is outdated and thus should be removed from the
 	// replicated map.
-	PutWithTtl(key interface{}, value interface{}, ttl int64, ttlTimeUnit time.Duration) (oldValue interface{}, err error)
+	PutWithTtl(key interface{}, value interface{}, ttl time.Duration) (oldValue interface{}, err error)
 
 	// PutAll copies all of the mappings from the specified map to this map.
 	// The effect of this call is equivalent to that of calling put(k, v)

--- a/internal/common/util.go
+++ b/internal/common/util.go
@@ -18,6 +18,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"io"
+	"math"
 	"net"
 	"strconv"
 	"strings"
@@ -43,12 +44,30 @@ func GetIpAndPort(addr string) (string, int32) {
 	return addr, int32(port)
 }
 
-func GetTimeInMilliSeconds(time int64, duration time.Duration) int64 {
-	var timeInMillis int64 = time * duration.Nanoseconds() / (1000000)
-	if time > 0 && timeInMillis == 0 {
-		timeInMillis = 1
+func GetTimeInMilliSeconds(duration time.Duration) int64 {
+	if duration == -1 {
+		return -1
 	}
-	return timeInMillis
+	if duration > 0 && duration < time.Millisecond {
+		return int64(time.Millisecond)
+	}
+	return duration.Nanoseconds() / int64(time.Millisecond)
+}
+
+func ConvertMillisToDuration(timeInMillis int64) time.Duration {
+	if timeInMillis == math.MaxInt64 {
+		return time.Duration(timeInMillis)
+	}
+	return time.Duration(timeInMillis) * time.Millisecond
+}
+
+func ConvertMillisToUnixTime(timeInMillis int64) time.Time {
+	if timeInMillis == 0 {
+		return time.Time{}
+	} else if timeInMillis == math.MaxInt64 {
+		return time.Unix(0, timeInMillis)
+	}
+	return time.Unix(0, timeInMillis*int64(time.Millisecond))
 }
 
 // NewUUID generates a random UUID according to RFC 4122

--- a/internal/common/util_test.go
+++ b/internal/common/util_test.go
@@ -43,20 +43,19 @@ func TestGetIpWithoutPort(t *testing.T) {
 }
 func TestGetTimeInMilliSeconds(t *testing.T) {
 	var expected int64 = 100
-	var baseTime int64 = 100
-	if result := GetTimeInMilliSeconds(baseTime, time.Millisecond); result != expected {
+	if result := GetTimeInMilliSeconds(100 * time.Millisecond); result != expected {
 		t.Fatal("An error in GetTimeInMilleSeconds()")
 	}
 	expected = expected * 1000
-	if result := GetTimeInMilliSeconds(baseTime, time.Second); result != expected {
+	if result := GetTimeInMilliSeconds(100 * time.Second); result != expected {
 		t.Fatal("An error in GetTimeInMilleSeconds()")
 	}
 	expected = expected * 60
-	if result := GetTimeInMilliSeconds(baseTime, time.Minute); result != expected {
+	if result := GetTimeInMilliSeconds(100 * time.Minute); result != expected {
 		t.Fatal("An error in GetTimeInMilleSeconds()")
 	}
 	expected = expected * 60
-	if result := GetTimeInMilliSeconds(baseTime, time.Hour); result != expected {
+	if result := GetTimeInMilliSeconds(100 * time.Hour); result != expected {
 		t.Fatal("An error in GetTimeInMilleSeconds()")
 	}
 }

--- a/internal/multi_map.go
+++ b/internal/multi_map.go
@@ -175,16 +175,16 @@ func (mmp *MultiMapProxy) RemoveEntryListener(registrationId *string) (removed b
 }
 
 func (mmp *MultiMapProxy) Lock(key interface{}) (err error) {
-	return mmp.LockWithLeaseTime(key, -1, time.Second)
+	return mmp.LockWithLeaseTime(key, -1)
 }
 
-func (mmp *MultiMapProxy) LockWithLeaseTime(key interface{}, lease int64, leaseTimeUnit time.Duration) (err error) {
+func (mmp *MultiMapProxy) LockWithLeaseTime(key interface{}, lease time.Duration) (err error) {
 	keyData, err := mmp.validateAndSerialize(key)
 	if err != nil {
 		return err
 	}
-	lease = common.GetTimeInMilliSeconds(lease, leaseTimeUnit)
-	request := protocol.MultiMapLockEncodeRequest(mmp.name, keyData, threadId, lease, mmp.client.ProxyManager.nextReferenceId())
+	leaseInMillis := common.GetTimeInMilliSeconds(lease)
+	request := protocol.MultiMapLockEncodeRequest(mmp.name, keyData, threadId, leaseInMillis, mmp.client.ProxyManager.nextReferenceId())
 	_, err = mmp.invokeOnKey(request, keyData)
 	return
 }
@@ -200,21 +200,21 @@ func (mmp *MultiMapProxy) IsLocked(key interface{}) (locked bool, err error) {
 }
 
 func (mmp *MultiMapProxy) TryLock(key interface{}) (locked bool, err error) {
-	return mmp.TryLockWithTimeout(key, 0, time.Second)
+	return mmp.TryLockWithTimeout(key, 0)
 }
 
-func (mmp *MultiMapProxy) TryLockWithTimeout(key interface{}, timeout int64, timeoutTimeUnit time.Duration) (locked bool, err error) {
-	return mmp.TryLockWithTimeoutAndLease(key, timeout, timeoutTimeUnit, -1, time.Second)
+func (mmp *MultiMapProxy) TryLockWithTimeout(key interface{}, timeout time.Duration) (locked bool, err error) {
+	return mmp.TryLockWithTimeoutAndLease(key, timeout, -1)
 }
 
-func (mmp *MultiMapProxy) TryLockWithTimeoutAndLease(key interface{}, timeout int64, timeoutTimeUnit time.Duration, lease int64, leaseTimeUnit time.Duration) (locked bool, err error) {
+func (mmp *MultiMapProxy) TryLockWithTimeoutAndLease(key interface{}, timeout time.Duration, lease time.Duration) (locked bool, err error) {
 	keyData, err := mmp.validateAndSerialize(key)
 	if err != nil {
 		return false, err
 	}
-	timeout = common.GetTimeInMilliSeconds(timeout, timeoutTimeUnit)
-	lease = common.GetTimeInMilliSeconds(lease, leaseTimeUnit)
-	request := protocol.MultiMapTryLockEncodeRequest(mmp.name, keyData, threadId, lease, timeout, mmp.client.ProxyManager.nextReferenceId())
+	timeoutInMillis := common.GetTimeInMilliSeconds(timeout)
+	leaseInMillis := common.GetTimeInMilliSeconds(lease)
+	request := protocol.MultiMapTryLockEncodeRequest(mmp.name, keyData, threadId, leaseInMillis, timeoutInMillis, mmp.client.ProxyManager.nextReferenceId())
 	responseMessage, err := mmp.invokeOnKey(request, keyData)
 	return mmp.decodeToBoolAndError(responseMessage, err, protocol.MultiMapTryLockDecodeResponse)
 }

--- a/internal/partition.go
+++ b/internal/partition.go
@@ -24,7 +24,7 @@ import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
-const PartitionUpdateInterval time.Duration = 5
+const PartitionUpdateInterval = 5 * time.Second
 
 type partitionService struct {
 	client         *HazelcastClient
@@ -41,7 +41,7 @@ func newPartitionService(client *HazelcastClient) *partitionService {
 func (ps *partitionService) start() {
 	ps.doRefresh()
 	go func() {
-		ticker := time.NewTicker(PartitionUpdateInterval * time.Second)
+		ticker := time.NewTicker(PartitionUpdateInterval)
 		for {
 			select {
 			case <-ticker.C:

--- a/internal/protocol/core.go
+++ b/internal/protocol/core.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"fmt"
 	"reflect"
+	"time"
 
 	"github.com/hazelcast/hazelcast-go-client/core"
 	"github.com/hazelcast/hazelcast-go-client/internal/common"
@@ -192,15 +193,15 @@ type EntryView struct {
 	key                    interface{}
 	value                  interface{}
 	cost                   int64
-	creationTime           int64
-	expirationTime         int64
+	creationTime           time.Time
+	expirationTime         time.Time
 	hits                   int64
-	lastAccessTime         int64
-	lastStoredTime         int64
-	lastUpdateTime         int64
+	lastAccessTime         time.Time
+	lastStoredTime         time.Time
+	lastUpdateTime         time.Time
 	version                int64
 	evictionCriteriaNumber int64
-	ttl                    int64
+	ttl                    time.Duration
 }
 
 func NewEntryView(key interface{}, value interface{}, cost int64, creationTime int64, expirationTime int64, hits int64,
@@ -209,15 +210,15 @@ func NewEntryView(key interface{}, value interface{}, cost int64, creationTime i
 		key:                    key,
 		value:                  value,
 		cost:                   cost,
-		creationTime:           creationTime,
-		expirationTime:         expirationTime,
+		creationTime:           common.ConvertMillisToUnixTime(creationTime),
+		expirationTime:         common.ConvertMillisToUnixTime(expirationTime),
 		hits:                   hits,
-		lastAccessTime:         lastAccessTime,
-		lastStoredTime:         lastStoredTime,
-		lastUpdateTime:         lastUpdateTime,
+		lastAccessTime:         common.ConvertMillisToUnixTime(lastAccessTime),
+		lastStoredTime:         common.ConvertMillisToUnixTime(lastStoredTime),
+		lastUpdateTime:         common.ConvertMillisToUnixTime(lastUpdateTime),
 		version:                version,
 		evictionCriteriaNumber: evictionCriteriaNumber,
-		ttl: ttl,
+		ttl: common.ConvertMillisToDuration(ttl),
 	}
 }
 func (ev *EntryView) Key() interface{} {
@@ -232,11 +233,11 @@ func (ev *EntryView) Cost() int64 {
 	return ev.cost
 }
 
-func (ev *EntryView) CreationTime() int64 {
+func (ev *EntryView) CreationTime() time.Time {
 	return ev.creationTime
 }
 
-func (ev *EntryView) ExpirationTime() int64 {
+func (ev *EntryView) ExpirationTime() time.Time {
 	return ev.expirationTime
 }
 
@@ -244,15 +245,15 @@ func (ev *EntryView) Hits() int64 {
 	return ev.hits
 }
 
-func (ev *EntryView) LastAccessTime() int64 {
+func (ev *EntryView) LastAccessTime() time.Time {
 	return ev.lastAccessTime
 }
 
-func (ev *EntryView) LastStoredTime() int64 {
+func (ev *EntryView) LastStoredTime() time.Time {
 	return ev.lastStoredTime
 }
 
-func (ev *EntryView) LastUpdateTime() int64 {
+func (ev *EntryView) LastUpdateTime() time.Time {
 	return ev.lastUpdateTime
 }
 
@@ -264,7 +265,7 @@ func (ev *EntryView) EvictionCriteriaNumber() int64 {
 	return ev.evictionCriteriaNumber
 }
 
-func (ev *EntryView) Ttl() int64 {
+func (ev *EntryView) Ttl() time.Duration {
 	return ev.ttl
 }
 
@@ -501,14 +502,14 @@ func GetEntryListenerFlags(listener interface{}) int32 {
 
 type TopicMessage struct {
 	messageObject    interface{}
-	publishTime      int64
+	publishTime      time.Time
 	publishingMember *Member
 }
 
 func NewTopicMessage(messageObject interface{}, publishTime int64, publishingMember *Member) *TopicMessage {
 	return &TopicMessage{
 		messageObject:    messageObject,
-		publishTime:      publishTime,
+		publishTime:      common.ConvertMillisToUnixTime(publishTime),
 		publishingMember: publishingMember,
 	}
 }
@@ -517,7 +518,7 @@ func (m *TopicMessage) MessageObject() interface{} {
 	return m.messageObject
 }
 
-func (m *TopicMessage) PublishTime() int64 {
+func (m *TopicMessage) PublishTime() time.Time {
 	return m.publishTime
 }
 

--- a/internal/protocol/custom_codec.go
+++ b/internal/protocol/custom_codec.go
@@ -54,22 +54,7 @@ func MemberCodecDecode(msg *ClientMessage) *Member {
 	}
 	return &Member{*address, *uuid, liteMember, attributes}
 }
-func EntryViewCodecDecode(msg *ClientMessage) *EntryView {
-	entryView := EntryView{}
-	entryView.key = *msg.ReadData()
-	entryView.value = *msg.ReadData()
-	entryView.cost = msg.ReadInt64()
-	entryView.creationTime = msg.ReadInt64()
-	entryView.expirationTime = msg.ReadInt64()
-	entryView.hits = msg.ReadInt64()
-	entryView.lastAccessTime = msg.ReadInt64()
-	entryView.lastStoredTime = msg.ReadInt64()
-	entryView.lastUpdateTime = msg.ReadInt64()
-	entryView.version = msg.ReadInt64()
-	entryView.evictionCriteriaNumber = msg.ReadInt64()
-	entryView.ttl = msg.ReadInt64()
-	return &entryView
-}
+
 func DataEntryViewCodecDecode(msg *ClientMessage) *DataEntryView {
 	dataEntryView := DataEntryView{}
 	dataEntryView.keyData = msg.ReadData()

--- a/internal/queue.go
+++ b/internal/queue.go
@@ -126,12 +126,12 @@ func (qp *QueueProxy) Offer(item interface{}) (added bool, err error) {
 	return qp.decodeToBoolAndError(responseMessage, err, protocol.QueueOfferDecodeResponse)
 }
 
-func (qp *QueueProxy) OfferWithTimeout(item interface{}, timeout int64, timeoutUnit time.Duration) (added bool, err error) {
+func (qp *QueueProxy) OfferWithTimeout(item interface{}, timeout time.Duration) (added bool, err error) {
 	itemData, err := qp.validateAndSerialize(item)
 	if err != nil {
 		return false, err
 	}
-	timeoutInMilliSeconds := common.GetTimeInMilliSeconds(timeout, timeoutUnit)
+	timeoutInMilliSeconds := common.GetTimeInMilliSeconds(timeout)
 	request := protocol.QueueOfferEncodeRequest(qp.name, itemData, timeoutInMilliSeconds)
 	responseMessage, err := qp.invoke(request)
 	return qp.decodeToBoolAndError(responseMessage, err, protocol.QueueOfferDecodeResponse)
@@ -149,8 +149,8 @@ func (qp *QueueProxy) Poll() (item interface{}, err error) {
 	return qp.decodeToObjectAndError(responseMessage, err, protocol.QueuePollDecodeResponse)
 }
 
-func (qp *QueueProxy) PollWithTimeout(timeout int64, timeoutUnit time.Duration) (item interface{}, err error) {
-	timeoutInMilliSeconds := common.GetTimeInMilliSeconds(timeout, timeoutUnit)
+func (qp *QueueProxy) PollWithTimeout(timeout time.Duration) (item interface{}, err error) {
+	timeoutInMilliSeconds := common.GetTimeInMilliSeconds(timeout)
 	request := protocol.QueuePollEncodeRequest(qp.name, timeoutInMilliSeconds)
 	responseMessage, err := qp.invoke(request)
 	return qp.decodeToObjectAndError(responseMessage, err, protocol.QueuePollDecodeResponse)

--- a/internal/replicated_map.go
+++ b/internal/replicated_map.go
@@ -35,15 +35,16 @@ func newReplicatedMapProxy(client *HazelcastClient, serviceName *string, name *s
 	return &ReplicatedMapProxy{proxy: &proxy{client, serviceName, name}, targetPartitionId: targetPartitionId}, nil
 }
 func (rmp *ReplicatedMapProxy) Put(key interface{}, value interface{}) (oldValue interface{}, err error) {
-	return rmp.PutWithTtl(key, value, ttlUnlimited, time.Second)
+	return rmp.PutWithTtl(key, value, ttlUnlimited)
 }
 
-func (rmp *ReplicatedMapProxy) PutWithTtl(key interface{}, value interface{}, ttl int64, ttlTimeUnit time.Duration) (oldValue interface{}, err error) {
+func (rmp *ReplicatedMapProxy) PutWithTtl(key interface{}, value interface{}, ttl time.Duration) (oldValue interface{}, err error) {
 	keyData, valueData, err := rmp.validateAndSerialize2(key, value)
 	if err != nil {
 		return nil, err
 	}
-	request := protocol.ReplicatedMapPutEncodeRequest(rmp.name, keyData, valueData, ttl)
+	ttlInMillis := common.GetTimeInMilliSeconds(ttl)
+	request := protocol.ReplicatedMapPutEncodeRequest(rmp.name, keyData, valueData, ttlInMillis)
 	responseMessage, err := rmp.invokeOnKey(request, keyData)
 	return rmp.decodeToObjectAndError(responseMessage, err, protocol.ReplicatedMapPutDecodeResponse)
 }

--- a/samples/org_website_samples/queue_sample.go
+++ b/samples/org_website_samples/queue_sample.go
@@ -32,8 +32,8 @@ func queueSampleRun() {
 	// Poll the Distributed Queue and return the String
 	queue.Poll()
 	//Timed blocking Operations
-	queue.OfferWithTimeout("anotheritem", 500, time.Millisecond)
-	queue.PollWithTimeout(5, time.Second)
+	queue.OfferWithTimeout("anotheritem", 500*time.Millisecond)
+	queue.PollWithTimeout(5 * time.Second)
 	//Indefinitely blocking Operations
 	queue.Put("yetanotheritem")
 	fmt.Println(queue.Take())

--- a/samples/topic/topic_example.go
+++ b/samples/topic/topic_example.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"strconv"
 	"sync"
-	"time"
 
 	"github.com/hazelcast/hazelcast-go-client"
 	"github.com/hazelcast/hazelcast-go-client/core"
@@ -61,6 +60,6 @@ type topicMessageListener struct {
 
 func (l *topicMessageListener) OnMessage(message core.ITopicMessage) {
 	fmt.Println("Got message: ", message.MessageObject())
-	fmt.Println("Publishing Time: ", time.Unix(0, message.PublishTime()*int64(time.Millisecond)))
+	fmt.Println("Publishing Time: ", message.PublishTime())
 	l.wg.Done()
 }

--- a/tests/heartbeat_test.go
+++ b/tests/heartbeat_test.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/hazelcast/hazelcast-go-client"
 	"github.com/hazelcast/hazelcast-go-client/internal"
@@ -36,14 +37,14 @@ func (l *heartbeatListener) OnHeartbeatStopped(connection *internal.Connection) 
 }
 
 func TestHeartbeatStoppedForConnection(t *testing.T) {
-	var wg *sync.WaitGroup = new(sync.WaitGroup)
+	var wg = new(sync.WaitGroup)
 	cluster, _ = remoteController.CreateCluster("3.9", DefaultServerConfig)
 	heartbeatListener := &heartbeatListener{wg: wg}
 	member, _ := remoteController.StartMember(cluster.ID)
 	config := hazelcast.NewHazelcastConfig()
 	config.ClientNetworkConfig().SetConnectionAttemptLimit(100)
-	config.SetHeartbeatIntervalInSeconds(3)
-	config.SetHeartbeatTimeoutInSeconds(5)
+	config.SetHeartbeatInterval(3 * time.Second)
+	config.SetHeartbeatTimeout(5 * time.Second)
 	client, _ := hazelcast.NewHazelcastClientWithConfig(config)
 	wg.Add(1)
 	client.(*internal.HazelcastClient).HeartBeatService.AddHeartbeatListener(heartbeatListener)

--- a/tests/invocation_test.go
+++ b/tests/invocation_test.go
@@ -68,7 +68,7 @@ func TestInvocationTimeout(t *testing.T) {
 	member1, _ := remoteController.StartMember(cluster.ID)
 	config := hazelcast.NewHazelcastConfig()
 	config.ClientNetworkConfig().SetRedoOperation(true).SetConnectionAttemptLimit(100)
-	config.ClientNetworkConfig().SetInvocationTimeoutInSeconds(5)
+	config.ClientNetworkConfig().SetInvocationTimeout(5 * time.Second)
 	client, _ := hazelcast.NewHazelcastClientWithConfig(config)
 	mp, _ := client.GetMap("testMap")
 	remoteController.ShutdownMember(cluster.ID, member1.UUID)
@@ -126,7 +126,7 @@ func TestInvocationNotSent(t *testing.T) {
 	member, _ := remoteController.StartMember(cluster.ID)
 	config := hazelcast.NewHazelcastConfig()
 	config.ClientNetworkConfig().SetRedoOperation(true).SetConnectionAttemptLimit(100).
-		SetInvocationTimeoutInSeconds(10).SetConnectionAttemptPeriod(1)
+		SetInvocationTimeout(10 * time.Second).SetConnectionAttemptPeriod(1 * time.Second)
 	client, _ := hazelcast.NewHazelcastClientWithConfig(config)
 	mp, _ := client.GetMap("testMap")
 	wg.Add(50)

--- a/tests/lifecycle_test.go
+++ b/tests/lifecycle_test.go
@@ -57,7 +57,7 @@ func TestLifecycleListenerForDisconnected(t *testing.T) {
 	remoteController.StartMember(cluster.ID)
 	wg.Add(1)
 	config := hazelcast.NewHazelcastConfig()
-	config.ClientNetworkConfig().SetConnectionAttemptLimit(10)
+	config.ClientNetworkConfig().SetConnectionAttemptLimit(100)
 	client, _ := hazelcast.NewHazelcastClientWithConfig(config)
 	registrationId := client.(*internal.HazelcastClient).LifecycleService.AddListener(&lifecycleListener)
 	remoteController.ShutdownCluster(cluster.ID)

--- a/tests/proxy/map/map_member_down/map_member_down_test.go
+++ b/tests/proxy/map/map_member_down/map_member_down_test.go
@@ -130,7 +130,7 @@ func TestMapLockWhenMemberDown(t *testing.T) {
 }
 
 func TestMapLockWithLeaseTimeWhenMemberDown(t *testing.T) {
-	err := mp.LockWithLeaseTime("key", 3, time.Second)
+	err := mp.LockWithLeaseTime("key", 3*time.Second)
 	AssertErrorNotNil(t, err, "lockWithLeaseTime should have returned an error when member is down")
 }
 
@@ -160,7 +160,7 @@ func TestMapSetWhenMemberDown(t *testing.T) {
 }
 
 func TestMapSetWithTtlWhenMemberDown(t *testing.T) {
-	err := mp.SetWithTtl("key", "value", 2, time.Second)
+	err := mp.SetWithTtl("key", "value", 2*time.Second)
 	AssertErrorNotNil(t, err, "setWithTtl should have returned an error when member is down")
 }
 
@@ -212,12 +212,12 @@ func TestMapTryLockWhenMemberDown(t *testing.T) {
 }
 
 func TestMapTryLockWithTimeoutWhenMemberDown(t *testing.T) {
-	_, err := mp.TryLockWithTimeout("key", 1, time.Second)
+	_, err := mp.TryLockWithTimeout("key", 1*time.Second)
 	AssertErrorNotNil(t, err, "tryLockWithTimeout should have returned an error when member is down")
 }
 
 func TestMapTryLockWithTimeoutAndLeaseWhenMemberDown(t *testing.T) {
-	_, err := mp.TryLockWithTimeoutAndLease("key", 2, time.Second, 2, time.Second)
+	_, err := mp.TryLockWithTimeoutAndLease("key", 2*time.Second, 2*time.Second)
 	AssertErrorNotNil(t, err, "tryLockWithTimeoutAndLease should have returned an error when member is down")
 }
 
@@ -227,7 +227,7 @@ func TestMapTryPutWhenMemberDown(t *testing.T) {
 }
 
 func TestMapTryRemoveWhenMemberDown(t *testing.T) {
-	_, err := mp.TryRemove("key", 2, time.Second)
+	_, err := mp.TryRemove("key", 2*time.Second)
 	AssertErrorNotNil(t, err, "tryRemove should have returned an error when member is down")
 }
 
@@ -244,7 +244,7 @@ func TestMapGetEntryViewWhenMemberDown(t *testing.T) {
 }
 
 func TestMapPutTransientWhenMemberDown(t *testing.T) {
-	err := mp.PutTransient("key", "value", 2, time.Second)
+	err := mp.PutTransient("key", "value", 2*time.Second)
 	AssertErrorNotNil(t, err, "putTransient should have returned an error when member is down")
 }
 

--- a/tests/proxy/map/map_test.go
+++ b/tests/proxy/map/map_test.go
@@ -116,7 +116,7 @@ func TestMapProxy_GetWithNilKey(t *testing.T) {
 
 func TestMapProxy_TryRemove(t *testing.T) {
 	mp.Put("testKey", "testValue")
-	_, err := mp.TryRemove("testKey", 5, time.Second)
+	_, err := mp.TryRemove("testKey", 5*time.Second)
 	if err != nil {
 		t.Fatal("tryRemove failed ", err)
 	}
@@ -124,7 +124,7 @@ func TestMapProxy_TryRemove(t *testing.T) {
 }
 
 func TestMapProxy_TryRemoveWithNilKey(t *testing.T) {
-	_, err := mp.TryRemove(nil, 1, time.Second)
+	_, err := mp.TryRemove(nil, 1*time.Second)
 	AssertErrorNotNil(t, err, "remove did not return an error for nil key")
 	mp.Clear()
 }
@@ -239,7 +239,7 @@ func TestMapProxy_PutTransient(t *testing.T) {
 	testKey := "testingKey"
 	testValue := "testingValue"
 	mp.Put(testKey, testValue)
-	mp.PutTransient(testKey, "nextValue", 100, time.Second)
+	mp.PutTransient(testKey, "nextValue", 100*time.Second)
 	res, err := mp.Get(testKey)
 	AssertEqualf(t, err, res, "nextValue", "putTransient failed")
 	mp.Clear()
@@ -250,7 +250,7 @@ func TestMapProxy_PutTransientWhenExpire(t *testing.T) {
 	testKey := "testingKey"
 	testValue := "testingValue"
 	mp.Put(testKey, testValue)
-	mp.PutTransient(testKey, "nextValue", 1, time.Millisecond)
+	mp.PutTransient(testKey, "nextValue", 1*time.Millisecond)
 	time.Sleep(5 * time.Second)
 	res, err := mp.Get(testKey)
 	AssertNilf(t, err, res, "putTransient failed")
@@ -260,14 +260,14 @@ func TestMapProxy_PutTransientWhenExpire(t *testing.T) {
 
 func TestMapProxy_PutTransientWithNilKey(t *testing.T) {
 	testValue := "testingValue"
-	err := mp.PutTransient(nil, testValue, 1, time.Millisecond)
+	err := mp.PutTransient(nil, testValue, 1*time.Millisecond)
 	AssertErrorNotNil(t, err, "putTransient did not return an error for nil key")
 	mp.Clear()
 }
 
 func TestMapProxy_PutTransientWithNilValue(t *testing.T) {
 	testKey := "testingKey"
-	err := mp.PutTransient(testKey, nil, 1, time.Millisecond)
+	err := mp.PutTransient(testKey, nil, 1*time.Millisecond)
 	AssertErrorNotNil(t, err, "putTransient did not return an error for nil value")
 	mp.Clear()
 }
@@ -414,7 +414,7 @@ func TestMapProxy_UnlockWithNilKey(t *testing.T) {
 
 func TestMapProxy_LockWithLeaseTime(t *testing.T) {
 	mp.Put("testingKey", "testingValue")
-	mp.LockWithLeaseTime("testingKey", 10, time.Millisecond)
+	mp.LockWithLeaseTime("testingKey", 10*time.Millisecond)
 	time.Sleep(5 * time.Second)
 	locked, err := mp.IsLocked("testingKey")
 	AssertEqualf(t, err, locked, false, "Key should not be locked.")
@@ -428,7 +428,7 @@ func TestMapProxy_LocktWithNilKey(t *testing.T) {
 
 func TestMapProxy_TryLock(t *testing.T) {
 	mp.Put("testingKey", "testingValue")
-	ok, err := mp.TryLockWithTimeoutAndLease("testingKey", 1, time.Second, 2, time.Second)
+	ok, err := mp.TryLockWithTimeoutAndLease("testingKey", 1*time.Second, 2*time.Second)
 	AssertEqualf(t, err, ok, true, "Try Lock failed")
 	time.Sleep(5 * time.Second)
 	locked, err := mp.IsLocked("testingKey")
@@ -451,7 +451,7 @@ func TestMapProxy_TryLockWithNilKey(t *testing.T) {
 
 func TestMapProxy_ForceUnlock(t *testing.T) {
 	mp.Put("testingKey", "testingValue")
-	ok, err := mp.TryLockWithTimeoutAndLease("testingKey", 1, time.Second, 20, time.Second)
+	ok, err := mp.TryLockWithTimeoutAndLease("testingKey", 1*time.Second, 20*time.Second)
 	AssertEqualf(t, err, ok, true, "Try Lock failed")
 	mp.ForceUnlock("testingKey")
 	locked, err := mp.IsLocked("testingKey")
@@ -549,13 +549,13 @@ func TestMapProxy_SetWithNilValue(t *testing.T) {
 }
 
 func TestMapProxy_SetWithTtl(t *testing.T) {
-	err := mp.SetWithTtl("testingKey1", "testingValue1", 0, time.Second)
+	err := mp.SetWithTtl("testingKey1", "testingValue1", 0*time.Second)
 	if err != nil {
 		t.Error(err)
 	}
 	newValue, err := mp.Get("testingKey1")
 	AssertEqualf(t, err, newValue, "testingValue1", "Map SetWithTtl failed.")
-	mp.SetWithTtl("testingKey1", "testingValue2", 1, time.Millisecond)
+	mp.SetWithTtl("testingKey1", "testingValue2", 1*time.Millisecond)
 	time.Sleep(5 * time.Second)
 	newValue, err = mp.Get("testingKey1")
 	AssertNilf(t, err, newValue, "Map SetWithTtl failed.")
@@ -775,22 +775,22 @@ func TestMapProxy_GetEntryView(t *testing.T) {
 	if cost := entryView.Cost(); cost <= 0 {
 		t.Fatal("entryView cost should be greater than 0.")
 	}
-	if creationTime := entryView.CreationTime(); creationTime <= 0 {
+	if creationTime := entryView.CreationTime(); !creationTime.After(time.Time{}) {
 		t.Fatal("entryView creationTime should be greater than 0.")
 	}
-	if expirationTime := entryView.ExpirationTime(); expirationTime <= 0 {
+	if expirationTime := entryView.ExpirationTime(); !expirationTime.After(time.Time{}) {
 		t.Fatal("entryView expirationTime should be greater than 0.")
 	}
-	if lastAccessTime := entryView.LastAccessTime(); lastAccessTime <= 0 {
+	if lastAccessTime := entryView.LastAccessTime(); !lastAccessTime.After(time.Time{}) {
 		t.Fatal("entryView lastAccessTime should be greater than 0.")
 	}
-	if lastUpdateTime := entryView.LastUpdateTime(); lastUpdateTime <= 0 {
+	if lastUpdateTime := entryView.LastUpdateTime(); !lastUpdateTime.After(time.Time{}) {
 		t.Fatal("entryView lastUpdateTime should be greater than 0.")
 	}
 	if ttl := entryView.Ttl(); ttl <= 0 {
 		t.Fatal("entryView ttl should be greater than 0.")
 	}
-	AssertEqualf(t, err, entryView.LastStoredTime(), int64(0), "Map GetEntryView returned a wrong view.")
+	AssertEqualf(t, err, entryView.LastStoredTime(), time.Time{}, "Map GetEntryView returned a wrong view.")
 	mp.Clear()
 }
 
@@ -1179,13 +1179,13 @@ func TestMapProxy_TryPutWithNonSerializableValue(t *testing.T) {
 }
 
 func TestMapProxy_PutTransientWithNonSerializableKey(t *testing.T) {
-	err := mp.PutTransient(student{}, "test", 1, time.Second)
+	err := mp.PutTransient(student{}, "test", 1*time.Second)
 	AssertErrorNotNil(t, err, "putTransient did not return an error for nonserializable key")
 	mp.Clear()
 }
 
 func TestMapProxy_PutTransientWithNonSerializableValue(t *testing.T) {
-	err := mp.PutTransient("test", student{}, 1, time.Second)
+	err := mp.PutTransient("test", student{}, 1*time.Second)
 	AssertErrorNotNil(t, err, "putTransient did not return an error for nonserializable value")
 	mp.Clear()
 }
@@ -1209,7 +1209,7 @@ func TestMapProxy_RemoveIfSameWithNonSerializableValue(t *testing.T) {
 }
 
 func TestMapProxy_TryRemoveWithNonSerializableKey(t *testing.T) {
-	_, err := mp.TryRemove(student{}, 1, time.Second)
+	_, err := mp.TryRemove(student{}, 1*time.Second)
 	AssertErrorNotNil(t, err, "tryRemove did not return an error for nonserializable key")
 	mp.Clear()
 }

--- a/tests/proxy/multi_map/multi_map_test.go
+++ b/tests/proxy/multi_map/multi_map_test.go
@@ -316,7 +316,7 @@ func TestMultiMapProxy_EntryListenerToKey(t *testing.T) {
 func TestMultiMapProxy_LockWithLeaseTime(t *testing.T) {
 	defer multiMap.Clear()
 	multiMap.Put(testKey, testValue)
-	multiMap.LockWithLeaseTime(testKey, 10, time.Millisecond)
+	multiMap.LockWithLeaseTime(testKey, 10*time.Millisecond)
 	time.Sleep(5 * time.Second)
 	locked, err := multiMap.IsLocked(testKey)
 	AssertEqualf(t, err, locked, false, "multiMap LockWithLeaseTime() failed.")
@@ -325,14 +325,14 @@ func TestMultiMapProxy_LockWithLeaseTime(t *testing.T) {
 func TestMultiMapProxy_LockWithLeaseTimeWithNilKey(t *testing.T) {
 	defer multiMap.Clear()
 	multiMap.Put(testKey, testValue)
-	err := multiMap.LockWithLeaseTime(nil, 10, time.Millisecond)
+	err := multiMap.LockWithLeaseTime(nil, 10*time.Millisecond)
 	AssertErrorNotNil(t, err, "multiMap LockWithLeaseTime() failed ")
 }
 
 func TestMultiMapProxy_Lock(t *testing.T) {
 	defer multiMap.Clear()
 	multiMap.Put(testKey, testValue)
-	multiMap.LockWithLeaseTime(testKey, 10, time.Millisecond)
+	multiMap.LockWithLeaseTime(testKey, 10*time.Millisecond)
 	time.Sleep(5 * time.Second)
 	locked, err := multiMap.IsLocked(testKey)
 	AssertEqualf(t, err, locked, false, "multiMap Lock() failed.")
@@ -367,7 +367,7 @@ func TestMultiMapProxy_IsLockedWithNilKey(t *testing.T) {
 func TestMultiMapProxy_TryLock(t *testing.T) {
 	defer multiMap.Clear()
 	multiMap.Put(testKey, testValue)
-	ok, err := multiMap.TryLockWithTimeoutAndLease(testKey, 1, time.Second, 2, time.Second)
+	ok, err := multiMap.TryLockWithTimeoutAndLease(testKey, 1*time.Second, 2*time.Second)
 	AssertEqualf(t, err, ok, true, "multiMap TryLock() failed.")
 	time.Sleep(5 * time.Second)
 	locked, err := multiMap.IsLocked(testKey)
@@ -378,14 +378,14 @@ func TestMultiMapProxy_TryLock(t *testing.T) {
 func TestMultiMapProxy_TryLockWithNilKey(t *testing.T) {
 	defer multiMap.Clear()
 	multiMap.Put(testKey, testValue)
-	_, err := multiMap.TryLockWithTimeoutAndLease(nil, 1, time.Second, 2, time.Second)
+	_, err := multiMap.TryLockWithTimeoutAndLease(nil, 1*time.Second, 2*time.Second)
 	AssertErrorNotNil(t, err, "multiMap TryLock() failed")
 }
 
 func TestMultiMapProxy_ForceUnlock(t *testing.T) {
 	defer multiMap.Clear()
 	multiMap.Put(testKey, testValue)
-	ok, err := multiMap.TryLockWithTimeoutAndLease(testKey, 1, time.Second, 20, time.Second)
+	ok, err := multiMap.TryLockWithTimeoutAndLease(testKey, 1*time.Second, 20*time.Second)
 	AssertEqualf(t, err, ok, true, "multiMap ForceUnLock() failed.")
 	multiMap.ForceUnlock(testKey)
 	locked, err := multiMap.IsLocked(testKey)

--- a/tests/proxy/queue/queue_test.go
+++ b/tests/proxy/queue/queue_test.go
@@ -165,7 +165,7 @@ func TestQueueProxy_OfferWithNilElement(t *testing.T) {
 
 func TestQueueProxy_OfferWithTimeout(t *testing.T) {
 	defer queue.Clear()
-	changed, err := queue.OfferWithTimeout(testElement, 0, time.Millisecond)
+	changed, err := queue.OfferWithTimeout(testElement, 0)
 	AssertEqualf(t, err, changed, true, "queue Offer() failed")
 	result, err := queue.Peek()
 	AssertEqualf(t, err, result, testElement, "queue Offer() failed")
@@ -175,13 +175,13 @@ func TestQueueProxy_OfferWithTimeoutWithFullCapacity(t *testing.T) {
 	defer queue.Clear()
 	all := []interface{}{"1", "2", "3", "4", "5", "6"}
 	queue.AddAll(all)
-	changed, err := queue.OfferWithTimeout(testElement, 1000, time.Millisecond)
+	changed, err := queue.OfferWithTimeout(testElement, 100*time.Millisecond)
 	AssertEqualf(t, err, changed, false, "queue Offer() failed with full capacity")
 }
 
 func TestQueueProxy_OfferWithTimeoutWithNilElement(t *testing.T) {
 	defer queue.Clear()
-	_, err := queue.OfferWithTimeout(nil, 0, time.Millisecond)
+	_, err := queue.OfferWithTimeout(nil, 0)
 	AssertErrorNotNil(t, err, "queue OfferWithTimeout() should return error for nil element")
 }
 
@@ -214,13 +214,13 @@ func TestQueueProxy_PollEmpty(t *testing.T) {
 func TestQueueProxy_PollWithTimeout(t *testing.T) {
 	defer queue.Clear()
 	queue.Put(testElement)
-	item, err := queue.PollWithTimeout(1000, time.Millisecond)
+	item, err := queue.PollWithTimeout(1000 * time.Millisecond)
 	AssertEqualf(t, err, item, testElement, "queue PollWithTimeout() failed")
 }
 
 func TestQueueProxy_PollWithTimeoutEmpty(t *testing.T) {
 	defer queue.Clear()
-	item, err := queue.PollWithTimeout(1000, time.Millisecond)
+	item, err := queue.PollWithTimeout(1000 * time.Millisecond)
 	AssertEqualf(t, err, item, nil, "queue PollWithTimeout() failed")
 }
 

--- a/tests/proxy/replicated_map/replicated_map_test.go
+++ b/tests/proxy/replicated_map/replicated_map_test.go
@@ -89,7 +89,7 @@ func TestReplicatedMapProxy_PutWithTtl(t *testing.T) {
 	testKey := "testingKey"
 	testValue := "testingValue"
 	rmp.Put(testKey, testValue)
-	oldValue, err := rmp.PutWithTtl(testKey, "nextValue", 100, time.Second)
+	oldValue, err := rmp.PutWithTtl(testKey, "nextValue", 100*time.Second)
 	AssertEqualf(t, err, oldValue, testValue, "replicatedMap PutWithTtl()  failed")
 	res, err := rmp.Get(testKey)
 	AssertEqualf(t, err, res, "nextValue", "replicatedMap PutWithTtl() failed")
@@ -98,14 +98,14 @@ func TestReplicatedMapProxy_PutWithTtl(t *testing.T) {
 func TestReplicatedMapProxy_PutWithTtlWithNilKey(t *testing.T) {
 	defer rmp.Clear()
 	testValue := "testingValue"
-	_, err := rmp.PutWithTtl(nil, testValue, 100, time.Second)
+	_, err := rmp.PutWithTtl(nil, testValue, 100*time.Second)
 	AssertErrorNotNil(t, err, "replicatedMap PutWithTtl() failed")
 }
 
 func TestReplicatedMapProxy_PutWithTtlWithNilValue(t *testing.T) {
 	defer rmp.Clear()
 	testKey := "testingKey"
-	_, err := rmp.PutWithTtl(testKey, nil, 100, time.Second)
+	_, err := rmp.PutWithTtl(testKey, nil, 100*time.Second)
 	AssertErrorNotNil(t, err, "replicatedMap PutWithTtl() failed")
 }
 
@@ -114,7 +114,7 @@ func TestMapProxy_PutWithTtlWhenExpire(t *testing.T) {
 	testKey := "testingKey"
 	testValue := "testingValue"
 	rmp.Put(testKey, testValue)
-	rmp.PutWithTtl(testKey, "nextValue", 1, time.Millisecond)
+	rmp.PutWithTtl(testKey, "nextValue", 1*time.Millisecond)
 	time.Sleep(2 * time.Second)
 	res, err := rmp.Get(testKey)
 	AssertNilf(t, err, res, "replicatedMap PutWithTtl() failed")

--- a/tests/proxy/topic/topic_test.go
+++ b/tests/proxy/topic/topic_test.go
@@ -18,6 +18,7 @@ import (
 	"log"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/hazelcast/hazelcast-go-client"
 	"github.com/hazelcast/hazelcast-go-client/core"
@@ -53,7 +54,7 @@ func TestTopicProxy_AddListener(t *testing.T) {
 	timeout := WaitTimeout(wg, Timeout)
 	AssertEqualf(t, nil, false, timeout, "topic AddListener() failed")
 	AssertEqualf(t, nil, listener.msg, "item-value", "topic AddListener() failed")
-	if listener.publishTime == 0 {
+	if !listener.publishTime.After(time.Time{}) {
 		t.Fatal("publishTime should be greater than 0")
 	}
 }
@@ -74,7 +75,7 @@ func TestTopicProxy_RemoveListener(t *testing.T) {
 type topicMessageListener struct {
 	wg          *sync.WaitGroup
 	msg         interface{}
-	publishTime int64
+	publishTime time.Time
 }
 
 func (l *topicMessageListener) OnMessage(message core.ITopicMessage) {


### PR DESCRIPTION
To represent fix time in point time.Time
To represent a duration time.Duration is used. 

Internal usages where duration used with wrong resolution is also fixed.