### PR TITLE
close channels after a shutdown

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -165,9 +165,12 @@ func (c *HazelcastClient) init() error {
 func (c *HazelcastClient) Shutdown() {
 	if c.LifecycleService.isLive.Load().(bool) {
 		c.LifecycleService.fireLifecycleEvent(LifecycleStateShuttingDown)
+		c.ConnectionManager.shutdown()
 		c.PartitionService.shutdown()
+		c.ClusterService.shutdown()
 		c.InvocationService.shutdown()
 		c.HeartBeatService.shutdown()
+		c.ListenerService.shutdown()
 		c.LifecycleService.fireLifecycleEvent(LifecycleStateShutdown)
 	}
 }

--- a/internal/cluster.go
+++ b/internal/cluster.go
@@ -382,3 +382,7 @@ func (cs *clusterService) onConnectionClosed(connection *Connection, cause error
 func (cs *clusterService) onConnectionOpened(connection *Connection) {
 
 }
+
+func (cs *clusterService) shutdown() {
+	close(cs.reconnectChan)
+}

--- a/internal/connection_manager.go
+++ b/internal/connection_manager.go
@@ -221,6 +221,13 @@ func (cm *connectionManager) fireConnectionAddedEvent(connection *Connection) {
 	}
 }
 
+func (cm *connectionManager) shutdown() {
+	activeCons := cm.getActiveConnections()
+	for _, con := range activeCons {
+		con.close(core.NewHazelcastClientNotActiveError("client is shutting down", nil))
+	}
+}
+
 type connectionListener interface {
 	onConnectionClosed(connection *Connection, cause error)
 	onConnectionOpened(connection *Connection)

--- a/internal/invocation.go
+++ b/internal/invocation.go
@@ -35,7 +35,6 @@ type invocation struct {
 	request                 *protocol.ClientMessage
 	partitionID             int32
 	response                chan *protocol.ClientMessage
-	closed                  chan bool
 	err                     chan error
 	done                    chan bool
 	eventHandler            func(clientMessage *protocol.ClientMessage)
@@ -63,7 +62,6 @@ func newInvocation(request *protocol.ClientMessage, partitionID int32, address *
 		boundConnection: connection,
 		response:        make(chan *protocol.ClientMessage, 10),
 		err:             make(chan error, 1),
-		closed:          make(chan bool, 1),
 		done:            make(chan bool, 1),
 		timeout:         time.After(client.ClientConfig.ClientNetworkConfig().InvocationTimeout()),
 	}
@@ -263,7 +261,6 @@ func (is *invocationService) sendToConnection(invocation *invocation, connection
 		is.notSentMessages <- invocation.request.CorrelationID()
 	} else {
 		invocation.sentConnection = connection
-		invocation.closed = connection.closed
 	}
 
 }

--- a/tests/client_test.go
+++ b/tests/client_test.go
@@ -17,6 +17,12 @@ package tests
 import (
 	"testing"
 
+	"time"
+
+	"runtime"
+
+	"log"
+
 	"github.com/hazelcast/hazelcast-go-client"
 	"github.com/hazelcast/hazelcast-go-client/tests/assert"
 )
@@ -29,4 +35,39 @@ func TestClientGetMapWhenNoMemberUp(t *testing.T) {
 	_, err := client.GetMap("map")
 	assert.ErrorNotNil(t, err, "getMap should have returned an error when no member is up")
 	client.Shutdown()
+}
+
+func TestClientShutdownAndReopen(t *testing.T) {
+	cluster, err := remoteController.CreateCluster("", DefaultServerConfig)
+	log.Println(err, cluster)
+	defer remoteController.ShutdownCluster(cluster.ID)
+	remoteController.StartMember(cluster.ID)
+	client, _ := hazelcast.NewHazelcastClient()
+	testMp, _ := client.GetMap("test")
+	testMp.Put("key", "value")
+	client.Shutdown()
+	time.Sleep(2 * time.Second)
+
+	client, _ = hazelcast.NewHazelcastClient()
+	testMp, _ = client.GetMap("test")
+	value, err := testMp.Get("key")
+	assert.Equalf(t, err, value, "value", "Client shutdown and reopen failed")
+	client.Shutdown()
+}
+
+func TestClientRoutineLeakage(t *testing.T) {
+	cluster, _ := remoteController.CreateCluster("", DefaultServerConfig)
+	remoteController.StartMember(cluster.ID)
+	defer remoteController.ShutdownCluster(cluster.ID)
+	time.Sleep(2 * time.Second)
+	routineNumBefore := runtime.NumGoroutine()
+	client, _ := hazelcast.NewHazelcastClient()
+	testMp, _ := client.GetMap("test")
+	testMp.Put("key", "value")
+	client.Shutdown()
+	time.Sleep(4 * time.Second)
+	routineNumAfter := runtime.NumGoroutine()
+	if routineNumBefore != routineNumAfter {
+		t.Fatalf("Expected number of routines %d, found %d", routineNumBefore, routineNumAfter)
+	}
 }


### PR DESCRIPTION
After a client shutdown some of the channels were not closed so they would cause some routines to leak. This pr adds shutdowns for some services. 

This pr also adds a method to `connectionManager` to close active connections during a shutdown.

`chan bool` is changed to `chan struct{}` as it is more convenient since we wont be sending anything when sending a close signal.

In `connection read()`  method we set a timeout for reading and if reading is not possible within that period we check if connection was closed, if so then we terminate the read go routine.
Fixes #242. 