### PR TITLE
remove server version when creating a cluster from rc

### DIFF
--- a/tests/client_test.go
+++ b/tests/client_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestClientGetMapWhenNoMemberUp(t *testing.T) {
-	cluster, _ = remoteController.CreateCluster("3.9", DefaultServerConfig)
+	cluster, _ = remoteController.CreateCluster("", DefaultServerConfig)
 	remoteController.StartMember(cluster.ID)
 	client, _ := hazelcast.NewHazelcastClient()
 	remoteController.ShutdownCluster(cluster.ID)

--- a/tests/cluster_test.go
+++ b/tests/cluster_test.go
@@ -54,7 +54,7 @@ func TestMain(m *testing.M) {
 
 func TestInitialMembershipListener(t *testing.T) {
 	var wg = new(sync.WaitGroup)
-	cluster, _ = remoteController.CreateCluster("3.9", DefaultServerConfig)
+	cluster, _ = remoteController.CreateCluster("", DefaultServerConfig)
 	remoteController.StartMember(cluster.ID)
 	config := hazelcast.NewHazelcastConfig()
 	config.AddMembershipListener(&membershipListener{wg: wg})
@@ -68,7 +68,7 @@ func TestInitialMembershipListener(t *testing.T) {
 
 func TestMemberAddedandRemoved(t *testing.T) {
 	var wg = new(sync.WaitGroup)
-	cluster, _ = remoteController.CreateCluster("3.9", DefaultServerConfig)
+	cluster, _ = remoteController.CreateCluster("", DefaultServerConfig)
 	remoteController.StartMember(cluster.ID)
 	config := hazelcast.NewHazelcastConfig()
 	config.AddMembershipListener(&membershipListener{wg: wg})
@@ -90,7 +90,7 @@ func TestMemberAddedandRemoved(t *testing.T) {
 
 func TestAddListener(t *testing.T) {
 	var wg = new(sync.WaitGroup)
-	cluster, _ = remoteController.CreateCluster("3.9", DefaultServerConfig)
+	cluster, _ = remoteController.CreateCluster("", DefaultServerConfig)
 	remoteController.StartMember(cluster.ID)
 	client, _ := hazelcast.NewHazelcastClient()
 	wg.Add(1)
@@ -115,7 +115,7 @@ func TestAddListener(t *testing.T) {
 
 func TestAddListeners(t *testing.T) {
 	var wg = new(sync.WaitGroup)
-	cluster, _ = remoteController.CreateCluster("3.9", DefaultServerConfig)
+	cluster, _ = remoteController.CreateCluster("", DefaultServerConfig)
 	remoteController.StartMember(cluster.ID)
 	client, _ := hazelcast.NewHazelcastClient()
 	wg.Add(2)
@@ -131,7 +131,7 @@ func TestAddListeners(t *testing.T) {
 }
 
 func TestGetMembers(t *testing.T) {
-	cluster, _ = remoteController.CreateCluster("3.9", DefaultServerConfig)
+	cluster, _ = remoteController.CreateCluster("", DefaultServerConfig)
 	member1, _ := remoteController.StartMember(cluster.ID)
 	member2, _ := remoteController.StartMember(cluster.ID)
 	member3, _ := remoteController.StartMember(cluster.ID)
@@ -150,7 +150,7 @@ func TestGetMembers(t *testing.T) {
 }
 
 func TestGetMember(t *testing.T) {
-	cluster, _ = remoteController.CreateCluster("3.9", DefaultServerConfig)
+	cluster, _ = remoteController.CreateCluster("", DefaultServerConfig)
 	member1, _ := remoteController.StartMember(cluster.ID)
 	member2, _ := remoteController.StartMember(cluster.ID)
 	client, _ := hazelcast.NewHazelcastClient()
@@ -164,7 +164,7 @@ func TestGetMember(t *testing.T) {
 }
 
 func TestGetInvalidMember(t *testing.T) {
-	cluster, _ = remoteController.CreateCluster("3.9", DefaultServerConfig)
+	cluster, _ = remoteController.CreateCluster("", DefaultServerConfig)
 	member1, _ := remoteController.StartMember(cluster.ID)
 	client, _ := hazelcast.NewHazelcastClient()
 	address := protocol.NewAddressWithParameters(member1.GetHost(), 0)
@@ -176,7 +176,7 @@ func TestGetInvalidMember(t *testing.T) {
 }
 
 func TestAuthenticationWithWrongCredentials(t *testing.T) {
-	cluster, _ = remoteController.CreateCluster("3.9", DefaultServerConfig)
+	cluster, _ = remoteController.CreateCluster("", DefaultServerConfig)
 	remoteController.StartMember(cluster.ID)
 	config := hazelcast.NewHazelcastConfig()
 	config.GroupConfig().SetName("wrongName")
@@ -190,7 +190,7 @@ func TestAuthenticationWithWrongCredentials(t *testing.T) {
 }
 
 func TestClientWithoutMember(t *testing.T) {
-	cluster, _ = remoteController.CreateCluster("3.9", DefaultServerConfig)
+	cluster, _ = remoteController.CreateCluster("", DefaultServerConfig)
 	client, err := hazelcast.NewHazelcastClient()
 	if _, ok := err.(*core.HazelcastIllegalStateError); !ok {
 		t.Fatal("client should have returned a hazelcastError")
@@ -201,7 +201,7 @@ func TestClientWithoutMember(t *testing.T) {
 
 func TestRestartMember(t *testing.T) {
 	var wg = new(sync.WaitGroup)
-	cluster, _ = remoteController.CreateCluster("3.9", DefaultServerConfig)
+	cluster, _ = remoteController.CreateCluster("", DefaultServerConfig)
 	member1, _ := remoteController.StartMember(cluster.ID)
 	config := hazelcast.NewHazelcastConfig()
 	config.ClientNetworkConfig().SetConnectionAttemptLimit(10)
@@ -224,7 +224,7 @@ func TestRestartMember(t *testing.T) {
 }
 
 func TestReconnectToNewNodeViaLastMemberList(t *testing.T) {
-	cluster, _ = remoteController.CreateCluster("3.9", DefaultServerConfig)
+	cluster, _ = remoteController.CreateCluster("", DefaultServerConfig)
 	oldMember, _ := remoteController.StartMember(cluster.ID)
 	config := hazelcast.NewHazelcastConfig()
 	config.ClientNetworkConfig().SetConnectionAttemptLimit(100)
@@ -241,7 +241,7 @@ func TestReconnectToNewNodeViaLastMemberList(t *testing.T) {
 }
 
 func TestConnectToClusterWithoutPort(t *testing.T) {
-	cluster, _ = remoteController.CreateCluster("3.9", DefaultServerConfig)
+	cluster, _ = remoteController.CreateCluster("", DefaultServerConfig)
 	remoteController.StartMember(cluster.ID)
 	config := hazelcast.NewHazelcastConfig()
 	config.ClientNetworkConfig().AddAddress("127.0.0.1")

--- a/tests/heartbeat_test.go
+++ b/tests/heartbeat_test.go
@@ -39,7 +39,7 @@ func (l *heartbeatListener) OnHeartbeatStopped(connection *internal.Connection) 
 
 func TestHeartbeatStoppedForConnection(t *testing.T) {
 	var wg = new(sync.WaitGroup)
-	cluster, _ = remoteController.CreateCluster("3.9", DefaultServerConfig)
+	cluster, _ = remoteController.CreateCluster("", DefaultServerConfig)
 	heartbeatListener := &heartbeatListener{wg: wg}
 	member, _ := remoteController.StartMember(cluster.ID)
 	config := hazelcast.NewHazelcastConfig()

--- a/tests/invocation_test.go
+++ b/tests/invocation_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestNonSmartInvoke(t *testing.T) {
-	cluster, _ = remoteController.CreateCluster("3.9", DefaultServerConfig)
+	cluster, _ = remoteController.CreateCluster("", DefaultServerConfig)
 	remoteController.StartMember(cluster.ID)
 	config := hazelcast.NewHazelcastConfig()
 	config.ClientNetworkConfig().SetSmartRouting(false)
@@ -44,7 +44,7 @@ func TestNonSmartInvoke(t *testing.T) {
 }
 
 func TestSingleConnectionWithManyMembers(t *testing.T) {
-	cluster, _ = remoteController.CreateCluster("3.9", DefaultServerConfig)
+	cluster, _ = remoteController.CreateCluster("", DefaultServerConfig)
 	remoteController.StartMember(cluster.ID)
 	remoteController.StartMember(cluster.ID)
 	remoteController.StartMember(cluster.ID)
@@ -67,7 +67,7 @@ func TestSingleConnectionWithManyMembers(t *testing.T) {
 }
 
 func TestInvocationTimeout(t *testing.T) {
-	cluster, _ = remoteController.CreateCluster("3.9", DefaultServerConfig)
+	cluster, _ = remoteController.CreateCluster("", DefaultServerConfig)
 	member1, _ := remoteController.StartMember(cluster.ID)
 	config := hazelcast.NewHazelcastConfig()
 	config.ClientNetworkConfig().SetRedoOperation(true).SetConnectionAttemptLimit(100)
@@ -84,7 +84,7 @@ func TestInvocationTimeout(t *testing.T) {
 }
 
 func TestInvocationRetry(t *testing.T) {
-	cluster, _ = remoteController.CreateCluster("3.9", DefaultServerConfig)
+	cluster, _ = remoteController.CreateCluster("", DefaultServerConfig)
 	member1, _ := remoteController.StartMember(cluster.ID)
 	config := hazelcast.NewHazelcastConfig()
 	config.ClientNetworkConfig().SetRedoOperation(true).SetConnectionAttemptLimit(10)
@@ -110,7 +110,7 @@ func TestInvocationRetry(t *testing.T) {
 }
 
 func TestInvocationWithShutdown(t *testing.T) {
-	cluster, _ = remoteController.CreateCluster("3.9", DefaultServerConfig)
+	cluster, _ = remoteController.CreateCluster("", DefaultServerConfig)
 	remoteController.StartMember(cluster.ID)
 	config := hazelcast.NewHazelcastConfig()
 	config.ClientNetworkConfig().SetRedoOperation(true).SetConnectionAttemptLimit(10)
@@ -126,7 +126,7 @@ func TestInvocationWithShutdown(t *testing.T) {
 
 func TestInvocationNotSent(t *testing.T) {
 	var wg = new(sync.WaitGroup)
-	cluster, _ = remoteController.CreateCluster("3.9", DefaultServerConfig)
+	cluster, _ = remoteController.CreateCluster("", DefaultServerConfig)
 	member, _ := remoteController.StartMember(cluster.ID)
 	config := hazelcast.NewHazelcastConfig()
 	config.ClientNetworkConfig().SetRedoOperation(true).SetConnectionAttemptLimit(100).

--- a/tests/lifecycle_test.go
+++ b/tests/lifecycle_test.go
@@ -35,7 +35,7 @@ func (l *lifecycleListener) LifecycleStateChanged(newState string) {
 
 func TestLifecycleListener(t *testing.T) {
 	var wg = new(sync.WaitGroup)
-	cluster, _ = remoteController.CreateCluster("3.9", DefaultServerConfig)
+	cluster, _ = remoteController.CreateCluster("", DefaultServerConfig)
 	config := hazelcast.NewHazelcastConfig()
 	lifecycleListener := lifecycleListener{wg: wg, collector: make([]string, 0)}
 	config.AddLifecycleListener(&lifecycleListener)
@@ -55,7 +55,7 @@ func TestLifecycleListener(t *testing.T) {
 
 func TestLifecycleListenerForDisconnected(t *testing.T) {
 	var wg = new(sync.WaitGroup)
-	cluster, _ = remoteController.CreateCluster("3.9", DefaultServerConfig)
+	cluster, _ = remoteController.CreateCluster("", DefaultServerConfig)
 	lifecycleListener := lifecycleListener{wg: wg, collector: make([]string, 0)}
 	remoteController.StartMember(cluster.ID)
 	wg.Add(1)
@@ -73,7 +73,7 @@ func TestLifecycleListenerForDisconnected(t *testing.T) {
 
 func TestRemoveListener(t *testing.T) {
 	var wg = new(sync.WaitGroup)
-	cluster, _ = remoteController.CreateCluster("3.9", DefaultServerConfig)
+	cluster, _ = remoteController.CreateCluster("", DefaultServerConfig)
 	lifecycleListener := lifecycleListener{wg: wg, collector: make([]string, 0)}
 	remoteController.StartMember(cluster.ID)
 	client, _ := hazelcast.NewHazelcastClient()

--- a/tests/listener_test.go
+++ b/tests/listener_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestListenerWhenNodeLeftAndReconnected(t *testing.T) {
 	var wg = new(sync.WaitGroup)
-	cluster, _ = remoteController.CreateCluster("3.9", DefaultServerConfig)
+	cluster, _ = remoteController.CreateCluster("", DefaultServerConfig)
 	member1, _ := remoteController.StartMember(cluster.ID)
 	config := hazelcast.NewHazelcastConfig()
 	config.ClientNetworkConfig().SetConnectionAttemptLimit(10)
@@ -41,7 +41,7 @@ func TestListenerWhenNodeLeftAndReconnected(t *testing.T) {
 
 func TestListenerWithMultipleMembers(t *testing.T) {
 	var wg = new(sync.WaitGroup)
-	cluster, _ = remoteController.CreateCluster("3.9", DefaultServerConfig)
+	cluster, _ = remoteController.CreateCluster("", DefaultServerConfig)
 	remoteController.StartMember(cluster.ID)
 	remoteController.StartMember(cluster.ID)
 	client, _ := hazelcast.NewHazelcastClient()
@@ -65,7 +65,7 @@ func TestListenerWithMultipleMembers(t *testing.T) {
 
 func TestListenerWithMemberConnectedAfterAWhile(t *testing.T) {
 	var wg = new(sync.WaitGroup)
-	cluster, _ = remoteController.CreateCluster("3.9", DefaultServerConfig)
+	cluster, _ = remoteController.CreateCluster("", DefaultServerConfig)
 	remoteController.StartMember(cluster.ID)
 	config := hazelcast.NewHazelcastConfig()
 	config.ClientNetworkConfig().SetConnectionAttemptLimit(10)

--- a/tests/proxy/list/list_test.go
+++ b/tests/proxy/list/list_test.go
@@ -35,7 +35,7 @@ func TestMain(m *testing.M) {
 	if remoteController == nil || err != nil {
 		log.Fatal("create remote controller failed:", err)
 	}
-	cluster, _ := remoteController.CreateCluster("3.9", tests.DefaultServerConfig)
+	cluster, _ := remoteController.CreateCluster("", tests.DefaultServerConfig)
 	remoteController.StartMember(cluster.ID)
 	client, _ = hazelcast.NewHazelcastClient()
 	list, _ = client.GetList("myList")

--- a/tests/proxy/map/map_member_down/map_member_down_test.go
+++ b/tests/proxy/map/map_member_down/map_member_down_test.go
@@ -35,7 +35,7 @@ func TestMain(m *testing.M) {
 	if remoteController == nil || err != nil {
 		log.Fatal("create remote controller failed:", err)
 	}
-	cluster, _ := remoteController.CreateCluster("3.9", tests.DefaultServerConfig)
+	cluster, _ := remoteController.CreateCluster("", tests.DefaultServerConfig)
 	remoteController.StartMember(cluster.ID)
 	client, _ = hazelcast.NewHazelcastClient()
 	mp, _ = client.GetMap("myMap")

--- a/tests/proxy/map/map_test.go
+++ b/tests/proxy/map/map_test.go
@@ -42,7 +42,7 @@ func TestMain(m *testing.M) {
 	if remoteController == nil || err != nil {
 		log.Fatal("create remote controller failed:", err)
 	}
-	cluster, _ := remoteController.CreateCluster("3.9", tests.DefaultServerConfig)
+	cluster, _ := remoteController.CreateCluster("", tests.DefaultServerConfig)
 	remoteController.StartMember(cluster.ID)
 	client, _ = hazelcast.NewHazelcastClient()
 	mp, _ = client.GetMap("myMap")

--- a/tests/proxy/multi_map/multi_map_test.go
+++ b/tests/proxy/multi_map/multi_map_test.go
@@ -39,7 +39,7 @@ func TestMain(m *testing.M) {
 	if remoteController == nil || err != nil {
 		log.Fatal("create remote controller failed:", err)
 	}
-	cluster, _ := remoteController.CreateCluster("3.9", tests.DefaultServerConfig)
+	cluster, _ := remoteController.CreateCluster("", tests.DefaultServerConfig)
 	remoteController.StartMember(cluster.ID)
 	client, _ = hazelcast.NewHazelcastClient()
 	multiMap, _ = client.GetMultiMap("myMultiMap")

--- a/tests/proxy/queue/queue_test.go
+++ b/tests/proxy/queue/queue_test.go
@@ -37,7 +37,7 @@ func TestMain(m *testing.M) {
 	if remoteController == nil || err != nil {
 		log.Fatal("create remote controller failed:", err)
 	}
-	cluster, _ := remoteController.CreateCluster("3.9", tests.DefaultServerConfig)
+	cluster, _ := remoteController.CreateCluster("", tests.DefaultServerConfig)
 	remoteController.StartMember(cluster.ID)
 	client, _ = hazelcast.NewHazelcastClient()
 	queue, _ = client.GetQueue(queueName)

--- a/tests/proxy/replicated_map/replicated_map_test.go
+++ b/tests/proxy/replicated_map/replicated_map_test.go
@@ -39,7 +39,7 @@ func TestMain(m *testing.M) {
 	if remoteController == nil || err != nil {
 		log.Fatal("create remote controller failed:", err)
 	}
-	cluster, _ := remoteController.CreateCluster("3.9", tests.DefaultServerConfig)
+	cluster, _ := remoteController.CreateCluster("", tests.DefaultServerConfig)
 	remoteController.StartMember(cluster.ID)
 	client, _ = hazelcast.NewHazelcastClient()
 	rmp, _ = client.GetReplicatedMap("myReplicatedMap")

--- a/tests/proxy/ringbuffer/ringbuffer_test.go
+++ b/tests/proxy/ringbuffer/ringbuffer_test.go
@@ -37,7 +37,7 @@ func TestMain(m *testing.M) {
 	if remoteController == nil || err != nil {
 		log.Fatal("create remote controller failed:", err)
 	}
-	cluster, _ := remoteController.CreateCluster("3.9", tests.DefaultServerConfig)
+	cluster, _ := remoteController.CreateCluster("", tests.DefaultServerConfig)
 	remoteController.StartMember(cluster.ID)
 	client, _ = hazelcast.NewHazelcastClient()
 	ringbuffer, _ = client.GetRingbuffer(ringbufferName)

--- a/tests/proxy/set/set_test.go
+++ b/tests/proxy/set/set_test.go
@@ -35,7 +35,7 @@ func TestMain(m *testing.M) {
 	if remoteController == nil || err != nil {
 		log.Fatal("create remote controller failed:", err)
 	}
-	cluster, _ := remoteController.CreateCluster("3.9", tests.DefaultServerConfig)
+	cluster, _ := remoteController.CreateCluster("", tests.DefaultServerConfig)
 	remoteController.StartMember(cluster.ID)
 	client, _ = hazelcast.NewHazelcastClient()
 	set, _ = client.GetSet("mySet")

--- a/tests/proxy/topic/topic_test.go
+++ b/tests/proxy/topic/topic_test.go
@@ -35,7 +35,7 @@ func TestMain(m *testing.M) {
 	if remoteController == nil || err != nil {
 		log.Fatal("create remote controller failed:", err)
 	}
-	cluster, _ := remoteController.CreateCluster("3.9", tests.DefaultServerConfig)
+	cluster, _ := remoteController.CreateCluster("", tests.DefaultServerConfig)
 	remoteController.StartMember(cluster.ID)
 	client, _ = hazelcast.NewHazelcastClient()
 	topic, _ = client.GetTopic("myTopic")


### PR DESCRIPTION
When creating a cluster from remotecontroller, server version doesnt have any effect so we can remove it as it is confusing.

