### PR TITLE
Refactor common pkg

### DIFF
--- a/internal/IPutil/util.go
+++ b/internal/IPutil/util.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package IPutil
+
+import (
+	"crypto/rand"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+)
+
+func IsValidIPAddress(addr string) bool {
+	return net.ParseIP(addr) != nil
+}
+
+func GetIPAndPort(addr string) (string, int32) {
+	var port int
+	var err error
+	parts := strings.Split(addr, ":")
+	if len(parts) == 2 {
+		port, err = strconv.Atoi(parts[1])
+		if err != nil {
+			port = 5701 // Default port
+		}
+	} else {
+		port = -1
+	}
+	addr = parts[0]
+	return addr, int32(port)
+}
+
+// NewUUID generates a random uuid according to RFC 4122
+func NewUUID() (string, error) {
+	uuid := make([]byte, 16)
+	n, err := io.ReadFull(rand.Reader, uuid)
+	if n != len(uuid) || err != nil {
+		return "", err
+	}
+	uuid[8] = uuid[8]&^0xc0 | 0x80
+	uuid[6] = uuid[6]&^0xf0 | 0x40
+	return fmt.Sprintf("%x-%x-%x-%x-%x", uuid[0:4], uuid[4:6], uuid[6:8], uuid[8:10], uuid[10:]), nil
+}

--- a/internal/IPutil/util_test.go
+++ b/internal/IPutil/util_test.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package IPutil
+
+import (
+	"testing"
+)
+
+func TestIsValidIPAddress(t *testing.T) {
+	ip := "142.1.2.4"
+	if ok := IsValidIPAddress(ip); !ok {
+		t.Fatal("IsValidIPAddress failed")
+	}
+	ip = "123.2.1"
+	if ok := IsValidIPAddress(ip); ok {
+		t.Fatal("IsValidIPAddress failed")
+	}
+}
+
+func TestGetIpAndPort(t *testing.T) {
+	testAddress := "121.1.23.3:1231"
+	if ip, port := GetIPAndPort(testAddress); ip != "121.1.23.3" || port != 1231 {
+		t.Fatal("GetIPAndPort failed.")
+	}
+}
+
+func TestGetIpWithoutPort(t *testing.T) {
+	testAddress := "121.1.23.3"
+	if ip, port := GetIPAndPort(testAddress); ip != "121.1.23.3" || port != -1 {
+		t.Fatal("GetIPAndPort failed.")
+	}
+}

--- a/internal/client.go
+++ b/internal/client.go
@@ -17,7 +17,7 @@ package internal
 import (
 	"github.com/hazelcast/hazelcast-go-client/config"
 	"github.com/hazelcast/hazelcast-go-client/core"
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
@@ -42,7 +42,7 @@ func NewHazelcastClient(config *config.ClientConfig) (*HazelcastClient, error) {
 }
 
 func (c *HazelcastClient) GetMap(name string) (core.Map, error) {
-	mp, err := c.GetDistributedObject(common.ServiceNameMap, name)
+	mp, err := c.GetDistributedObject(bufutil.ServiceNameMap, name)
 	if err != nil {
 		return nil, err
 	}
@@ -50,7 +50,7 @@ func (c *HazelcastClient) GetMap(name string) (core.Map, error) {
 }
 
 func (c *HazelcastClient) GetList(name string) (core.List, error) {
-	list, err := c.GetDistributedObject(common.ServiceNameList, name)
+	list, err := c.GetDistributedObject(bufutil.ServiceNameList, name)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +58,7 @@ func (c *HazelcastClient) GetList(name string) (core.List, error) {
 }
 
 func (c *HazelcastClient) GetSet(name string) (core.Set, error) {
-	set, err := c.GetDistributedObject(common.ServiceNameSet, name)
+	set, err := c.GetDistributedObject(bufutil.ServiceNameSet, name)
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +66,7 @@ func (c *HazelcastClient) GetSet(name string) (core.Set, error) {
 }
 
 func (c *HazelcastClient) GetReplicatedMap(name string) (core.ReplicatedMap, error) {
-	mp, err := c.GetDistributedObject(common.ServiceNameReplicatedMap, name)
+	mp, err := c.GetDistributedObject(bufutil.ServiceNameReplicatedMap, name)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +74,7 @@ func (c *HazelcastClient) GetReplicatedMap(name string) (core.ReplicatedMap, err
 }
 
 func (c *HazelcastClient) GetMultiMap(name string) (core.MultiMap, error) {
-	mmp, err := c.GetDistributedObject(common.ServiceNameMultiMap, name)
+	mmp, err := c.GetDistributedObject(bufutil.ServiceNameMultiMap, name)
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +82,7 @@ func (c *HazelcastClient) GetMultiMap(name string) (core.MultiMap, error) {
 }
 
 func (c *HazelcastClient) GetFlakeIDGenerator(name string) (core.FlakeIDGenerator, error) {
-	flakeIDGenerator, err := c.GetDistributedObject(common.ServiceNameIDGenerator, name)
+	flakeIDGenerator, err := c.GetDistributedObject(bufutil.ServiceNameIDGenerator, name)
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +90,7 @@ func (c *HazelcastClient) GetFlakeIDGenerator(name string) (core.FlakeIDGenerato
 }
 
 func (c *HazelcastClient) GetTopic(name string) (core.Topic, error) {
-	topic, err := c.GetDistributedObject(common.ServiceNameTopic, name)
+	topic, err := c.GetDistributedObject(bufutil.ServiceNameTopic, name)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +98,7 @@ func (c *HazelcastClient) GetTopic(name string) (core.Topic, error) {
 }
 
 func (c *HazelcastClient) GetQueue(name string) (core.Queue, error) {
-	queue, err := c.GetDistributedObject(common.ServiceNameQueue, name)
+	queue, err := c.GetDistributedObject(bufutil.ServiceNameQueue, name)
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +106,7 @@ func (c *HazelcastClient) GetQueue(name string) (core.Queue, error) {
 }
 
 func (c *HazelcastClient) GetRingbuffer(name string) (core.Ringbuffer, error) {
-	rb, err := c.GetDistributedObject(common.ServiceNameRingbufferService, name)
+	rb, err := c.GetDistributedObject(bufutil.ServiceNameRingbufferService, name)
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +114,7 @@ func (c *HazelcastClient) GetRingbuffer(name string) (core.Ringbuffer, error) {
 }
 
 func (c *HazelcastClient) GetPNCounter(name string) (core.PNCounter, error) {
-	counter, err := c.GetDistributedObject(common.ServiceNamePNCounter, name)
+	counter, err := c.GetDistributedObject(bufutil.ServiceNamePNCounter, name)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cluster.go
+++ b/internal/cluster.go
@@ -23,8 +23,8 @@ import (
 
 	"github.com/hazelcast/hazelcast-go-client/config"
 	"github.com/hazelcast/hazelcast-go-client/core"
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
 	"github.com/hazelcast/hazelcast-go-client/internal/protocol"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 const (
@@ -78,8 +78,8 @@ func getPossibleAddresses(addressList []string, memberList []*protocol.Member) [
 	}
 	allAddresses := make(map[protocol.Address]struct{}, len(addressList)+len(memberList))
 	for _, address := range addressList {
-		ip, port := common.GetIPAndPort(address)
-		if common.IsValidIPAddress(ip) {
+		ip, port := bufutil.GetIPAndPort(address)
+		if bufutil.IsValidIPAddress(ip) {
 			if port == -1 {
 				allAddresses[*protocol.NewAddressWithParameters(ip, defaultPort)] = struct{}{}
 				allAddresses[*protocol.NewAddressWithParameters(ip, defaultPort+1)] = struct{}{}
@@ -210,7 +210,7 @@ func (cs *clusterService) logMembers() {
 }
 
 func (cs *clusterService) AddListener(listener interface{}) *string {
-	registrationID, _ := common.NewUUID()
+	registrationID, _ := bufutil.NewUUID()
 	cs.mu.Lock()
 	defer cs.mu.Unlock()
 	listeners := cs.listeners.Load().(map[string]interface{})

--- a/internal/cluster.go
+++ b/internal/cluster.go
@@ -23,8 +23,8 @@ import (
 
 	"github.com/hazelcast/hazelcast-go-client/config"
 	"github.com/hazelcast/hazelcast-go-client/core"
+	"github.com/hazelcast/hazelcast-go-client/internal/IPutil"
 	"github.com/hazelcast/hazelcast-go-client/internal/protocol"
-	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 const (
@@ -78,8 +78,8 @@ func getPossibleAddresses(addressList []string, memberList []*protocol.Member) [
 	}
 	allAddresses := make(map[protocol.Address]struct{}, len(addressList)+len(memberList))
 	for _, address := range addressList {
-		ip, port := bufutil.GetIPAndPort(address)
-		if bufutil.IsValidIPAddress(ip) {
+		ip, port := IPutil.GetIPAndPort(address)
+		if IPutil.IsValidIPAddress(ip) {
 			if port == -1 {
 				allAddresses[*protocol.NewAddressWithParameters(ip, defaultPort)] = struct{}{}
 				allAddresses[*protocol.NewAddressWithParameters(ip, defaultPort+1)] = struct{}{}
@@ -210,7 +210,7 @@ func (cs *clusterService) logMembers() {
 }
 
 func (cs *clusterService) AddListener(listener interface{}) *string {
-	registrationID, _ := bufutil.NewUUID()
+	registrationID, _ := IPutil.NewUUID()
 	cs.mu.Lock()
 	defer cs.mu.Unlock()
 	listeners := cs.listeners.Load().(map[string]interface{})

--- a/internal/cluster_test.go
+++ b/internal/cluster_test.go
@@ -17,8 +17,8 @@ package internal
 import (
 	"testing"
 
+	"github.com/hazelcast/hazelcast-go-client/internal/IPutil"
 	"github.com/hazelcast/hazelcast-go-client/internal/protocol"
-	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func Test_getPossibleAddresses(t *testing.T) {
@@ -42,7 +42,7 @@ func Test_getPossibleAddresses(t *testing.T) {
 		addressesInMap[address] = struct{}{}
 	}
 	for _, address := range configAddresses {
-		ip, port := bufutil.GetIPAndPort(address)
+		ip, port := IPutil.GetIPAndPort(address)
 		if _, found := addressesInMap[*protocol.NewAddressWithParameters(ip, port)]; !found {
 			t.Fatal("getPossibleAddresses failed")
 		}

--- a/internal/cluster_test.go
+++ b/internal/cluster_test.go
@@ -17,8 +17,8 @@ package internal
 import (
 	"testing"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
 	"github.com/hazelcast/hazelcast-go-client/internal/protocol"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func Test_getPossibleAddresses(t *testing.T) {
@@ -42,7 +42,7 @@ func Test_getPossibleAddresses(t *testing.T) {
 		addressesInMap[address] = struct{}{}
 	}
 	for _, address := range configAddresses {
-		ip, port := common.GetIPAndPort(address)
+		ip, port := bufutil.GetIPAndPort(address)
 		if _, found := addressesInMap[*protocol.NewAddressWithParameters(ip, port)]; !found {
 			t.Fatal("getPossibleAddresses failed")
 		}

--- a/internal/colutil/util.go
+++ b/internal/colutil/util.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package collection
+package colutil
 
 import (
 	"github.com/hazelcast/hazelcast-go-client/core"

--- a/internal/colutil/util.go
+++ b/internal/colutil/util.go
@@ -16,19 +16,19 @@ package colutil
 
 import (
 	"github.com/hazelcast/hazelcast-go-client/core"
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
 	"github.com/hazelcast/hazelcast-go-client/internal/protocol"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
 func ObjectToDataCollection(objects []interface{}, service *serialization.Service) ([]*serialization.Data, error) {
 	if objects == nil {
-		return nil, core.NewHazelcastNilPointerError(common.NilSliceIsNotAllowed, nil)
+		return nil, core.NewHazelcastNilPointerError(bufutil.NilSliceIsNotAllowed, nil)
 	}
 	elementsData := make([]*serialization.Data, len(objects))
 	for index, element := range objects {
 		if element == nil {
-			return nil, core.NewHazelcastNilPointerError(common.NilArgIsNotAllowed, nil)
+			return nil, core.NewHazelcastNilPointerError(bufutil.NilArgIsNotAllowed, nil)
 		}
 		elementData, err := service.ToData(element)
 		if err != nil {
@@ -41,7 +41,7 @@ func ObjectToDataCollection(objects []interface{}, service *serialization.Servic
 
 func DataToObjectCollection(dataSlice []*serialization.Data, service *serialization.Service) ([]interface{}, error) {
 	if dataSlice == nil {
-		return nil, core.NewHazelcastNilPointerError(common.NilSliceIsNotAllowed, nil)
+		return nil, core.NewHazelcastNilPointerError(bufutil.NilSliceIsNotAllowed, nil)
 	}
 	elements := make([]interface{}, len(dataSlice))
 	for index, data := range dataSlice {

--- a/internal/connection.go
+++ b/internal/connection.go
@@ -23,8 +23,8 @@ import (
 	"time"
 
 	"github.com/hazelcast/hazelcast-go-client/core"
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
 	"github.com/hazelcast/hazelcast-go-client/internal/protocol"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 const BufferSize = 8192 * 2
@@ -146,7 +146,7 @@ func (c *Connection) read() {
 
 func (c *Connection) receiveMessage() {
 	c.lastRead.Store(time.Now())
-	for len(c.readBuffer) > common.Int32SizeInBytes {
+	for len(c.readBuffer) > bufutil.Int32SizeInBytes {
 		frameLength := binary.LittleEndian.Uint32(c.readBuffer[0:4])
 		if frameLength > uint32(len(c.readBuffer)) {
 			return

--- a/internal/error.go
+++ b/internal/error.go
@@ -18,8 +18,8 @@ import (
 	"fmt"
 
 	"github.com/hazelcast/hazelcast-go-client/core"
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
 	"github.com/hazelcast/hazelcast-go-client/internal/protocol"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func createHazelcastError(err *protocol.Error) core.HazelcastError {
@@ -29,20 +29,20 @@ func createHazelcastError(err *protocol.Error) core.HazelcastError {
 			trace.LineNumber())
 	}
 	message := fmt.Sprintf("got exception from server:\n %s: %s\n %s", err.ClassName(), err.Message(), stackTrace)
-	switch common.ErrorCode(err.ErrorCode()) {
-	case common.ErrorCodeAuthentication:
+	switch bufutil.ErrorCode(err.ErrorCode()) {
+	case bufutil.ErrorCodeAuthentication:
 		return core.NewHazelcastAuthenticationError(message, nil)
-	case common.ErrorCodeHazelcastInstanceNotActive:
+	case bufutil.ErrorCodeHazelcastInstanceNotActive:
 		return core.NewHazelcastInstanceNotActiveError(message, nil)
-	case common.ErrorCodeHazelcastSerialization:
+	case bufutil.ErrorCodeHazelcastSerialization:
 		return core.NewHazelcastSerializationError(message, nil)
-	case common.ErrorCodeTargetDisconnected:
+	case bufutil.ErrorCodeTargetDisconnected:
 		return core.NewHazelcastTargetDisconnectedError(message, nil)
-	case common.ErrorCodeTargetNotMember:
+	case bufutil.ErrorCodeTargetNotMember:
 		return core.NewHazelcastTargetNotMemberError(message, nil)
-	case common.ErrorCodeUnsupportedOperation:
+	case bufutil.ErrorCodeUnsupportedOperation:
 		return core.NewHazelcastUnsupportedOperationError(message, nil)
-	case common.ErrorCodeConsistencyLostException:
+	case bufutil.ErrorCodeConsistencyLostException:
 		return core.NewHazelcastConsistencyLostError(message, nil)
 	}
 

--- a/internal/lifecycle.go
+++ b/internal/lifecycle.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/hazelcast/hazelcast-go-client/config"
 	"github.com/hazelcast/hazelcast-go-client/core"
-	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
+	"github.com/hazelcast/hazelcast-go-client/internal/IPutil"
 )
 
 const (
@@ -53,7 +53,7 @@ func newLifecycleService(config *config.ClientConfig) *lifecycleService {
 }
 
 func (ls *lifecycleService) AddListener(listener interface{}) string {
-	registrationID, _ := bufutil.NewUUID()
+	registrationID, _ := IPutil.NewUUID()
 	ls.mu.Lock()
 	defer ls.mu.Unlock()
 	listeners := ls.listeners.Load().(map[string]interface{})

--- a/internal/lifecycle.go
+++ b/internal/lifecycle.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/hazelcast/hazelcast-go-client/config"
 	"github.com/hazelcast/hazelcast-go-client/core"
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 const (
@@ -53,7 +53,7 @@ func newLifecycleService(config *config.ClientConfig) *lifecycleService {
 }
 
 func (ls *lifecycleService) AddListener(listener interface{}) string {
-	registrationID, _ := common.NewUUID()
+	registrationID, _ := bufutil.NewUUID()
 	ls.mu.Lock()
 	defer ls.mu.Unlock()
 	listeners := ls.listeners.Load().(map[string]interface{})

--- a/internal/listener.go
+++ b/internal/listener.go
@@ -19,8 +19,8 @@ import (
 	"time"
 
 	"github.com/hazelcast/hazelcast-go-client/core"
+	"github.com/hazelcast/hazelcast-go-client/internal/IPutil"
 	"github.com/hazelcast/hazelcast-go-client/internal/protocol"
-	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 type listenerService struct {
@@ -152,7 +152,7 @@ func (ls *listenerService) registerListener(request *protocol.ClientMessage,
 	if err != nil {
 		return nil, err
 	}
-	userRegistrationID, _ := bufutil.NewUUID()
+	userRegistrationID, _ := IPutil.NewUUID()
 	registrationKey := listenerRegistrationKey{
 		userRegistrationKey: userRegistrationID,
 		request:             request,

--- a/internal/listener.go
+++ b/internal/listener.go
@@ -19,8 +19,8 @@ import (
 	"time"
 
 	"github.com/hazelcast/hazelcast-go-client/core"
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
 	"github.com/hazelcast/hazelcast-go-client/internal/protocol"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 type listenerService struct {
@@ -152,7 +152,7 @@ func (ls *listenerService) registerListener(request *protocol.ClientMessage,
 	if err != nil {
 		return nil, err
 	}
-	userRegistrationID, _ := common.NewUUID()
+	userRegistrationID, _ := bufutil.NewUUID()
 	registrationKey := listenerRegistrationKey{
 		userRegistrationKey: userRegistrationID,
 		request:             request,

--- a/internal/map.go
+++ b/internal/map.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hazelcast/hazelcast-go-client/internal/protocol"
 	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/timeutil"
 )
 
 type mapProxy struct {
@@ -56,7 +57,7 @@ func (mp *mapProxy) PutTransient(key interface{}, value interface{}, ttl time.Du
 	if err != nil {
 		return err
 	}
-	ttlInMillis := bufutil.GetTimeInMilliSeconds(ttl)
+	ttlInMillis := timeutil.GetTimeInMilliSeconds(ttl)
 	request := protocol.MapPutTransientEncodeRequest(mp.name, keyData, valueData, threadID, ttlInMillis)
 	_, err = mp.invokeOnKey(request, keyData)
 	return err
@@ -107,7 +108,7 @@ func (mp *mapProxy) TryRemove(key interface{}, timeout time.Duration) (ok bool, 
 	if err != nil {
 		return false, err
 	}
-	timeoutInMillis := bufutil.GetTimeInMilliSeconds(timeout)
+	timeoutInMillis := timeutil.GetTimeInMilliSeconds(timeout)
 	request := protocol.MapTryRemoveEncodeRequest(mp.name, keyData, threadID, timeoutInMillis)
 	responseMessage, err := mp.invokeOnKey(request, keyData)
 	return mp.decodeToBoolAndError(responseMessage, err, protocol.MapTryRemoveDecodeResponse)
@@ -214,7 +215,7 @@ func (mp *mapProxy) LockWithLeaseTime(key interface{}, lease time.Duration) (err
 	if err != nil {
 		return err
 	}
-	leaseInMillis := bufutil.GetTimeInMilliSeconds(lease)
+	leaseInMillis := timeutil.GetTimeInMilliSeconds(lease)
 	request := protocol.MapLockEncodeRequest(mp.name, keyData, threadID, leaseInMillis, mp.client.ProxyManager.nextReferenceID())
 	_, err = mp.invokeOnKey(request, keyData)
 	return
@@ -234,8 +235,8 @@ func (mp *mapProxy) TryLockWithTimeoutAndLease(key interface{}, timeout time.Dur
 	if err != nil {
 		return false, err
 	}
-	timeoutInMillis := bufutil.GetTimeInMilliSeconds(timeout)
-	leaseInMillis := bufutil.GetTimeInMilliSeconds(lease)
+	timeoutInMillis := timeutil.GetTimeInMilliSeconds(timeout)
+	leaseInMillis := timeutil.GetTimeInMilliSeconds(lease)
 	request := protocol.MapTryLockEncodeRequest(mp.name, keyData, threadID, leaseInMillis, timeoutInMillis,
 		mp.client.ProxyManager.nextReferenceID())
 	responseMessage, err := mp.invokeOnKey(request, keyData)
@@ -304,7 +305,7 @@ func (mp *mapProxy) SetWithTTL(key interface{}, value interface{}, ttl time.Dura
 	if err != nil {
 		return err
 	}
-	ttlInMillis := bufutil.GetTimeInMilliSeconds(ttl)
+	ttlInMillis := timeutil.GetTimeInMilliSeconds(ttl)
 	request := protocol.MapSetEncodeRequest(mp.name, keyData, valueData, threadID, ttlInMillis)
 	_, err = mp.invokeOnKey(request, keyData)
 	return

--- a/internal/message_builder.go
+++ b/internal/message_builder.go
@@ -15,8 +15,8 @@
 package internal
 
 import (
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
 	"github.com/hazelcast/hazelcast-go-client/internal/protocol"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 type clientMessageBuilder struct {
@@ -25,9 +25,9 @@ type clientMessageBuilder struct {
 }
 
 func (mb *clientMessageBuilder) onMessage(msg *protocol.ClientMessage) {
-	if msg.HasFlags(common.BeginEndFlag) > 0 {
+	if msg.HasFlags(bufutil.BeginEndFlag) > 0 {
 		mb.responseChannel <- msg
-	} else if msg.HasFlags(common.BeginFlag) > 0 {
+	} else if msg.HasFlags(bufutil.BeginFlag) > 0 {
 		mb.incompleteMessages[msg.CorrelationID()] = msg
 	} else {
 		message, found := mb.incompleteMessages[msg.CorrelationID()]
@@ -35,8 +35,8 @@ func (mb *clientMessageBuilder) onMessage(msg *protocol.ClientMessage) {
 			return
 		}
 		message.Accumulate(msg)
-		if msg.HasFlags(common.EndFlag) > 0 {
-			message.AddFlags(common.BeginEndFlag)
+		if msg.HasFlags(bufutil.EndFlag) > 0 {
+			message.AddFlags(bufutil.BeginEndFlag)
 			mb.responseChannel <- message
 			delete(mb.incompleteMessages, msg.CorrelationID())
 		}

--- a/internal/message_builder_test.go
+++ b/internal/message_builder_test.go
@@ -19,8 +19,8 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
 	"github.com/hazelcast/hazelcast-go-client/internal/protocol"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func TestClientMessageBuilder_OnMessage(t *testing.T) {
@@ -42,7 +42,7 @@ func TestClientMessageBuilder_OnMessage(t *testing.T) {
 	serverVersion := "3.9"
 	expectedClientMessage := protocol.ClientAuthenticationEncodeRequest(&testString, &testString, &testString, &testString, false,
 		&testString, 1, &serverVersion)
-	expectedClientMessage.SetFlags(common.BeginEndFlag)
+	expectedClientMessage.SetFlags(bufutil.BeginEndFlag)
 	expectedClientMessage.SetCorrelationID(1)
 	expectedClientMessage.SetFrameLength(int32(len(expectedClientMessage.Buffer)))
 
@@ -60,9 +60,9 @@ func TestClientMessageBuilder_OnMessage(t *testing.T) {
 	firstMessage.SetFrameLength(int32(len(firstMessage.Buffer)))
 	secondMessage.SetFrameLength(int32(len(secondMessage.Buffer)))
 
-	firstMessage.SetFlags(common.BeginFlag)
+	firstMessage.SetFlags(bufutil.BeginFlag)
 	builder.onMessage(firstMessage)
-	secondMessage.SetFlags(common.EndFlag)
+	secondMessage.SetFlags(bufutil.EndFlag)
 	builder.onMessage(secondMessage)
 	mu.Lock()
 	if !reflect.DeepEqual(builtClientMessage.Buffer, expectedClientMessage.Buffer) {

--- a/internal/multi_map.go
+++ b/internal/multi_map.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hazelcast/hazelcast-go-client/internal/protocol"
 	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/timeutil"
 )
 
 type multiMapProxy struct {
@@ -182,7 +183,7 @@ func (mmp *multiMapProxy) LockWithLeaseTime(key interface{}, lease time.Duration
 	if err != nil {
 		return err
 	}
-	leaseInMillis := bufutil.GetTimeInMilliSeconds(lease)
+	leaseInMillis := timeutil.GetTimeInMilliSeconds(lease)
 	request := protocol.MultiMapLockEncodeRequest(mmp.name, keyData, threadID, leaseInMillis,
 		mmp.client.ProxyManager.nextReferenceID())
 	_, err = mmp.invokeOnKey(request, keyData)
@@ -213,8 +214,8 @@ func (mmp *multiMapProxy) TryLockWithTimeoutAndLease(key interface{}, timeout ti
 	if err != nil {
 		return false, err
 	}
-	timeoutInMillis := bufutil.GetTimeInMilliSeconds(timeout)
-	leaseInMillis := bufutil.GetTimeInMilliSeconds(lease)
+	timeoutInMillis := timeutil.GetTimeInMilliSeconds(timeout)
+	leaseInMillis := timeutil.GetTimeInMilliSeconds(lease)
 	request := protocol.MultiMapTryLockEncodeRequest(mmp.name, keyData, threadID, leaseInMillis, timeoutInMillis,
 		mmp.client.ProxyManager.nextReferenceID())
 	responseMessage, err := mmp.invokeOnKey(request, keyData)

--- a/internal/multi_map.go
+++ b/internal/multi_map.go
@@ -18,8 +18,8 @@ import (
 	"time"
 
 	"github.com/hazelcast/hazelcast-go-client/core"
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
 	"github.com/hazelcast/hazelcast-go-client/internal/protocol"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
@@ -182,7 +182,7 @@ func (mmp *multiMapProxy) LockWithLeaseTime(key interface{}, lease time.Duration
 	if err != nil {
 		return err
 	}
-	leaseInMillis := common.GetTimeInMilliSeconds(lease)
+	leaseInMillis := bufutil.GetTimeInMilliSeconds(lease)
 	request := protocol.MultiMapLockEncodeRequest(mmp.name, keyData, threadID, leaseInMillis,
 		mmp.client.ProxyManager.nextReferenceID())
 	_, err = mmp.invokeOnKey(request, keyData)
@@ -213,8 +213,8 @@ func (mmp *multiMapProxy) TryLockWithTimeoutAndLease(key interface{}, timeout ti
 	if err != nil {
 		return false, err
 	}
-	timeoutInMillis := common.GetTimeInMilliSeconds(timeout)
-	leaseInMillis := common.GetTimeInMilliSeconds(lease)
+	timeoutInMillis := bufutil.GetTimeInMilliSeconds(timeout)
+	leaseInMillis := bufutil.GetTimeInMilliSeconds(lease)
 	request := protocol.MultiMapTryLockEncodeRequest(mmp.name, keyData, threadID, leaseInMillis, timeoutInMillis,
 		mmp.client.ProxyManager.nextReferenceID())
 	responseMessage, err := mmp.invokeOnKey(request, keyData)
@@ -251,11 +251,11 @@ func (mmp *multiMapProxy) onEntryEvent(keyData *serialization.Data, oldValueData
 	entryEvent := protocol.NewEntryEvent(key, oldValue, value, mergingValue, eventType, uuid)
 	mapEvent := protocol.NewMapEvent(eventType, uuid, numberOfAffectedEntries)
 	switch eventType {
-	case common.EntryEventAdded:
+	case bufutil.EntryEventAdded:
 		listener.(protocol.EntryAddedListener).EntryAdded(entryEvent)
-	case common.EntryEventRemoved:
+	case bufutil.EntryEventRemoved:
 		listener.(protocol.EntryRemovedListener).EntryRemoved(entryEvent)
-	case common.EntryEventClearAll:
+	case bufutil.EntryEventClearAll:
 		listener.(protocol.EntryClearAllListener).EntryClearAll(mapEvent)
 	}
 }

--- a/internal/murmur/murmur.go
+++ b/internal/murmur/murmur.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package common
+package murmur
 
 import (
 	"encoding/binary"
@@ -20,12 +20,12 @@ import (
 
 var defaultSeed uint32 = 0x01000193
 
-func Murmur3ADefault(key []byte, offset int32, len int) int32 {
-	return Murmur3A(key, offset, len, defaultSeed)
+func Default3A(key []byte, offset int32, len int) int32 {
+	return M3A(key, offset, len, defaultSeed)
 }
 
 // MurmurHash3 for x86, 32-bit (MurmurHash3_x86_32)
-func Murmur3A(key []byte, offset int32, len int, seed uint32) int32 {
+func M3A(key []byte, offset int32, len int, seed uint32) int32 {
 	var h1 = seed
 	var c1 uint32 = 0xcc9e2d51
 	var c2 uint32 = 0x1b873593

--- a/internal/murmur/murmur.go
+++ b/internal/murmur/murmur.go
@@ -24,7 +24,7 @@ func Default3A(key []byte, offset int32, len int) int32 {
 	return M3A(key, offset, len, defaultSeed)
 }
 
-// MurmurHash3 for x86, 32-bit (MurmurHash3_x86_32)
+// M3A computes MurmurHash3 for x86, 32-bit (MurmurHash3_x86_32)
 func M3A(key []byte, offset int32, len int, seed uint32) int32 {
 	var h1 = seed
 	var c1 uint32 = 0xcc9e2d51

--- a/internal/murmur/murmur_test.go
+++ b/internal/murmur/murmur_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package common
+package murmur
 
 import (
 	"testing"
@@ -37,7 +37,7 @@ func TestMurmur3A(t *testing.T) {
 		{"key-9", 1182720020, 140},
 	}
 	for _, ele := range list {
-		hash := Murmur3ADefault([]byte(ele.key), 0, len(ele.key))
+		hash := Default3A([]byte(ele.key), 0, len(ele.key))
 		if hash != int32(ele.expected) {
 			t.Errorf("Expected %d but was %d for Murmur3A\n", int32(ele.expected), hash)
 		}

--- a/internal/partition.go
+++ b/internal/partition.go
@@ -19,7 +19,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/murmur"
 	"github.com/hazelcast/hazelcast-go-client/internal/protocol"
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
@@ -72,7 +72,7 @@ func (ps *partitionService) GetPartitionID(keyData *serialization.Data) int32 {
 	if count <= 0 {
 		return 0
 	}
-	return common.HashToIndex(keyData.GetPartitionHash(), count)
+	return murmur.HashToIndex(keyData.GetPartitionHash(), count)
 }
 
 func (ps *partitionService) GetPartitionIDWithKey(key interface{}) (int32, error) {

--- a/internal/protocol/bufutil/consts.go
+++ b/internal/protocol/bufutil/consts.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package common
+package bufutil
 
 const (
 	ServiceNameAtomicLong                  = "hz:impl:atomicLongService"

--- a/internal/protocol/bufutil/util.go
+++ b/internal/protocol/bufutil/util.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package common
+package bufutil
 
 import (
 	"crypto/rand"

--- a/internal/protocol/bufutil/util_test.go
+++ b/internal/protocol/bufutil/util_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package common
+package bufutil
 
 import (
 	"testing"

--- a/internal/protocol/client_addmembershiplistener.go
+++ b/internal/protocol/client_addmembershiplistener.go
@@ -15,13 +15,13 @@
 package protocol
 
 import (
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func ClientAddMembershipListenerCalculateSize(localOnly bool) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += common.BoolSizeInBytes
+	dataSize += bufutil.BoolSizeInBytes
 	return dataSize
 }
 
@@ -80,13 +80,13 @@ func ClientAddMembershipListenerHandle(clientMessage *ClientMessage,
 	handleEventMemberAttributeChange ClientAddMembershipListenerHandleEventMemberAttributeChangeFunc) {
 	// Event handler
 	messageType := clientMessage.MessageType()
-	if messageType == common.EventMember && handleEventMember != nil {
+	if messageType == bufutil.EventMember && handleEventMember != nil {
 		handleEventMember(ClientAddMembershipListenerEventMemberDecode(clientMessage))
 	}
-	if messageType == common.EventMemberList && handleEventMemberList != nil {
+	if messageType == bufutil.EventMemberList && handleEventMemberList != nil {
 		handleEventMemberList(ClientAddMembershipListenerEventMemberListDecode(clientMessage))
 	}
-	if messageType == common.EventMemberAttributeChange && handleEventMemberAttributeChange != nil {
+	if messageType == bufutil.EventMemberAttributeChange && handleEventMemberAttributeChange != nil {
 		handleEventMemberAttributeChange(ClientAddMembershipListenerEventMemberAttributeChangeDecode(clientMessage))
 	}
 }

--- a/internal/protocol/client_authentication.go
+++ b/internal/protocol/client_authentication.go
@@ -15,26 +15,26 @@
 package protocol
 
 import (
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func ClientAuthenticationCalculateSize(username *string, password *string, uuid *string, ownerUUID *string, isOwnerConnection bool, clientType *string, serializationVersion uint8, clientHazelcastVersion *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(username)
-	dataSize += StringCalculateSize(password)
-	dataSize += common.BoolSizeInBytes
+	dataSize += stringCalculateSize(username)
+	dataSize += stringCalculateSize(password)
+	dataSize += bufutil.BoolSizeInBytes
 	if uuid != nil {
-		dataSize += StringCalculateSize(uuid)
+		dataSize += stringCalculateSize(uuid)
 	}
-	dataSize += common.BoolSizeInBytes
+	dataSize += bufutil.BoolSizeInBytes
 	if ownerUUID != nil {
-		dataSize += StringCalculateSize(ownerUUID)
+		dataSize += stringCalculateSize(ownerUUID)
 	}
-	dataSize += common.BoolSizeInBytes
-	dataSize += StringCalculateSize(clientType)
-	dataSize += common.Uint8SizeInBytes
-	dataSize += StringCalculateSize(clientHazelcastVersion)
+	dataSize += bufutil.BoolSizeInBytes
+	dataSize += stringCalculateSize(clientType)
+	dataSize += bufutil.Uint8SizeInBytes
+	dataSize += stringCalculateSize(clientHazelcastVersion)
 	return dataSize
 }
 

--- a/internal/protocol/client_createproxy.go
+++ b/internal/protocol/client_createproxy.go
@@ -17,9 +17,9 @@ package protocol
 func ClientCreateProxyCalculateSize(name *string, serviceName *string, target *Address) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += StringCalculateSize(serviceName)
-	dataSize += AddressCalculateSize(target)
+	dataSize += stringCalculateSize(name)
+	dataSize += stringCalculateSize(serviceName)
+	dataSize += addressCalculateSize(target)
 	return dataSize
 }
 

--- a/internal/protocol/client_destroyproxy.go
+++ b/internal/protocol/client_destroyproxy.go
@@ -17,8 +17,8 @@ package protocol
 func ClientDestroyProxyCalculateSize(name *string, serviceName *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += StringCalculateSize(serviceName)
+	dataSize += stringCalculateSize(name)
+	dataSize += stringCalculateSize(serviceName)
 	return dataSize
 }
 

--- a/internal/protocol/core.go
+++ b/internal/protocol/core.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	"github.com/hazelcast/hazelcast-go-client/core"
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
@@ -213,15 +213,15 @@ func NewEntryView(key interface{}, value interface{}, cost int64, creationTime i
 		key:                    key,
 		value:                  value,
 		cost:                   cost,
-		creationTime:           common.ConvertMillisToUnixTime(creationTime),
-		expirationTime:         common.ConvertMillisToUnixTime(expirationTime),
+		creationTime:           bufutil.ConvertMillisToUnixTime(creationTime),
+		expirationTime:         bufutil.ConvertMillisToUnixTime(expirationTime),
 		hits:                   hits,
-		lastAccessTime:         common.ConvertMillisToUnixTime(lastAccessTime),
-		lastStoredTime:         common.ConvertMillisToUnixTime(lastStoredTime),
-		lastUpdateTime:         common.ConvertMillisToUnixTime(lastUpdateTime),
+		lastAccessTime:         bufutil.ConvertMillisToUnixTime(lastAccessTime),
+		lastStoredTime:         bufutil.ConvertMillisToUnixTime(lastStoredTime),
+		lastUpdateTime:         bufutil.ConvertMillisToUnixTime(lastUpdateTime),
 		version:                version,
 		evictionCriteriaNumber: evictionCriteriaNumber,
-		ttl: common.ConvertMillisToDuration(ttl),
+		ttl: bufutil.ConvertMillisToDuration(ttl),
 	}
 }
 
@@ -490,28 +490,28 @@ type MemberRemovedListener interface {
 func GetEntryListenerFlags(listener interface{}) int32 {
 	flags := int32(0)
 	if _, ok := listener.(EntryAddedListener); ok {
-		flags |= common.EntryEventAdded
+		flags |= bufutil.EntryEventAdded
 	}
 	if _, ok := listener.(EntryRemovedListener); ok {
-		flags |= common.EntryEventRemoved
+		flags |= bufutil.EntryEventRemoved
 	}
 	if _, ok := listener.(EntryUpdatedListener); ok {
-		flags |= common.EntryEventUpdated
+		flags |= bufutil.EntryEventUpdated
 	}
 	if _, ok := listener.(EntryEvictedListener); ok {
-		flags |= common.EntryEventEvicted
+		flags |= bufutil.EntryEventEvicted
 	}
 	if _, ok := listener.(EntryEvictAllListener); ok {
-		flags |= common.EntryEventEvictAll
+		flags |= bufutil.EntryEventEvictAll
 	}
 	if _, ok := listener.(EntryClearAllListener); ok {
-		flags |= common.EntryEventClearAll
+		flags |= bufutil.EntryEventClearAll
 	}
 	if _, ok := listener.(EntryExpiredListener); ok {
-		flags |= common.EntryEventExpired
+		flags |= bufutil.EntryEventExpired
 	}
 	if _, ok := listener.(EntryMergedListener); ok {
-		flags |= common.EntryEventMerged
+		flags |= bufutil.EntryEventMerged
 	}
 	return flags
 }
@@ -525,7 +525,7 @@ type TopicMessage struct {
 func NewTopicMessage(messageObject interface{}, publishTime int64, publishingMember *Member) *TopicMessage {
 	return &TopicMessage{
 		messageObject:    messageObject,
-		publishTime:      common.ConvertMillisToUnixTime(publishTime),
+		publishTime:      bufutil.ConvertMillisToUnixTime(publishTime),
 		publishingMember: publishingMember,
 	}
 }

--- a/internal/protocol/core.go
+++ b/internal/protocol/core.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hazelcast/hazelcast-go-client/core"
 	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/timeutil"
 )
 
 type Address struct {
@@ -213,15 +214,15 @@ func NewEntryView(key interface{}, value interface{}, cost int64, creationTime i
 		key:                    key,
 		value:                  value,
 		cost:                   cost,
-		creationTime:           bufutil.ConvertMillisToUnixTime(creationTime),
-		expirationTime:         bufutil.ConvertMillisToUnixTime(expirationTime),
+		creationTime:           timeutil.ConvertMillisToUnixTime(creationTime),
+		expirationTime:         timeutil.ConvertMillisToUnixTime(expirationTime),
 		hits:                   hits,
-		lastAccessTime:         bufutil.ConvertMillisToUnixTime(lastAccessTime),
-		lastStoredTime:         bufutil.ConvertMillisToUnixTime(lastStoredTime),
-		lastUpdateTime:         bufutil.ConvertMillisToUnixTime(lastUpdateTime),
+		lastAccessTime:         timeutil.ConvertMillisToUnixTime(lastAccessTime),
+		lastStoredTime:         timeutil.ConvertMillisToUnixTime(lastStoredTime),
+		lastUpdateTime:         timeutil.ConvertMillisToUnixTime(lastUpdateTime),
 		version:                version,
 		evictionCriteriaNumber: evictionCriteriaNumber,
-		ttl: bufutil.ConvertMillisToDuration(ttl),
+		ttl: timeutil.ConvertMillisToDuration(ttl),
 	}
 }
 
@@ -525,7 +526,7 @@ type TopicMessage struct {
 func NewTopicMessage(messageObject interface{}, publishTime int64, publishingMember *Member) *TopicMessage {
 	return &TopicMessage{
 		messageObject:    messageObject,
-		publishTime:      bufutil.ConvertMillisToUnixTime(publishTime),
+		publishTime:      timeutil.ConvertMillisToUnixTime(publishTime),
 		publishingMember: publishingMember,
 	}
 }

--- a/internal/protocol/custom_codec_test.go
+++ b/internal/protocol/custom_codec_test.go
@@ -17,7 +17,7 @@ package protocol
 import (
 	"testing"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
@@ -25,7 +25,7 @@ func TestAddressCodecEncodeDecode(t *testing.T) {
 	host := "test-host"
 	var port int32 = 8080
 	address := Address{host, port}
-	msg := NewClientMessage(nil, AddressCalculateSize(&address))
+	msg := NewClientMessage(nil, addressCalculateSize(&address))
 	AddressCodecEncode(msg, &address)
 	//Skip the header.
 	for i := 0; i < len(READ_HEADER); i++ {
@@ -122,9 +122,9 @@ func DataEntryViewCodecEncode(msg *ClientMessage, entryView *DataEntryView) {
 
 func DataEntryViewCalculateSize(ev *DataEntryView) int {
 	dataSize := 0
-	dataSize += DataCalculateSize(ev.keyData)
-	dataSize += DataCalculateSize(ev.valueData)
-	dataSize += 10 * common.Int64SizeInBytes
+	dataSize += dataCalculateSize(ev.keyData)
+	dataSize += dataCalculateSize(ev.valueData)
+	dataSize += 10 * bufutil.Int64SizeInBytes
 	return dataSize
 }
 
@@ -144,13 +144,13 @@ func MemberCodecEncode(msg *ClientMessage, member *Member) {
 
 func MemberCalculateSize(member *Member) int {
 	dataSize := 0
-	dataSize += AddressCalculateSize(&member.address)
-	dataSize += StringCalculateSize(&member.uuid)
-	dataSize += common.BoolSizeInBytes
-	dataSize += common.Int32SizeInBytes //Size of the map(attributes)
+	dataSize += addressCalculateSize(&member.address)
+	dataSize += stringCalculateSize(&member.uuid)
+	dataSize += bufutil.BoolSizeInBytes
+	dataSize += bufutil.Int32SizeInBytes //Size of the map(attributes)
 	for key, value := range member.attributes {
-		dataSize += StringCalculateSize(&key)
-		dataSize += StringCalculateSize(&value)
+		dataSize += stringCalculateSize(&key)
+		dataSize += stringCalculateSize(&value)
 	}
 	return dataSize
 }
@@ -165,7 +165,7 @@ func DistributedObjectInfoCodecEncode(msg *ClientMessage, obj *DistributedObject
 
 func DistributedObjectInfoCalculateSize(obj *DistributedObjectInfo) int {
 	dataSize := 0
-	dataSize += StringCalculateSize(&obj.name)
-	dataSize += StringCalculateSize(&obj.serviceName)
+	dataSize += stringCalculateSize(&obj.name)
+	dataSize += stringCalculateSize(&obj.serviceName)
 	return dataSize
 }

--- a/internal/protocol/flakeidgenerator_newidbatch.go
+++ b/internal/protocol/flakeidgenerator_newidbatch.go
@@ -15,14 +15,14 @@
 package protocol
 
 import (
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func FlakeIDGeneratorNewIDBatchCalculateSize(name *string, batchSize int32) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += common.Int32SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += bufutil.Int32SizeInBytes
 	return dataSize
 }
 

--- a/internal/protocol/list_add.go
+++ b/internal/protocol/list_add.go
@@ -21,8 +21,8 @@ import (
 func ListAddCalculateSize(name *string, value *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(value)
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(value)
 	return dataSize
 }
 

--- a/internal/protocol/list_addall.go
+++ b/internal/protocol/list_addall.go
@@ -17,16 +17,16 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func ListAddAllCalculateSize(name *string, valueList []*serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += common.Int32SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += bufutil.Int32SizeInBytes
 	for _, valueListItem := range valueList {
-		dataSize += DataCalculateSize(valueListItem)
+		dataSize += dataCalculateSize(valueListItem)
 	}
 	return dataSize
 }

--- a/internal/protocol/list_addallwithindex.go
+++ b/internal/protocol/list_addallwithindex.go
@@ -17,17 +17,17 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func ListAddAllWithIndexCalculateSize(name *string, index int32, valueList []*serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += common.Int32SizeInBytes
-	dataSize += common.Int32SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += bufutil.Int32SizeInBytes
+	dataSize += bufutil.Int32SizeInBytes
 	for _, valueListItem := range valueList {
-		dataSize += DataCalculateSize(valueListItem)
+		dataSize += dataCalculateSize(valueListItem)
 	}
 	return dataSize
 }

--- a/internal/protocol/list_addlistener.go
+++ b/internal/protocol/list_addlistener.go
@@ -17,15 +17,15 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func ListAddListenerCalculateSize(name *string, includeValue bool, localOnly bool) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += common.BoolSizeInBytes
-	dataSize += common.BoolSizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += bufutil.BoolSizeInBytes
+	dataSize += bufutil.BoolSizeInBytes
 	return dataSize
 }
 
@@ -65,7 +65,7 @@ func ListAddListenerHandle(clientMessage *ClientMessage,
 	handleEventItem ListAddListenerHandleEventItemFunc) {
 	// Event handler
 	messageType := clientMessage.MessageType()
-	if messageType == common.EventItem && handleEventItem != nil {
+	if messageType == bufutil.EventItem && handleEventItem != nil {
 		handleEventItem(ListAddListenerEventItemDecode(clientMessage))
 	}
 }

--- a/internal/protocol/list_addwithindex.go
+++ b/internal/protocol/list_addwithindex.go
@@ -17,15 +17,15 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func ListAddWithIndexCalculateSize(name *string, index int32, value *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += common.Int32SizeInBytes
-	dataSize += DataCalculateSize(value)
+	dataSize += stringCalculateSize(name)
+	dataSize += bufutil.Int32SizeInBytes
+	dataSize += dataCalculateSize(value)
 	return dataSize
 }
 

--- a/internal/protocol/list_clear.go
+++ b/internal/protocol/list_clear.go
@@ -17,7 +17,7 @@ package protocol
 func ListClearCalculateSize(name *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
+	dataSize += stringCalculateSize(name)
 	return dataSize
 }
 

--- a/internal/protocol/list_compareandremoveall.go
+++ b/internal/protocol/list_compareandremoveall.go
@@ -17,16 +17,16 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func ListCompareAndRemoveAllCalculateSize(name *string, values []*serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += common.Int32SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += bufutil.Int32SizeInBytes
 	for _, valuesItem := range values {
-		dataSize += DataCalculateSize(valuesItem)
+		dataSize += dataCalculateSize(valuesItem)
 	}
 	return dataSize
 }

--- a/internal/protocol/list_compareandretainall.go
+++ b/internal/protocol/list_compareandretainall.go
@@ -17,16 +17,16 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func ListCompareAndRetainAllCalculateSize(name *string, values []*serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += common.Int32SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += bufutil.Int32SizeInBytes
 	for _, valuesItem := range values {
-		dataSize += DataCalculateSize(valuesItem)
+		dataSize += dataCalculateSize(valuesItem)
 	}
 	return dataSize
 }

--- a/internal/protocol/list_contains.go
+++ b/internal/protocol/list_contains.go
@@ -21,8 +21,8 @@ import (
 func ListContainsCalculateSize(name *string, value *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(value)
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(value)
 	return dataSize
 }
 

--- a/internal/protocol/list_containsall.go
+++ b/internal/protocol/list_containsall.go
@@ -17,16 +17,16 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func ListContainsAllCalculateSize(name *string, values []*serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += common.Int32SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += bufutil.Int32SizeInBytes
 	for _, valuesItem := range values {
-		dataSize += DataCalculateSize(valuesItem)
+		dataSize += dataCalculateSize(valuesItem)
 	}
 	return dataSize
 }

--- a/internal/protocol/list_get.go
+++ b/internal/protocol/list_get.go
@@ -15,15 +15,15 @@
 package protocol
 
 import (
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
 func ListGetCalculateSize(name *string, index int32) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += common.Int32SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += bufutil.Int32SizeInBytes
 	return dataSize
 }
 

--- a/internal/protocol/list_getall.go
+++ b/internal/protocol/list_getall.go
@@ -21,7 +21,7 @@ import (
 func ListGetAllCalculateSize(name *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
+	dataSize += stringCalculateSize(name)
 	return dataSize
 }
 

--- a/internal/protocol/list_indexof.go
+++ b/internal/protocol/list_indexof.go
@@ -21,8 +21,8 @@ import (
 func ListIndexOfCalculateSize(name *string, value *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(value)
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(value)
 	return dataSize
 }
 

--- a/internal/protocol/list_isempty.go
+++ b/internal/protocol/list_isempty.go
@@ -17,7 +17,7 @@ package protocol
 func ListIsEmptyCalculateSize(name *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
+	dataSize += stringCalculateSize(name)
 	return dataSize
 }
 

--- a/internal/protocol/list_lastindexof.go
+++ b/internal/protocol/list_lastindexof.go
@@ -21,8 +21,8 @@ import (
 func ListLastIndexOfCalculateSize(name *string, value *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(value)
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(value)
 	return dataSize
 }
 

--- a/internal/protocol/list_remove.go
+++ b/internal/protocol/list_remove.go
@@ -21,8 +21,8 @@ import (
 func ListRemoveCalculateSize(name *string, value *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(value)
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(value)
 	return dataSize
 }
 

--- a/internal/protocol/list_removelistener.go
+++ b/internal/protocol/list_removelistener.go
@@ -17,8 +17,8 @@ package protocol
 func ListRemoveListenerCalculateSize(name *string, registrationID *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += StringCalculateSize(registrationID)
+	dataSize += stringCalculateSize(name)
+	dataSize += stringCalculateSize(registrationID)
 	return dataSize
 }
 

--- a/internal/protocol/list_removewithindex.go
+++ b/internal/protocol/list_removewithindex.go
@@ -15,15 +15,15 @@
 package protocol
 
 import (
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
 func ListRemoveWithIndexCalculateSize(name *string, index int32) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += common.Int32SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += bufutil.Int32SizeInBytes
 	return dataSize
 }
 

--- a/internal/protocol/list_set.go
+++ b/internal/protocol/list_set.go
@@ -17,15 +17,15 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func ListSetCalculateSize(name *string, index int32, value *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += common.Int32SizeInBytes
-	dataSize += DataCalculateSize(value)
+	dataSize += stringCalculateSize(name)
+	dataSize += bufutil.Int32SizeInBytes
+	dataSize += dataCalculateSize(value)
 	return dataSize
 }
 

--- a/internal/protocol/list_size.go
+++ b/internal/protocol/list_size.go
@@ -17,7 +17,7 @@ package protocol
 func ListSizeCalculateSize(name *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
+	dataSize += stringCalculateSize(name)
 	return dataSize
 }
 

--- a/internal/protocol/list_sub.go
+++ b/internal/protocol/list_sub.go
@@ -15,16 +15,16 @@
 package protocol
 
 import (
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
 func ListSubCalculateSize(name *string, from int32, to int32) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += common.Int32SizeInBytes
-	dataSize += common.Int32SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += bufutil.Int32SizeInBytes
+	dataSize += bufutil.Int32SizeInBytes
 	return dataSize
 }
 

--- a/internal/protocol/map_addentrylistener.go
+++ b/internal/protocol/map_addentrylistener.go
@@ -17,16 +17,16 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func MapAddEntryListenerCalculateSize(name *string, includeValue bool, listenerFlags int32, localOnly bool) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += common.BoolSizeInBytes
-	dataSize += common.Int32SizeInBytes
-	dataSize += common.BoolSizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += bufutil.BoolSizeInBytes
+	dataSize += bufutil.Int32SizeInBytes
+	dataSize += bufutil.BoolSizeInBytes
 	return dataSize
 }
 
@@ -80,7 +80,7 @@ func MapAddEntryListenerHandle(clientMessage *ClientMessage,
 	handleEventEntry MapAddEntryListenerHandleEventEntryFunc) {
 	// Event handler
 	messageType := clientMessage.MessageType()
-	if messageType == common.EventEntry && handleEventEntry != nil {
+	if messageType == bufutil.EventEntry && handleEventEntry != nil {
 		handleEventEntry(MapAddEntryListenerEventEntryDecode(clientMessage))
 	}
 }

--- a/internal/protocol/map_addentrylistenertokey.go
+++ b/internal/protocol/map_addentrylistenertokey.go
@@ -17,17 +17,17 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func MapAddEntryListenerToKeyCalculateSize(name *string, key *serialization.Data, includeValue bool, listenerFlags int32, localOnly bool) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(key)
-	dataSize += common.BoolSizeInBytes
-	dataSize += common.Int32SizeInBytes
-	dataSize += common.BoolSizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(key)
+	dataSize += bufutil.BoolSizeInBytes
+	dataSize += bufutil.Int32SizeInBytes
+	dataSize += bufutil.BoolSizeInBytes
 	return dataSize
 }
 
@@ -82,7 +82,7 @@ func MapAddEntryListenerToKeyHandle(clientMessage *ClientMessage,
 	handleEventEntry MapAddEntryListenerToKeyHandleEventEntryFunc) {
 	// Event handler
 	messageType := clientMessage.MessageType()
-	if messageType == common.EventEntry && handleEventEntry != nil {
+	if messageType == bufutil.EventEntry && handleEventEntry != nil {
 		handleEventEntry(MapAddEntryListenerToKeyEventEntryDecode(clientMessage))
 	}
 }

--- a/internal/protocol/map_addentrylistenertokeywithpredicate.go
+++ b/internal/protocol/map_addentrylistenertokeywithpredicate.go
@@ -17,18 +17,18 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func MapAddEntryListenerToKeyWithPredicateCalculateSize(name *string, key *serialization.Data, predicate *serialization.Data, includeValue bool, listenerFlags int32, localOnly bool) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(key)
-	dataSize += DataCalculateSize(predicate)
-	dataSize += common.BoolSizeInBytes
-	dataSize += common.Int32SizeInBytes
-	dataSize += common.BoolSizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(key)
+	dataSize += dataCalculateSize(predicate)
+	dataSize += bufutil.BoolSizeInBytes
+	dataSize += bufutil.Int32SizeInBytes
+	dataSize += bufutil.BoolSizeInBytes
 	return dataSize
 }
 
@@ -84,7 +84,7 @@ func MapAddEntryListenerToKeyWithPredicateHandle(clientMessage *ClientMessage,
 	handleEventEntry MapAddEntryListenerToKeyWithPredicateHandleEventEntryFunc) {
 	// Event handler
 	messageType := clientMessage.MessageType()
-	if messageType == common.EventEntry && handleEventEntry != nil {
+	if messageType == bufutil.EventEntry && handleEventEntry != nil {
 		handleEventEntry(MapAddEntryListenerToKeyWithPredicateEventEntryDecode(clientMessage))
 	}
 }

--- a/internal/protocol/map_addentrylistenerwithpredicate.go
+++ b/internal/protocol/map_addentrylistenerwithpredicate.go
@@ -17,17 +17,17 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func MapAddEntryListenerWithPredicateCalculateSize(name *string, predicate *serialization.Data, includeValue bool, listenerFlags int32, localOnly bool) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(predicate)
-	dataSize += common.BoolSizeInBytes
-	dataSize += common.Int32SizeInBytes
-	dataSize += common.BoolSizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(predicate)
+	dataSize += bufutil.BoolSizeInBytes
+	dataSize += bufutil.Int32SizeInBytes
+	dataSize += bufutil.BoolSizeInBytes
 	return dataSize
 }
 
@@ -82,7 +82,7 @@ func MapAddEntryListenerWithPredicateHandle(clientMessage *ClientMessage,
 	handleEventEntry MapAddEntryListenerWithPredicateHandleEventEntryFunc) {
 	// Event handler
 	messageType := clientMessage.MessageType()
-	if messageType == common.EventEntry && handleEventEntry != nil {
+	if messageType == bufutil.EventEntry && handleEventEntry != nil {
 		handleEventEntry(MapAddEntryListenerWithPredicateEventEntryDecode(clientMessage))
 	}
 }

--- a/internal/protocol/map_addindex.go
+++ b/internal/protocol/map_addindex.go
@@ -15,15 +15,15 @@
 package protocol
 
 import (
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func MapAddIndexCalculateSize(name *string, attribute *string, ordered bool) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += StringCalculateSize(attribute)
-	dataSize += common.BoolSizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += stringCalculateSize(attribute)
+	dataSize += bufutil.BoolSizeInBytes
 	return dataSize
 }
 

--- a/internal/protocol/map_clear.go
+++ b/internal/protocol/map_clear.go
@@ -17,7 +17,7 @@ package protocol
 func MapClearCalculateSize(name *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
+	dataSize += stringCalculateSize(name)
 	return dataSize
 }
 

--- a/internal/protocol/map_containskey.go
+++ b/internal/protocol/map_containskey.go
@@ -17,15 +17,15 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func MapContainsKeyCalculateSize(name *string, key *serialization.Data, threadID int64) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(key)
-	dataSize += common.Int64SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(key)
+	dataSize += bufutil.Int64SizeInBytes
 	return dataSize
 }
 

--- a/internal/protocol/map_containsvalue.go
+++ b/internal/protocol/map_containsvalue.go
@@ -21,8 +21,8 @@ import (
 func MapContainsValueCalculateSize(name *string, value *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(value)
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(value)
 	return dataSize
 }
 

--- a/internal/protocol/map_delete.go
+++ b/internal/protocol/map_delete.go
@@ -17,15 +17,15 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func MapDeleteCalculateSize(name *string, key *serialization.Data, threadID int64) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(key)
-	dataSize += common.Int64SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(key)
+	dataSize += bufutil.Int64SizeInBytes
 	return dataSize
 }
 

--- a/internal/protocol/map_entrieswithpredicate.go
+++ b/internal/protocol/map_entrieswithpredicate.go
@@ -21,8 +21,8 @@ import (
 func MapEntriesWithPredicateCalculateSize(name *string, predicate *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(predicate)
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(predicate)
 	return dataSize
 }
 

--- a/internal/protocol/map_entryset.go
+++ b/internal/protocol/map_entryset.go
@@ -17,7 +17,7 @@ package protocol
 func MapEntrySetCalculateSize(name *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
+	dataSize += stringCalculateSize(name)
 	return dataSize
 }
 

--- a/internal/protocol/map_evict.go
+++ b/internal/protocol/map_evict.go
@@ -17,15 +17,15 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func MapEvictCalculateSize(name *string, key *serialization.Data, threadID int64) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(key)
-	dataSize += common.Int64SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(key)
+	dataSize += bufutil.Int64SizeInBytes
 	return dataSize
 }
 

--- a/internal/protocol/map_evictall.go
+++ b/internal/protocol/map_evictall.go
@@ -17,7 +17,7 @@ package protocol
 func MapEvictAllCalculateSize(name *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
+	dataSize += stringCalculateSize(name)
 	return dataSize
 }
 

--- a/internal/protocol/map_executeonallkeys.go
+++ b/internal/protocol/map_executeonallkeys.go
@@ -21,8 +21,8 @@ import (
 func MapExecuteOnAllKeysCalculateSize(name *string, entryProcessor *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(entryProcessor)
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(entryProcessor)
 	return dataSize
 }
 

--- a/internal/protocol/map_executeonkey.go
+++ b/internal/protocol/map_executeonkey.go
@@ -17,16 +17,16 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func MapExecuteOnKeyCalculateSize(name *string, entryProcessor *serialization.Data, key *serialization.Data, threadID int64) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(entryProcessor)
-	dataSize += DataCalculateSize(key)
-	dataSize += common.Int64SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(entryProcessor)
+	dataSize += dataCalculateSize(key)
+	dataSize += bufutil.Int64SizeInBytes
 	return dataSize
 }
 

--- a/internal/protocol/map_executeonkeys.go
+++ b/internal/protocol/map_executeonkeys.go
@@ -17,17 +17,17 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func MapExecuteOnKeysCalculateSize(name *string, entryProcessor *serialization.Data, keys []*serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(entryProcessor)
-	dataSize += common.Int32SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(entryProcessor)
+	dataSize += bufutil.Int32SizeInBytes
 	for _, keysItem := range keys {
-		dataSize += DataCalculateSize(keysItem)
+		dataSize += dataCalculateSize(keysItem)
 	}
 	return dataSize
 }

--- a/internal/protocol/map_executewithpredicate.go
+++ b/internal/protocol/map_executewithpredicate.go
@@ -21,9 +21,9 @@ import (
 func MapExecuteWithPredicateCalculateSize(name *string, entryProcessor *serialization.Data, predicate *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(entryProcessor)
-	dataSize += DataCalculateSize(predicate)
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(entryProcessor)
+	dataSize += dataCalculateSize(predicate)
 	return dataSize
 }
 

--- a/internal/protocol/map_flush.go
+++ b/internal/protocol/map_flush.go
@@ -17,7 +17,7 @@ package protocol
 func MapFlushCalculateSize(name *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
+	dataSize += stringCalculateSize(name)
 	return dataSize
 }
 

--- a/internal/protocol/map_forceunlock.go
+++ b/internal/protocol/map_forceunlock.go
@@ -17,15 +17,15 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func MapForceUnlockCalculateSize(name *string, key *serialization.Data, referenceID int64) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(key)
-	dataSize += common.Int64SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(key)
+	dataSize += bufutil.Int64SizeInBytes
 	return dataSize
 }
 

--- a/internal/protocol/map_get.go
+++ b/internal/protocol/map_get.go
@@ -17,15 +17,15 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func MapGetCalculateSize(name *string, key *serialization.Data, threadID int64) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(key)
-	dataSize += common.Int64SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(key)
+	dataSize += bufutil.Int64SizeInBytes
 	return dataSize
 }
 

--- a/internal/protocol/map_getall.go
+++ b/internal/protocol/map_getall.go
@@ -17,16 +17,16 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func MapGetAllCalculateSize(name *string, keys []*serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += common.Int32SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += bufutil.Int32SizeInBytes
 	for _, keysItem := range keys {
-		dataSize += DataCalculateSize(keysItem)
+		dataSize += dataCalculateSize(keysItem)
 	}
 	return dataSize
 }

--- a/internal/protocol/map_getentryview.go
+++ b/internal/protocol/map_getentryview.go
@@ -17,15 +17,15 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func MapGetEntryViewCalculateSize(name *string, key *serialization.Data, threadID int64) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(key)
-	dataSize += common.Int64SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(key)
+	dataSize += bufutil.Int64SizeInBytes
 	return dataSize
 }
 

--- a/internal/protocol/map_isempty.go
+++ b/internal/protocol/map_isempty.go
@@ -17,7 +17,7 @@ package protocol
 func MapIsEmptyCalculateSize(name *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
+	dataSize += stringCalculateSize(name)
 	return dataSize
 }
 

--- a/internal/protocol/map_islocked.go
+++ b/internal/protocol/map_islocked.go
@@ -21,8 +21,8 @@ import (
 func MapIsLockedCalculateSize(name *string, key *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(key)
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(key)
 	return dataSize
 }
 

--- a/internal/protocol/map_keyset.go
+++ b/internal/protocol/map_keyset.go
@@ -21,7 +21,7 @@ import (
 func MapKeySetCalculateSize(name *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
+	dataSize += stringCalculateSize(name)
 	return dataSize
 }
 

--- a/internal/protocol/map_keysetwithpredicate.go
+++ b/internal/protocol/map_keysetwithpredicate.go
@@ -21,8 +21,8 @@ import (
 func MapKeySetWithPredicateCalculateSize(name *string, predicate *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(predicate)
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(predicate)
 	return dataSize
 }
 

--- a/internal/protocol/map_lock.go
+++ b/internal/protocol/map_lock.go
@@ -17,17 +17,17 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func MapLockCalculateSize(name *string, key *serialization.Data, threadID int64, ttl int64, referenceID int64) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(key)
-	dataSize += common.Int64SizeInBytes
-	dataSize += common.Int64SizeInBytes
-	dataSize += common.Int64SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(key)
+	dataSize += bufutil.Int64SizeInBytes
+	dataSize += bufutil.Int64SizeInBytes
+	dataSize += bufutil.Int64SizeInBytes
 	return dataSize
 }
 

--- a/internal/protocol/map_put.go
+++ b/internal/protocol/map_put.go
@@ -17,17 +17,17 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func MapPutCalculateSize(name *string, key *serialization.Data, value *serialization.Data, threadID int64, ttl int64) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(key)
-	dataSize += DataCalculateSize(value)
-	dataSize += common.Int64SizeInBytes
-	dataSize += common.Int64SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(key)
+	dataSize += dataCalculateSize(value)
+	dataSize += bufutil.Int64SizeInBytes
+	dataSize += bufutil.Int64SizeInBytes
 	return dataSize
 }
 

--- a/internal/protocol/map_putall.go
+++ b/internal/protocol/map_putall.go
@@ -17,19 +17,19 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func MapPutAllCalculateSize(name *string, entries []*Pair) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += common.Int32SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += bufutil.Int32SizeInBytes
 	for _, entriesItem := range entries {
 		key := entriesItem.key.(*serialization.Data)
 		val := entriesItem.value.(*serialization.Data)
-		dataSize += DataCalculateSize(key)
-		dataSize += DataCalculateSize(val)
+		dataSize += dataCalculateSize(key)
+		dataSize += dataCalculateSize(val)
 	}
 	return dataSize
 }

--- a/internal/protocol/map_putifabsent.go
+++ b/internal/protocol/map_putifabsent.go
@@ -17,17 +17,17 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func MapPutIfAbsentCalculateSize(name *string, key *serialization.Data, value *serialization.Data, threadID int64, ttl int64) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(key)
-	dataSize += DataCalculateSize(value)
-	dataSize += common.Int64SizeInBytes
-	dataSize += common.Int64SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(key)
+	dataSize += dataCalculateSize(value)
+	dataSize += bufutil.Int64SizeInBytes
+	dataSize += bufutil.Int64SizeInBytes
 	return dataSize
 }
 

--- a/internal/protocol/map_puttransient.go
+++ b/internal/protocol/map_puttransient.go
@@ -17,17 +17,17 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func MapPutTransientCalculateSize(name *string, key *serialization.Data, value *serialization.Data, threadID int64, ttl int64) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(key)
-	dataSize += DataCalculateSize(value)
-	dataSize += common.Int64SizeInBytes
-	dataSize += common.Int64SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(key)
+	dataSize += dataCalculateSize(value)
+	dataSize += bufutil.Int64SizeInBytes
+	dataSize += bufutil.Int64SizeInBytes
 	return dataSize
 }
 

--- a/internal/protocol/map_remove.go
+++ b/internal/protocol/map_remove.go
@@ -17,15 +17,15 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func MapRemoveCalculateSize(name *string, key *serialization.Data, threadID int64) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(key)
-	dataSize += common.Int64SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(key)
+	dataSize += bufutil.Int64SizeInBytes
 	return dataSize
 }
 

--- a/internal/protocol/map_removeall.go
+++ b/internal/protocol/map_removeall.go
@@ -21,8 +21,8 @@ import (
 func MapRemoveAllCalculateSize(name *string, predicate *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(predicate)
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(predicate)
 	return dataSize
 }
 

--- a/internal/protocol/map_removeentrylistener.go
+++ b/internal/protocol/map_removeentrylistener.go
@@ -17,8 +17,8 @@ package protocol
 func MapRemoveEntryListenerCalculateSize(name *string, registrationID *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += StringCalculateSize(registrationID)
+	dataSize += stringCalculateSize(name)
+	dataSize += stringCalculateSize(registrationID)
 	return dataSize
 }
 

--- a/internal/protocol/map_removeifsame.go
+++ b/internal/protocol/map_removeifsame.go
@@ -17,16 +17,16 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func MapRemoveIfSameCalculateSize(name *string, key *serialization.Data, value *serialization.Data, threadID int64) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(key)
-	dataSize += DataCalculateSize(value)
-	dataSize += common.Int64SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(key)
+	dataSize += dataCalculateSize(value)
+	dataSize += bufutil.Int64SizeInBytes
 	return dataSize
 }
 

--- a/internal/protocol/map_replace.go
+++ b/internal/protocol/map_replace.go
@@ -17,16 +17,16 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func MapReplaceCalculateSize(name *string, key *serialization.Data, value *serialization.Data, threadID int64) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(key)
-	dataSize += DataCalculateSize(value)
-	dataSize += common.Int64SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(key)
+	dataSize += dataCalculateSize(value)
+	dataSize += bufutil.Int64SizeInBytes
 	return dataSize
 }
 

--- a/internal/protocol/map_replaceifsame.go
+++ b/internal/protocol/map_replaceifsame.go
@@ -17,17 +17,17 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func MapReplaceIfSameCalculateSize(name *string, key *serialization.Data, testValue *serialization.Data, value *serialization.Data, threadID int64) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(key)
-	dataSize += DataCalculateSize(testValue)
-	dataSize += DataCalculateSize(value)
-	dataSize += common.Int64SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(key)
+	dataSize += dataCalculateSize(testValue)
+	dataSize += dataCalculateSize(value)
+	dataSize += bufutil.Int64SizeInBytes
 	return dataSize
 }
 

--- a/internal/protocol/map_set.go
+++ b/internal/protocol/map_set.go
@@ -17,17 +17,17 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func MapSetCalculateSize(name *string, key *serialization.Data, value *serialization.Data, threadID int64, ttl int64) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(key)
-	dataSize += DataCalculateSize(value)
-	dataSize += common.Int64SizeInBytes
-	dataSize += common.Int64SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(key)
+	dataSize += dataCalculateSize(value)
+	dataSize += bufutil.Int64SizeInBytes
+	dataSize += bufutil.Int64SizeInBytes
 	return dataSize
 }
 

--- a/internal/protocol/map_size.go
+++ b/internal/protocol/map_size.go
@@ -17,7 +17,7 @@ package protocol
 func MapSizeCalculateSize(name *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
+	dataSize += stringCalculateSize(name)
 	return dataSize
 }
 

--- a/internal/protocol/map_trylock.go
+++ b/internal/protocol/map_trylock.go
@@ -17,18 +17,18 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func MapTryLockCalculateSize(name *string, key *serialization.Data, threadID int64, lease int64, timeout int64, referenceID int64) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(key)
-	dataSize += common.Int64SizeInBytes
-	dataSize += common.Int64SizeInBytes
-	dataSize += common.Int64SizeInBytes
-	dataSize += common.Int64SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(key)
+	dataSize += bufutil.Int64SizeInBytes
+	dataSize += bufutil.Int64SizeInBytes
+	dataSize += bufutil.Int64SizeInBytes
+	dataSize += bufutil.Int64SizeInBytes
 	return dataSize
 }
 

--- a/internal/protocol/map_tryput.go
+++ b/internal/protocol/map_tryput.go
@@ -17,17 +17,17 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func MapTryPutCalculateSize(name *string, key *serialization.Data, value *serialization.Data, threadID int64, timeout int64) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(key)
-	dataSize += DataCalculateSize(value)
-	dataSize += common.Int64SizeInBytes
-	dataSize += common.Int64SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(key)
+	dataSize += dataCalculateSize(value)
+	dataSize += bufutil.Int64SizeInBytes
+	dataSize += bufutil.Int64SizeInBytes
 	return dataSize
 }
 

--- a/internal/protocol/map_tryremove.go
+++ b/internal/protocol/map_tryremove.go
@@ -17,16 +17,16 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func MapTryRemoveCalculateSize(name *string, key *serialization.Data, threadID int64, timeout int64) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(key)
-	dataSize += common.Int64SizeInBytes
-	dataSize += common.Int64SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(key)
+	dataSize += bufutil.Int64SizeInBytes
+	dataSize += bufutil.Int64SizeInBytes
 	return dataSize
 }
 

--- a/internal/protocol/map_unlock.go
+++ b/internal/protocol/map_unlock.go
@@ -17,16 +17,16 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func MapUnlockCalculateSize(name *string, key *serialization.Data, threadID int64, referenceID int64) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(key)
-	dataSize += common.Int64SizeInBytes
-	dataSize += common.Int64SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(key)
+	dataSize += bufutil.Int64SizeInBytes
+	dataSize += bufutil.Int64SizeInBytes
 	return dataSize
 }
 

--- a/internal/protocol/map_values.go
+++ b/internal/protocol/map_values.go
@@ -21,7 +21,7 @@ import (
 func MapValuesCalculateSize(name *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
+	dataSize += stringCalculateSize(name)
 	return dataSize
 }
 

--- a/internal/protocol/map_valueswithpredicate.go
+++ b/internal/protocol/map_valueswithpredicate.go
@@ -21,8 +21,8 @@ import (
 func MapValuesWithPredicateCalculateSize(name *string, predicate *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(predicate)
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(predicate)
 	return dataSize
 }
 

--- a/internal/protocol/message.go
+++ b/internal/protocol/message.go
@@ -18,7 +18,7 @@ import (
 	"encoding/binary"
 	"unicode/utf8"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
@@ -59,39 +59,39 @@ func NewClientMessage(buffer []byte, payloadSize int) *ClientMessage {
 	if buffer != nil {
 		//Message has a buffer so it will be decoded.
 		clientMessage.Buffer = buffer
-		clientMessage.readIndex = common.HeaderSize
+		clientMessage.readIndex = bufutil.HeaderSize
 	} else {
 		//Client message that will be encoded.
-		clientMessage.Buffer = make([]byte, common.HeaderSize+payloadSize)
-		clientMessage.SetDataOffset(common.HeaderSize)
-		clientMessage.writeIndex = common.HeaderSize
+		clientMessage.Buffer = make([]byte, bufutil.HeaderSize+payloadSize)
+		clientMessage.SetDataOffset(bufutil.HeaderSize)
+		clientMessage.writeIndex = bufutil.HeaderSize
 	}
 	clientMessage.IsRetryable = false
 	return clientMessage
 }
 
 func (m *ClientMessage) FrameLength() int32 {
-	return int32(binary.LittleEndian.Uint32(m.Buffer[common.FrameLengthFieldOffset:common.VersionFieldOffset]))
+	return int32(binary.LittleEndian.Uint32(m.Buffer[bufutil.FrameLengthFieldOffset:bufutil.VersionFieldOffset]))
 }
 
 func (m *ClientMessage) SetFrameLength(v int32) {
-	binary.LittleEndian.PutUint32(m.Buffer[common.FrameLengthFieldOffset:common.VersionFieldOffset], uint32(v))
+	binary.LittleEndian.PutUint32(m.Buffer[bufutil.FrameLengthFieldOffset:bufutil.VersionFieldOffset], uint32(v))
 }
 
 func (m *ClientMessage) SetVersion(v uint8) {
-	m.Buffer[common.VersionFieldOffset] = byte(v)
+	m.Buffer[bufutil.VersionFieldOffset] = byte(v)
 }
 
 func (m *ClientMessage) Flags() uint8 {
-	return m.Buffer[common.FlagsFieldOffset]
+	return m.Buffer[bufutil.FlagsFieldOffset]
 }
 
 func (m *ClientMessage) SetFlags(v uint8) {
-	m.Buffer[common.FlagsFieldOffset] = byte(v)
+	m.Buffer[bufutil.FlagsFieldOffset] = byte(v)
 }
 
 func (m *ClientMessage) AddFlags(v uint8) {
-	m.Buffer[common.FlagsFieldOffset] = m.Buffer[common.FlagsFieldOffset] | byte(v)
+	m.Buffer[bufutil.FlagsFieldOffset] = m.Buffer[bufutil.FlagsFieldOffset] | byte(v)
 }
 
 func (m *ClientMessage) HasFlags(flags uint8) uint8 {
@@ -102,36 +102,36 @@ func (m *ClientMessage) HasFlags(flags uint8) uint8 {
 	return 0
 }
 
-func (m *ClientMessage) MessageType() common.MessageType {
-	return common.MessageType(binary.LittleEndian.Uint16(m.Buffer[common.TypeFieldOffset:common.CorrelationIDFieldOffset]))
+func (m *ClientMessage) MessageType() bufutil.MessageType {
+	return bufutil.MessageType(binary.LittleEndian.Uint16(m.Buffer[bufutil.TypeFieldOffset:bufutil.CorrelationIDFieldOffset]))
 }
 
-func (m *ClientMessage) SetMessageType(v common.MessageType) {
-	binary.LittleEndian.PutUint16(m.Buffer[common.TypeFieldOffset:common.CorrelationIDFieldOffset], uint16(v))
+func (m *ClientMessage) SetMessageType(v bufutil.MessageType) {
+	binary.LittleEndian.PutUint16(m.Buffer[bufutil.TypeFieldOffset:bufutil.CorrelationIDFieldOffset], uint16(v))
 }
 
 func (m *ClientMessage) CorrelationID() int64 {
-	return int64(binary.LittleEndian.Uint64(m.Buffer[common.CorrelationIDFieldOffset:common.PartitionIDFieldOffset]))
+	return int64(binary.LittleEndian.Uint64(m.Buffer[bufutil.CorrelationIDFieldOffset:bufutil.PartitionIDFieldOffset]))
 }
 
 func (m *ClientMessage) SetCorrelationID(val int64) {
-	binary.LittleEndian.PutUint64(m.Buffer[common.CorrelationIDFieldOffset:common.PartitionIDFieldOffset], uint64(val))
+	binary.LittleEndian.PutUint64(m.Buffer[bufutil.CorrelationIDFieldOffset:bufutil.PartitionIDFieldOffset], uint64(val))
 }
 
 func (m *ClientMessage) PartitionID() int32 {
-	return int32(binary.LittleEndian.Uint32(m.Buffer[common.PartitionIDFieldOffset:common.DataOffsetFieldOffset]))
+	return int32(binary.LittleEndian.Uint32(m.Buffer[bufutil.PartitionIDFieldOffset:bufutil.DataOffsetFieldOffset]))
 }
 
 func (m *ClientMessage) SetPartitionID(val int32) {
-	binary.LittleEndian.PutUint32(m.Buffer[common.PartitionIDFieldOffset:common.DataOffsetFieldOffset], uint32(val))
+	binary.LittleEndian.PutUint32(m.Buffer[bufutil.PartitionIDFieldOffset:bufutil.DataOffsetFieldOffset], uint32(val))
 }
 
 func (m *ClientMessage) DataOffset() uint16 {
-	return binary.LittleEndian.Uint16(m.Buffer[common.DataOffsetFieldOffset:common.HeaderSize])
+	return binary.LittleEndian.Uint16(m.Buffer[bufutil.DataOffsetFieldOffset:bufutil.HeaderSize])
 }
 
 func (m *ClientMessage) SetDataOffset(v uint16) {
-	binary.LittleEndian.PutUint16(m.Buffer[common.DataOffsetFieldOffset:common.HeaderSize], v)
+	binary.LittleEndian.PutUint16(m.Buffer[bufutil.DataOffsetFieldOffset:bufutil.HeaderSize], v)
 }
 
 func (m *ClientMessage) writeOffset() int32 {
@@ -148,17 +148,17 @@ func (m *ClientMessage) readOffset() int32 {
 
 func (m *ClientMessage) AppendByte(v uint8) {
 	m.Buffer[m.writeIndex] = byte(v)
-	m.writeIndex += common.ByteSizeInBytes
+	m.writeIndex += bufutil.ByteSizeInBytes
 }
 
 func (m *ClientMessage) AppendUint8(v uint8) {
 	m.Buffer[m.writeIndex] = byte(v)
-	m.writeIndex += common.ByteSizeInBytes
+	m.writeIndex += bufutil.ByteSizeInBytes
 }
 
 func (m *ClientMessage) AppendInt32(v int32) {
-	binary.LittleEndian.PutUint32(m.Buffer[m.writeIndex:m.writeIndex+common.Int32SizeInBytes], uint32(v))
-	m.writeIndex += common.Int32SizeInBytes
+	binary.LittleEndian.PutUint32(m.Buffer[m.writeIndex:m.writeIndex+bufutil.Int32SizeInBytes], uint32(v))
+	m.writeIndex += bufutil.Int32SizeInBytes
 }
 
 func (m *ClientMessage) AppendData(v *serialization.Data) {
@@ -175,8 +175,8 @@ func (m *ClientMessage) AppendByteArray(arr []byte) {
 }
 
 func (m *ClientMessage) AppendInt64(v int64) {
-	binary.LittleEndian.PutUint64(m.Buffer[m.writeIndex:m.writeIndex+common.Int64SizeInBytes], uint64(v))
-	m.writeIndex += common.Int64SizeInBytes
+	binary.LittleEndian.PutUint64(m.Buffer[m.writeIndex:m.writeIndex+bufutil.Int64SizeInBytes], uint64(v))
+	m.writeIndex += bufutil.Int64SizeInBytes
 }
 
 func (m *ClientMessage) AppendString(str *string) {
@@ -206,20 +206,20 @@ func (m *ClientMessage) AppendBool(v bool) {
 */
 
 func (m *ClientMessage) ReadInt32() int32 {
-	int := int32(binary.LittleEndian.Uint32(m.Buffer[m.readOffset() : m.readOffset()+common.Int32SizeInBytes]))
-	m.readIndex += common.Int32SizeInBytes
+	int := int32(binary.LittleEndian.Uint32(m.Buffer[m.readOffset() : m.readOffset()+bufutil.Int32SizeInBytes]))
+	m.readIndex += bufutil.Int32SizeInBytes
 	return int
 }
 
 func (m *ClientMessage) ReadInt64() int64 {
-	int64 := int64(binary.LittleEndian.Uint64(m.Buffer[m.readOffset() : m.readOffset()+common.Int64SizeInBytes]))
-	m.readIndex += common.Int64SizeInBytes
+	int64 := int64(binary.LittleEndian.Uint64(m.Buffer[m.readOffset() : m.readOffset()+bufutil.Int64SizeInBytes]))
+	m.readIndex += bufutil.Int64SizeInBytes
 	return int64
 }
 
 func (m *ClientMessage) ReadUint8() uint8 {
 	byte := byte(m.Buffer[m.readOffset()])
-	m.readIndex += common.ByteSizeInBytes
+	m.readIndex += bufutil.ByteSizeInBytes
 	return byte
 }
 
@@ -262,5 +262,5 @@ func (m *ClientMessage) Accumulate(newMsg *ClientMessage) {
 }
 
 func (m *ClientMessage) IsComplete() bool {
-	return (m.readOffset() >= common.HeaderSize) && (m.readOffset() == m.FrameLength())
+	return (m.readOffset() >= bufutil.HeaderSize) && (m.readOffset() == m.FrameLength())
 }

--- a/internal/protocol/message_test.go
+++ b/internal/protocol/message_test.go
@@ -18,7 +18,7 @@ import (
 	"encoding/hex"
 	"testing"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 var READ_HEADER = []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 16, 0}
@@ -26,7 +26,7 @@ var READ_HEADER = []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 func TestHeaderFields(t *testing.T) {
 	message := NewClientMessage(nil, 30)
 	var correlationID int64 = 6474838
-	var messageType common.MessageType = 987
+	var messageType bufutil.MessageType = 987
 	var flags uint8 = 5
 	var partitionID int32 = 27
 	var frameLength int32 = 100
@@ -184,13 +184,13 @@ func TestClientMessage_ReadString(t *testing.T) {
 func TestNoFlag(t *testing.T) {
 	message := NewClientMessage(nil, 30)
 	message.SetFlags(0)
-	if result := message.HasFlags(common.BeginFlag); result != 0 {
+	if result := message.HasFlags(bufutil.BeginFlag); result != 0 {
 		t.Errorf("HasFlag returned %d expected 0", result)
 	}
-	if result := message.HasFlags(common.EndFlag); result != 0 {
+	if result := message.HasFlags(bufutil.EndFlag); result != 0 {
 		t.Errorf("HasFlag returned %d expected 0", result)
 	}
-	if result := message.HasFlags(common.ListenerFlag); result != 0 {
+	if result := message.HasFlags(bufutil.ListenerFlag); result != 0 {
 		t.Errorf("HasFlag returned %d expected 0", result)
 	}
 }
@@ -198,14 +198,14 @@ func TestNoFlag(t *testing.T) {
 func TestSetFlagBegin(t *testing.T) {
 	message := NewClientMessage(nil, 30)
 	message.SetFlags(0)
-	message.AddFlags(common.BeginFlag)
-	if result := message.HasFlags(common.BeginFlag); result == 0 {
+	message.AddFlags(bufutil.BeginFlag)
+	if result := message.HasFlags(bufutil.BeginFlag); result == 0 {
 		t.Errorf("HasFlag returned %d expected 128", result)
 	}
-	if result := message.HasFlags(common.EndFlag); result != 0 {
+	if result := message.HasFlags(bufutil.EndFlag); result != 0 {
 		t.Errorf("HasFlag returned %d expected 0", result)
 	}
-	if result := message.HasFlags(common.ListenerFlag); result != 0 {
+	if result := message.HasFlags(bufutil.ListenerFlag); result != 0 {
 		t.Errorf("HasFlag returned %d expected 0", result)
 	}
 }
@@ -213,14 +213,14 @@ func TestSetFlagBegin(t *testing.T) {
 func TestSetFlagEnd(t *testing.T) {
 	message := NewClientMessage(nil, 30)
 	message.SetFlags(0)
-	message.AddFlags(common.EndFlag)
-	if result := message.HasFlags(common.BeginFlag); result != 0 {
+	message.AddFlags(bufutil.EndFlag)
+	if result := message.HasFlags(bufutil.BeginFlag); result != 0 {
 		t.Errorf("HasFlag returned %d expected 0", result)
 	}
-	if result := message.HasFlags(common.EndFlag); result == 0 {
+	if result := message.HasFlags(bufutil.EndFlag); result == 0 {
 		t.Errorf("HasFlag returned %d expected 64", result)
 	}
-	if result := message.HasFlags(common.ListenerFlag); result != 0 {
+	if result := message.HasFlags(bufutil.ListenerFlag); result != 0 {
 		t.Errorf("HasFlag returned %d expected 0", result)
 	}
 }
@@ -228,22 +228,22 @@ func TestSetFlagEnd(t *testing.T) {
 func TestSetListenerFlag(t *testing.T) {
 	message := NewClientMessage(nil, 30)
 	message.SetFlags(0)
-	message.AddFlags(common.ListenerFlag)
-	if result := message.HasFlags(common.BeginFlag); result != 0 {
+	message.AddFlags(bufutil.ListenerFlag)
+	if result := message.HasFlags(bufutil.BeginFlag); result != 0 {
 		t.Errorf("HasFlag returned %d expected 0", result)
 	}
-	if result := message.HasFlags(common.EndFlag); result != 0 {
+	if result := message.HasFlags(bufutil.EndFlag); result != 0 {
 		t.Errorf("HasFlag returned %d expected 0", result)
 	}
-	if result := message.HasFlags(common.ListenerFlag); result == 0 {
+	if result := message.HasFlags(bufutil.ListenerFlag); result == 0 {
 		t.Errorf("HasFlag returned %d expected 1", result)
 	}
 }
 
 func TestCalculateSizeStr(t *testing.T) {
 	testString := "abc"
-	if result := StringCalculateSize(&testString); result != len(testString)+common.Int32SizeInBytes {
-		t.Errorf("StringCalculateSize returned %d expected %d", result, len(testString)+common.Int32SizeInBytes)
+	if result := stringCalculateSize(&testString); result != len(testString)+bufutil.Int32SizeInBytes {
+		t.Errorf("StringCalculateSize returned %d expected %d", result, len(testString)+bufutil.Int32SizeInBytes)
 	}
 }
 

--- a/internal/protocol/multimap_addentrylistener.go
+++ b/internal/protocol/multimap_addentrylistener.go
@@ -17,15 +17,15 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func MultiMapAddEntryListenerCalculateSize(name *string, includeValue bool, localOnly bool) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += common.BoolSizeInBytes
-	dataSize += common.BoolSizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += bufutil.BoolSizeInBytes
+	dataSize += bufutil.BoolSizeInBytes
 	return dataSize
 }
 
@@ -78,7 +78,7 @@ func MultiMapAddEntryListenerHandle(clientMessage *ClientMessage,
 	handleEventEntry MultiMapAddEntryListenerHandleEventEntryFunc) {
 	// Event handler
 	messageType := clientMessage.MessageType()
-	if messageType == common.EventEntry && handleEventEntry != nil {
+	if messageType == bufutil.EventEntry && handleEventEntry != nil {
 		handleEventEntry(MultiMapAddEntryListenerEventEntryDecode(clientMessage))
 	}
 }

--- a/internal/protocol/multimap_addentrylistenertokey.go
+++ b/internal/protocol/multimap_addentrylistenertokey.go
@@ -17,16 +17,16 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func MultiMapAddEntryListenerToKeyCalculateSize(name *string, key *serialization.Data, includeValue bool, localOnly bool) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(key)
-	dataSize += common.BoolSizeInBytes
-	dataSize += common.BoolSizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(key)
+	dataSize += bufutil.BoolSizeInBytes
+	dataSize += bufutil.BoolSizeInBytes
 	return dataSize
 }
 
@@ -80,7 +80,7 @@ func MultiMapAddEntryListenerToKeyHandle(clientMessage *ClientMessage,
 	handleEventEntry MultiMapAddEntryListenerToKeyHandleEventEntryFunc) {
 	// Event handler
 	messageType := clientMessage.MessageType()
-	if messageType == common.EventEntry && handleEventEntry != nil {
+	if messageType == bufutil.EventEntry && handleEventEntry != nil {
 		handleEventEntry(MultiMapAddEntryListenerToKeyEventEntryDecode(clientMessage))
 	}
 }

--- a/internal/protocol/multimap_clear.go
+++ b/internal/protocol/multimap_clear.go
@@ -17,7 +17,7 @@ package protocol
 func MultiMapClearCalculateSize(name *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
+	dataSize += stringCalculateSize(name)
 	return dataSize
 }
 

--- a/internal/protocol/multimap_containsentry.go
+++ b/internal/protocol/multimap_containsentry.go
@@ -17,16 +17,16 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func MultiMapContainsEntryCalculateSize(name *string, key *serialization.Data, value *serialization.Data, threadID int64) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(key)
-	dataSize += DataCalculateSize(value)
-	dataSize += common.Int64SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(key)
+	dataSize += dataCalculateSize(value)
+	dataSize += bufutil.Int64SizeInBytes
 	return dataSize
 }
 

--- a/internal/protocol/multimap_containskey.go
+++ b/internal/protocol/multimap_containskey.go
@@ -17,15 +17,15 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func MultiMapContainsKeyCalculateSize(name *string, key *serialization.Data, threadID int64) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(key)
-	dataSize += common.Int64SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(key)
+	dataSize += bufutil.Int64SizeInBytes
 	return dataSize
 }
 

--- a/internal/protocol/multimap_containsvalue.go
+++ b/internal/protocol/multimap_containsvalue.go
@@ -21,8 +21,8 @@ import (
 func MultiMapContainsValueCalculateSize(name *string, value *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(value)
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(value)
 	return dataSize
 }
 

--- a/internal/protocol/multimap_delete.go
+++ b/internal/protocol/multimap_delete.go
@@ -17,15 +17,15 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func MultiMapDeleteCalculateSize(name *string, key *serialization.Data, threadID int64) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(key)
-	dataSize += common.Int64SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(key)
+	dataSize += bufutil.Int64SizeInBytes
 	return dataSize
 }
 

--- a/internal/protocol/multimap_entryset.go
+++ b/internal/protocol/multimap_entryset.go
@@ -17,7 +17,7 @@ package protocol
 func MultiMapEntrySetCalculateSize(name *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
+	dataSize += stringCalculateSize(name)
 	return dataSize
 }
 

--- a/internal/protocol/multimap_forceunlock.go
+++ b/internal/protocol/multimap_forceunlock.go
@@ -17,15 +17,15 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func MultiMapForceUnlockCalculateSize(name *string, key *serialization.Data, referenceID int64) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(key)
-	dataSize += common.Int64SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(key)
+	dataSize += bufutil.Int64SizeInBytes
 	return dataSize
 }
 

--- a/internal/protocol/multimap_get.go
+++ b/internal/protocol/multimap_get.go
@@ -17,15 +17,15 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func MultiMapGetCalculateSize(name *string, key *serialization.Data, threadID int64) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(key)
-	dataSize += common.Int64SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(key)
+	dataSize += bufutil.Int64SizeInBytes
 	return dataSize
 }
 

--- a/internal/protocol/multimap_islocked.go
+++ b/internal/protocol/multimap_islocked.go
@@ -21,8 +21,8 @@ import (
 func MultiMapIsLockedCalculateSize(name *string, key *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(key)
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(key)
 	return dataSize
 }
 

--- a/internal/protocol/multimap_keyset.go
+++ b/internal/protocol/multimap_keyset.go
@@ -21,7 +21,7 @@ import (
 func MultiMapKeySetCalculateSize(name *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
+	dataSize += stringCalculateSize(name)
 	return dataSize
 }
 

--- a/internal/protocol/multimap_lock.go
+++ b/internal/protocol/multimap_lock.go
@@ -17,17 +17,17 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func MultiMapLockCalculateSize(name *string, key *serialization.Data, threadID int64, ttl int64, referenceID int64) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(key)
-	dataSize += common.Int64SizeInBytes
-	dataSize += common.Int64SizeInBytes
-	dataSize += common.Int64SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(key)
+	dataSize += bufutil.Int64SizeInBytes
+	dataSize += bufutil.Int64SizeInBytes
+	dataSize += bufutil.Int64SizeInBytes
 	return dataSize
 }
 

--- a/internal/protocol/multimap_put.go
+++ b/internal/protocol/multimap_put.go
@@ -17,16 +17,16 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func MultiMapPutCalculateSize(name *string, key *serialization.Data, value *serialization.Data, threadID int64) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(key)
-	dataSize += DataCalculateSize(value)
-	dataSize += common.Int64SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(key)
+	dataSize += dataCalculateSize(value)
+	dataSize += bufutil.Int64SizeInBytes
 	return dataSize
 }
 

--- a/internal/protocol/multimap_remove.go
+++ b/internal/protocol/multimap_remove.go
@@ -17,15 +17,15 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func MultiMapRemoveCalculateSize(name *string, key *serialization.Data, threadID int64) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(key)
-	dataSize += common.Int64SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(key)
+	dataSize += bufutil.Int64SizeInBytes
 	return dataSize
 }
 

--- a/internal/protocol/multimap_removeentry.go
+++ b/internal/protocol/multimap_removeentry.go
@@ -17,16 +17,16 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func MultiMapRemoveEntryCalculateSize(name *string, key *serialization.Data, value *serialization.Data, threadID int64) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(key)
-	dataSize += DataCalculateSize(value)
-	dataSize += common.Int64SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(key)
+	dataSize += dataCalculateSize(value)
+	dataSize += bufutil.Int64SizeInBytes
 	return dataSize
 }
 

--- a/internal/protocol/multimap_removeentrylistener.go
+++ b/internal/protocol/multimap_removeentrylistener.go
@@ -17,8 +17,8 @@ package protocol
 func MultiMapRemoveEntryListenerCalculateSize(name *string, registrationID *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += StringCalculateSize(registrationID)
+	dataSize += stringCalculateSize(name)
+	dataSize += stringCalculateSize(registrationID)
 	return dataSize
 }
 

--- a/internal/protocol/multimap_size.go
+++ b/internal/protocol/multimap_size.go
@@ -17,7 +17,7 @@ package protocol
 func MultiMapSizeCalculateSize(name *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
+	dataSize += stringCalculateSize(name)
 	return dataSize
 }
 

--- a/internal/protocol/multimap_trylock.go
+++ b/internal/protocol/multimap_trylock.go
@@ -17,18 +17,18 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func MultiMapTryLockCalculateSize(name *string, key *serialization.Data, threadID int64, lease int64, timeout int64, referenceID int64) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(key)
-	dataSize += common.Int64SizeInBytes
-	dataSize += common.Int64SizeInBytes
-	dataSize += common.Int64SizeInBytes
-	dataSize += common.Int64SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(key)
+	dataSize += bufutil.Int64SizeInBytes
+	dataSize += bufutil.Int64SizeInBytes
+	dataSize += bufutil.Int64SizeInBytes
+	dataSize += bufutil.Int64SizeInBytes
 	return dataSize
 }
 

--- a/internal/protocol/multimap_unlock.go
+++ b/internal/protocol/multimap_unlock.go
@@ -17,16 +17,16 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func MultiMapUnlockCalculateSize(name *string, key *serialization.Data, threadID int64, referenceID int64) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(key)
-	dataSize += common.Int64SizeInBytes
-	dataSize += common.Int64SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(key)
+	dataSize += bufutil.Int64SizeInBytes
+	dataSize += bufutil.Int64SizeInBytes
 	return dataSize
 }
 

--- a/internal/protocol/multimap_valuecount.go
+++ b/internal/protocol/multimap_valuecount.go
@@ -17,15 +17,15 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func MultiMapValueCountCalculateSize(name *string, key *serialization.Data, threadID int64) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(key)
-	dataSize += common.Int64SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(key)
+	dataSize += bufutil.Int64SizeInBytes
 	return dataSize
 }
 

--- a/internal/protocol/multimap_values.go
+++ b/internal/protocol/multimap_values.go
@@ -21,7 +21,7 @@ import (
 func MultiMapValuesCalculateSize(name *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
+	dataSize += stringCalculateSize(name)
 	return dataSize
 }
 

--- a/internal/protocol/pncounter_add.go
+++ b/internal/protocol/pncounter_add.go
@@ -15,23 +15,23 @@
 package protocol
 
 import (
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func PNCounterAddCalculateSize(name *string, delta int64, getBeforeUpdate bool, replicaTimestamps []*Pair, targetReplica *Address) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += common.Int64SizeInBytes
-	dataSize += common.BoolSizeInBytes
-	dataSize += common.Int32SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += bufutil.Int64SizeInBytes
+	dataSize += bufutil.BoolSizeInBytes
+	dataSize += bufutil.Int32SizeInBytes
 	for _, replicaTimestampsItem := range replicaTimestamps {
 		key := replicaTimestampsItem.key.(*string)
 		val := replicaTimestampsItem.value.(int64)
-		dataSize += StringCalculateSize(key)
-		dataSize += Int64CalculateSize(val)
+		dataSize += stringCalculateSize(key)
+		dataSize += int64CalculateSize(val)
 	}
-	dataSize += AddressCalculateSize(targetReplica)
+	dataSize += addressCalculateSize(targetReplica)
 	return dataSize
 }
 

--- a/internal/protocol/pncounter_get.go
+++ b/internal/protocol/pncounter_get.go
@@ -15,21 +15,21 @@
 package protocol
 
 import (
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func PNCounterGetCalculateSize(name *string, replicaTimestamps []*Pair, targetReplica *Address) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += common.Int32SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += bufutil.Int32SizeInBytes
 	for _, replicaTimestampsItem := range replicaTimestamps {
 		key := replicaTimestampsItem.key.(*string)
 		val := replicaTimestampsItem.value.(int64)
-		dataSize += StringCalculateSize(key)
-		dataSize += Int64CalculateSize(val)
+		dataSize += stringCalculateSize(key)
+		dataSize += int64CalculateSize(val)
 	}
-	dataSize += AddressCalculateSize(targetReplica)
+	dataSize += addressCalculateSize(targetReplica)
 	return dataSize
 }
 

--- a/internal/protocol/pncounter_getconfiguredreplicacount.go
+++ b/internal/protocol/pncounter_getconfiguredreplicacount.go
@@ -17,7 +17,7 @@ package protocol
 func PNCounterGetConfiguredReplicaCountCalculateSize(name *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
+	dataSize += stringCalculateSize(name)
 	return dataSize
 }
 

--- a/internal/protocol/queue_addall.go
+++ b/internal/protocol/queue_addall.go
@@ -17,16 +17,16 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func QueueAddAllCalculateSize(name *string, dataList []*serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += common.Int32SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += bufutil.Int32SizeInBytes
 	for _, dataListItem := range dataList {
-		dataSize += DataCalculateSize(dataListItem)
+		dataSize += dataCalculateSize(dataListItem)
 	}
 	return dataSize
 }

--- a/internal/protocol/queue_addlistener.go
+++ b/internal/protocol/queue_addlistener.go
@@ -17,15 +17,15 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func QueueAddListenerCalculateSize(name *string, includeValue bool, localOnly bool) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += common.BoolSizeInBytes
-	dataSize += common.BoolSizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += bufutil.BoolSizeInBytes
+	dataSize += bufutil.BoolSizeInBytes
 	return dataSize
 }
 
@@ -65,7 +65,7 @@ func QueueAddListenerHandle(clientMessage *ClientMessage,
 	handleEventItem QueueAddListenerHandleEventItemFunc) {
 	// Event handler
 	messageType := clientMessage.MessageType()
-	if messageType == common.EventItem && handleEventItem != nil {
+	if messageType == bufutil.EventItem && handleEventItem != nil {
 		handleEventItem(QueueAddListenerEventItemDecode(clientMessage))
 	}
 }

--- a/internal/protocol/queue_clear.go
+++ b/internal/protocol/queue_clear.go
@@ -17,7 +17,7 @@ package protocol
 func QueueClearCalculateSize(name *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
+	dataSize += stringCalculateSize(name)
 	return dataSize
 }
 

--- a/internal/protocol/queue_compareandremoveall.go
+++ b/internal/protocol/queue_compareandremoveall.go
@@ -17,16 +17,16 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func QueueCompareAndRemoveAllCalculateSize(name *string, dataList []*serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += common.Int32SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += bufutil.Int32SizeInBytes
 	for _, dataListItem := range dataList {
-		dataSize += DataCalculateSize(dataListItem)
+		dataSize += dataCalculateSize(dataListItem)
 	}
 	return dataSize
 }

--- a/internal/protocol/queue_compareandretainall.go
+++ b/internal/protocol/queue_compareandretainall.go
@@ -17,16 +17,16 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func QueueCompareAndRetainAllCalculateSize(name *string, dataList []*serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += common.Int32SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += bufutil.Int32SizeInBytes
 	for _, dataListItem := range dataList {
-		dataSize += DataCalculateSize(dataListItem)
+		dataSize += dataCalculateSize(dataListItem)
 	}
 	return dataSize
 }

--- a/internal/protocol/queue_contains.go
+++ b/internal/protocol/queue_contains.go
@@ -21,8 +21,8 @@ import (
 func QueueContainsCalculateSize(name *string, value *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(value)
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(value)
 	return dataSize
 }
 

--- a/internal/protocol/queue_containsall.go
+++ b/internal/protocol/queue_containsall.go
@@ -17,16 +17,16 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func QueueContainsAllCalculateSize(name *string, dataList []*serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += common.Int32SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += bufutil.Int32SizeInBytes
 	for _, dataListItem := range dataList {
-		dataSize += DataCalculateSize(dataListItem)
+		dataSize += dataCalculateSize(dataListItem)
 	}
 	return dataSize
 }

--- a/internal/protocol/queue_drainto.go
+++ b/internal/protocol/queue_drainto.go
@@ -21,7 +21,7 @@ import (
 func QueueDrainToCalculateSize(name *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
+	dataSize += stringCalculateSize(name)
 	return dataSize
 }
 

--- a/internal/protocol/queue_draintomaxsize.go
+++ b/internal/protocol/queue_draintomaxsize.go
@@ -15,15 +15,15 @@
 package protocol
 
 import (
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
 func QueueDrainToMaxSizeCalculateSize(name *string, maxSize int32) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += common.Int32SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += bufutil.Int32SizeInBytes
 	return dataSize
 }
 

--- a/internal/protocol/queue_isempty.go
+++ b/internal/protocol/queue_isempty.go
@@ -17,7 +17,7 @@ package protocol
 func QueueIsEmptyCalculateSize(name *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
+	dataSize += stringCalculateSize(name)
 	return dataSize
 }
 

--- a/internal/protocol/queue_iterator.go
+++ b/internal/protocol/queue_iterator.go
@@ -21,7 +21,7 @@ import (
 func QueueIteratorCalculateSize(name *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
+	dataSize += stringCalculateSize(name)
 	return dataSize
 }
 

--- a/internal/protocol/queue_offer.go
+++ b/internal/protocol/queue_offer.go
@@ -17,15 +17,15 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func QueueOfferCalculateSize(name *string, value *serialization.Data, timeoutMillis int64) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(value)
-	dataSize += common.Int64SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(value)
+	dataSize += bufutil.Int64SizeInBytes
 	return dataSize
 }
 

--- a/internal/protocol/queue_peek.go
+++ b/internal/protocol/queue_peek.go
@@ -21,7 +21,7 @@ import (
 func QueuePeekCalculateSize(name *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
+	dataSize += stringCalculateSize(name)
 	return dataSize
 }
 

--- a/internal/protocol/queue_poll.go
+++ b/internal/protocol/queue_poll.go
@@ -15,15 +15,15 @@
 package protocol
 
 import (
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
 func QueuePollCalculateSize(name *string, timeoutMillis int64) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += common.Int64SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += bufutil.Int64SizeInBytes
 	return dataSize
 }
 

--- a/internal/protocol/queue_put.go
+++ b/internal/protocol/queue_put.go
@@ -21,8 +21,8 @@ import (
 func QueuePutCalculateSize(name *string, value *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(value)
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(value)
 	return dataSize
 }
 

--- a/internal/protocol/queue_remainingcapacity.go
+++ b/internal/protocol/queue_remainingcapacity.go
@@ -17,7 +17,7 @@ package protocol
 func QueueRemainingCapacityCalculateSize(name *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
+	dataSize += stringCalculateSize(name)
 	return dataSize
 }
 

--- a/internal/protocol/queue_remove.go
+++ b/internal/protocol/queue_remove.go
@@ -21,8 +21,8 @@ import (
 func QueueRemoveCalculateSize(name *string, value *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(value)
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(value)
 	return dataSize
 }
 

--- a/internal/protocol/queue_removelistener.go
+++ b/internal/protocol/queue_removelistener.go
@@ -17,8 +17,8 @@ package protocol
 func QueueRemoveListenerCalculateSize(name *string, registrationID *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += StringCalculateSize(registrationID)
+	dataSize += stringCalculateSize(name)
+	dataSize += stringCalculateSize(registrationID)
 	return dataSize
 }
 

--- a/internal/protocol/queue_size.go
+++ b/internal/protocol/queue_size.go
@@ -17,7 +17,7 @@ package protocol
 func QueueSizeCalculateSize(name *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
+	dataSize += stringCalculateSize(name)
 	return dataSize
 }
 

--- a/internal/protocol/queue_take.go
+++ b/internal/protocol/queue_take.go
@@ -21,7 +21,7 @@ import (
 func QueueTakeCalculateSize(name *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
+	dataSize += stringCalculateSize(name)
 	return dataSize
 }
 

--- a/internal/protocol/replicatedmap_addentrylistener.go
+++ b/internal/protocol/replicatedmap_addentrylistener.go
@@ -17,14 +17,14 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func ReplicatedMapAddEntryListenerCalculateSize(name *string, localOnly bool) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += common.BoolSizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += bufutil.BoolSizeInBytes
 	return dataSize
 }
 
@@ -76,7 +76,7 @@ func ReplicatedMapAddEntryListenerHandle(clientMessage *ClientMessage,
 	handleEventEntry ReplicatedMapAddEntryListenerHandleEventEntryFunc) {
 	// Event handler
 	messageType := clientMessage.MessageType()
-	if messageType == common.EventEntry && handleEventEntry != nil {
+	if messageType == bufutil.EventEntry && handleEventEntry != nil {
 		handleEventEntry(ReplicatedMapAddEntryListenerEventEntryDecode(clientMessage))
 	}
 }

--- a/internal/protocol/replicatedmap_addentrylistenertokey.go
+++ b/internal/protocol/replicatedmap_addentrylistenertokey.go
@@ -17,15 +17,15 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func ReplicatedMapAddEntryListenerToKeyCalculateSize(name *string, key *serialization.Data, localOnly bool) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(key)
-	dataSize += common.BoolSizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(key)
+	dataSize += bufutil.BoolSizeInBytes
 	return dataSize
 }
 
@@ -78,7 +78,7 @@ func ReplicatedMapAddEntryListenerToKeyHandle(clientMessage *ClientMessage,
 	handleEventEntry ReplicatedMapAddEntryListenerToKeyHandleEventEntryFunc) {
 	// Event handler
 	messageType := clientMessage.MessageType()
-	if messageType == common.EventEntry && handleEventEntry != nil {
+	if messageType == bufutil.EventEntry && handleEventEntry != nil {
 		handleEventEntry(ReplicatedMapAddEntryListenerToKeyEventEntryDecode(clientMessage))
 	}
 }

--- a/internal/protocol/replicatedmap_addentrylistenertokeywithpredicate.go
+++ b/internal/protocol/replicatedmap_addentrylistenertokeywithpredicate.go
@@ -17,16 +17,16 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func ReplicatedMapAddEntryListenerToKeyWithPredicateCalculateSize(name *string, key *serialization.Data, predicate *serialization.Data, localOnly bool) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(key)
-	dataSize += DataCalculateSize(predicate)
-	dataSize += common.BoolSizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(key)
+	dataSize += dataCalculateSize(predicate)
+	dataSize += bufutil.BoolSizeInBytes
 	return dataSize
 }
 
@@ -80,7 +80,7 @@ func ReplicatedMapAddEntryListenerToKeyWithPredicateHandle(clientMessage *Client
 	handleEventEntry ReplicatedMapAddEntryListenerToKeyWithPredicateHandleEventEntryFunc) {
 	// Event handler
 	messageType := clientMessage.MessageType()
-	if messageType == common.EventEntry && handleEventEntry != nil {
+	if messageType == bufutil.EventEntry && handleEventEntry != nil {
 		handleEventEntry(ReplicatedMapAddEntryListenerToKeyWithPredicateEventEntryDecode(clientMessage))
 	}
 }

--- a/internal/protocol/replicatedmap_addentrylistenerwithpredicate.go
+++ b/internal/protocol/replicatedmap_addentrylistenerwithpredicate.go
@@ -17,15 +17,15 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func ReplicatedMapAddEntryListenerWithPredicateCalculateSize(name *string, predicate *serialization.Data, localOnly bool) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(predicate)
-	dataSize += common.BoolSizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(predicate)
+	dataSize += bufutil.BoolSizeInBytes
 	return dataSize
 }
 
@@ -78,7 +78,7 @@ func ReplicatedMapAddEntryListenerWithPredicateHandle(clientMessage *ClientMessa
 	handleEventEntry ReplicatedMapAddEntryListenerWithPredicateHandleEventEntryFunc) {
 	// Event handler
 	messageType := clientMessage.MessageType()
-	if messageType == common.EventEntry && handleEventEntry != nil {
+	if messageType == bufutil.EventEntry && handleEventEntry != nil {
 		handleEventEntry(ReplicatedMapAddEntryListenerWithPredicateEventEntryDecode(clientMessage))
 	}
 }

--- a/internal/protocol/replicatedmap_addnearcacheentrylistener.go
+++ b/internal/protocol/replicatedmap_addnearcacheentrylistener.go
@@ -17,15 +17,15 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func ReplicatedMapAddNearCacheEntryListenerCalculateSize(name *string, includeValue bool, localOnly bool) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += common.BoolSizeInBytes
-	dataSize += common.BoolSizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += bufutil.BoolSizeInBytes
+	dataSize += bufutil.BoolSizeInBytes
 	return dataSize
 }
 
@@ -78,7 +78,7 @@ func ReplicatedMapAddNearCacheEntryListenerHandle(clientMessage *ClientMessage,
 	handleEventEntry ReplicatedMapAddNearCacheEntryListenerHandleEventEntryFunc) {
 	// Event handler
 	messageType := clientMessage.MessageType()
-	if messageType == common.EventEntry && handleEventEntry != nil {
+	if messageType == bufutil.EventEntry && handleEventEntry != nil {
 		handleEventEntry(ReplicatedMapAddNearCacheEntryListenerEventEntryDecode(clientMessage))
 	}
 }

--- a/internal/protocol/replicatedmap_clear.go
+++ b/internal/protocol/replicatedmap_clear.go
@@ -17,7 +17,7 @@ package protocol
 func ReplicatedMapClearCalculateSize(name *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
+	dataSize += stringCalculateSize(name)
 	return dataSize
 }
 

--- a/internal/protocol/replicatedmap_containskey.go
+++ b/internal/protocol/replicatedmap_containskey.go
@@ -21,8 +21,8 @@ import (
 func ReplicatedMapContainsKeyCalculateSize(name *string, key *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(key)
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(key)
 	return dataSize
 }
 

--- a/internal/protocol/replicatedmap_containsvalue.go
+++ b/internal/protocol/replicatedmap_containsvalue.go
@@ -21,8 +21,8 @@ import (
 func ReplicatedMapContainsValueCalculateSize(name *string, value *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(value)
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(value)
 	return dataSize
 }
 

--- a/internal/protocol/replicatedmap_entryset.go
+++ b/internal/protocol/replicatedmap_entryset.go
@@ -17,7 +17,7 @@ package protocol
 func ReplicatedMapEntrySetCalculateSize(name *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
+	dataSize += stringCalculateSize(name)
 	return dataSize
 }
 

--- a/internal/protocol/replicatedmap_get.go
+++ b/internal/protocol/replicatedmap_get.go
@@ -21,8 +21,8 @@ import (
 func ReplicatedMapGetCalculateSize(name *string, key *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(key)
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(key)
 	return dataSize
 }
 

--- a/internal/protocol/replicatedmap_isempty.go
+++ b/internal/protocol/replicatedmap_isempty.go
@@ -17,7 +17,7 @@ package protocol
 func ReplicatedMapIsEmptyCalculateSize(name *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
+	dataSize += stringCalculateSize(name)
 	return dataSize
 }
 

--- a/internal/protocol/replicatedmap_keyset.go
+++ b/internal/protocol/replicatedmap_keyset.go
@@ -21,7 +21,7 @@ import (
 func ReplicatedMapKeySetCalculateSize(name *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
+	dataSize += stringCalculateSize(name)
 	return dataSize
 }
 

--- a/internal/protocol/replicatedmap_put.go
+++ b/internal/protocol/replicatedmap_put.go
@@ -17,16 +17,16 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func ReplicatedMapPutCalculateSize(name *string, key *serialization.Data, value *serialization.Data, ttl int64) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(key)
-	dataSize += DataCalculateSize(value)
-	dataSize += common.Int64SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(key)
+	dataSize += dataCalculateSize(value)
+	dataSize += bufutil.Int64SizeInBytes
 	return dataSize
 }
 

--- a/internal/protocol/replicatedmap_putall.go
+++ b/internal/protocol/replicatedmap_putall.go
@@ -17,19 +17,19 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func ReplicatedMapPutAllCalculateSize(name *string, entries []*Pair) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += common.Int32SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += bufutil.Int32SizeInBytes
 	for _, entriesItem := range entries {
 		key := entriesItem.key.(*serialization.Data)
 		val := entriesItem.value.(*serialization.Data)
-		dataSize += DataCalculateSize(key)
-		dataSize += DataCalculateSize(val)
+		dataSize += dataCalculateSize(key)
+		dataSize += dataCalculateSize(val)
 	}
 	return dataSize
 }

--- a/internal/protocol/replicatedmap_remove.go
+++ b/internal/protocol/replicatedmap_remove.go
@@ -21,8 +21,8 @@ import (
 func ReplicatedMapRemoveCalculateSize(name *string, key *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(key)
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(key)
 	return dataSize
 }
 

--- a/internal/protocol/replicatedmap_removeentrylistener.go
+++ b/internal/protocol/replicatedmap_removeentrylistener.go
@@ -17,8 +17,8 @@ package protocol
 func ReplicatedMapRemoveEntryListenerCalculateSize(name *string, registrationID *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += StringCalculateSize(registrationID)
+	dataSize += stringCalculateSize(name)
+	dataSize += stringCalculateSize(registrationID)
 	return dataSize
 }
 

--- a/internal/protocol/replicatedmap_size.go
+++ b/internal/protocol/replicatedmap_size.go
@@ -17,7 +17,7 @@ package protocol
 func ReplicatedMapSizeCalculateSize(name *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
+	dataSize += stringCalculateSize(name)
 	return dataSize
 }
 

--- a/internal/protocol/replicatedmap_values.go
+++ b/internal/protocol/replicatedmap_values.go
@@ -21,7 +21,7 @@ import (
 func ReplicatedMapValuesCalculateSize(name *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
+	dataSize += stringCalculateSize(name)
 	return dataSize
 }
 

--- a/internal/protocol/ringbuffer_add.go
+++ b/internal/protocol/ringbuffer_add.go
@@ -17,15 +17,15 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func RingbufferAddCalculateSize(name *string, overflowPolicy int32, value *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += common.Int32SizeInBytes
-	dataSize += DataCalculateSize(value)
+	dataSize += stringCalculateSize(name)
+	dataSize += bufutil.Int32SizeInBytes
+	dataSize += dataCalculateSize(value)
 	return dataSize
 }
 

--- a/internal/protocol/ringbuffer_addall.go
+++ b/internal/protocol/ringbuffer_addall.go
@@ -17,18 +17,18 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func RingbufferAddAllCalculateSize(name *string, valueList []*serialization.Data, overflowPolicy int32) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += common.Int32SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += bufutil.Int32SizeInBytes
 	for _, valueListItem := range valueList {
-		dataSize += DataCalculateSize(valueListItem)
+		dataSize += dataCalculateSize(valueListItem)
 	}
-	dataSize += common.Int32SizeInBytes
+	dataSize += bufutil.Int32SizeInBytes
 	return dataSize
 }
 

--- a/internal/protocol/ringbuffer_capacity.go
+++ b/internal/protocol/ringbuffer_capacity.go
@@ -17,7 +17,7 @@ package protocol
 func RingbufferCapacityCalculateSize(name *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
+	dataSize += stringCalculateSize(name)
 	return dataSize
 }
 

--- a/internal/protocol/ringbuffer_headsequence.go
+++ b/internal/protocol/ringbuffer_headsequence.go
@@ -17,7 +17,7 @@ package protocol
 func RingbufferHeadSequenceCalculateSize(name *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
+	dataSize += stringCalculateSize(name)
 	return dataSize
 }
 

--- a/internal/protocol/ringbuffer_readmany.go
+++ b/internal/protocol/ringbuffer_readmany.go
@@ -17,19 +17,19 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func RingbufferReadManyCalculateSize(name *string, startSequence int64, minCount int32, maxCount int32, filter *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += common.Int64SizeInBytes
-	dataSize += common.Int32SizeInBytes
-	dataSize += common.Int32SizeInBytes
-	dataSize += common.BoolSizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += bufutil.Int64SizeInBytes
+	dataSize += bufutil.Int32SizeInBytes
+	dataSize += bufutil.Int32SizeInBytes
+	dataSize += bufutil.BoolSizeInBytes
 	if filter != nil {
-		dataSize += DataCalculateSize(filter)
+		dataSize += dataCalculateSize(filter)
 	}
 	return dataSize
 }

--- a/internal/protocol/ringbuffer_readone.go
+++ b/internal/protocol/ringbuffer_readone.go
@@ -15,15 +15,15 @@
 package protocol
 
 import (
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
 func RingbufferReadOneCalculateSize(name *string, sequence int64) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += common.Int64SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += bufutil.Int64SizeInBytes
 	return dataSize
 }
 

--- a/internal/protocol/ringbuffer_remainingcapacity.go
+++ b/internal/protocol/ringbuffer_remainingcapacity.go
@@ -17,7 +17,7 @@ package protocol
 func RingbufferRemainingCapacityCalculateSize(name *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
+	dataSize += stringCalculateSize(name)
 	return dataSize
 }
 

--- a/internal/protocol/ringbuffer_size.go
+++ b/internal/protocol/ringbuffer_size.go
@@ -17,7 +17,7 @@ package protocol
 func RingbufferSizeCalculateSize(name *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
+	dataSize += stringCalculateSize(name)
 	return dataSize
 }
 

--- a/internal/protocol/ringbuffer_tailsequence.go
+++ b/internal/protocol/ringbuffer_tailsequence.go
@@ -17,7 +17,7 @@ package protocol
 func RingbufferTailSequenceCalculateSize(name *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
+	dataSize += stringCalculateSize(name)
 	return dataSize
 }
 

--- a/internal/protocol/set_add.go
+++ b/internal/protocol/set_add.go
@@ -21,8 +21,8 @@ import (
 func SetAddCalculateSize(name *string, value *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(value)
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(value)
 	return dataSize
 }
 

--- a/internal/protocol/set_addall.go
+++ b/internal/protocol/set_addall.go
@@ -17,16 +17,16 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func SetAddAllCalculateSize(name *string, valueList []*serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += common.Int32SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += bufutil.Int32SizeInBytes
 	for _, valueListItem := range valueList {
-		dataSize += DataCalculateSize(valueListItem)
+		dataSize += dataCalculateSize(valueListItem)
 	}
 	return dataSize
 }

--- a/internal/protocol/set_addlistener.go
+++ b/internal/protocol/set_addlistener.go
@@ -17,15 +17,15 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func SetAddListenerCalculateSize(name *string, includeValue bool, localOnly bool) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += common.BoolSizeInBytes
-	dataSize += common.BoolSizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += bufutil.BoolSizeInBytes
+	dataSize += bufutil.BoolSizeInBytes
 	return dataSize
 }
 
@@ -65,7 +65,7 @@ func SetAddListenerHandle(clientMessage *ClientMessage,
 	handleEventItem SetAddListenerHandleEventItemFunc) {
 	// Event handler
 	messageType := clientMessage.MessageType()
-	if messageType == common.EventItem && handleEventItem != nil {
+	if messageType == bufutil.EventItem && handleEventItem != nil {
 		handleEventItem(SetAddListenerEventItemDecode(clientMessage))
 	}
 }

--- a/internal/protocol/set_clear.go
+++ b/internal/protocol/set_clear.go
@@ -17,7 +17,7 @@ package protocol
 func SetClearCalculateSize(name *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
+	dataSize += stringCalculateSize(name)
 	return dataSize
 }
 

--- a/internal/protocol/set_compareandremoveall.go
+++ b/internal/protocol/set_compareandremoveall.go
@@ -17,16 +17,16 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func SetCompareAndRemoveAllCalculateSize(name *string, values []*serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += common.Int32SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += bufutil.Int32SizeInBytes
 	for _, valuesItem := range values {
-		dataSize += DataCalculateSize(valuesItem)
+		dataSize += dataCalculateSize(valuesItem)
 	}
 	return dataSize
 }

--- a/internal/protocol/set_compareandretainall.go
+++ b/internal/protocol/set_compareandretainall.go
@@ -17,16 +17,16 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func SetCompareAndRetainAllCalculateSize(name *string, values []*serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += common.Int32SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += bufutil.Int32SizeInBytes
 	for _, valuesItem := range values {
-		dataSize += DataCalculateSize(valuesItem)
+		dataSize += dataCalculateSize(valuesItem)
 	}
 	return dataSize
 }

--- a/internal/protocol/set_contains.go
+++ b/internal/protocol/set_contains.go
@@ -21,8 +21,8 @@ import (
 func SetContainsCalculateSize(name *string, value *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(value)
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(value)
 	return dataSize
 }
 

--- a/internal/protocol/set_containsall.go
+++ b/internal/protocol/set_containsall.go
@@ -17,16 +17,16 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func SetContainsAllCalculateSize(name *string, items []*serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += common.Int32SizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += bufutil.Int32SizeInBytes
 	for _, itemsItem := range items {
-		dataSize += DataCalculateSize(itemsItem)
+		dataSize += dataCalculateSize(itemsItem)
 	}
 	return dataSize
 }

--- a/internal/protocol/set_getall.go
+++ b/internal/protocol/set_getall.go
@@ -21,7 +21,7 @@ import (
 func SetGetAllCalculateSize(name *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
+	dataSize += stringCalculateSize(name)
 	return dataSize
 }
 

--- a/internal/protocol/set_isempty.go
+++ b/internal/protocol/set_isempty.go
@@ -17,7 +17,7 @@ package protocol
 func SetIsEmptyCalculateSize(name *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
+	dataSize += stringCalculateSize(name)
 	return dataSize
 }
 

--- a/internal/protocol/set_remove.go
+++ b/internal/protocol/set_remove.go
@@ -21,8 +21,8 @@ import (
 func SetRemoveCalculateSize(name *string, value *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(value)
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(value)
 	return dataSize
 }
 

--- a/internal/protocol/set_removelistener.go
+++ b/internal/protocol/set_removelistener.go
@@ -17,8 +17,8 @@ package protocol
 func SetRemoveListenerCalculateSize(name *string, registrationID *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += StringCalculateSize(registrationID)
+	dataSize += stringCalculateSize(name)
+	dataSize += stringCalculateSize(registrationID)
 	return dataSize
 }
 

--- a/internal/protocol/set_size.go
+++ b/internal/protocol/set_size.go
@@ -17,7 +17,7 @@ package protocol
 func SetSizeCalculateSize(name *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
+	dataSize += stringCalculateSize(name)
 	return dataSize
 }
 

--- a/internal/protocol/topic_addmessagelistener.go
+++ b/internal/protocol/topic_addmessagelistener.go
@@ -17,14 +17,14 @@ package protocol
 import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 func TopicAddMessageListenerCalculateSize(name *string, localOnly bool) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += common.BoolSizeInBytes
+	dataSize += stringCalculateSize(name)
+	dataSize += bufutil.BoolSizeInBytes
 	return dataSize
 }
 
@@ -60,7 +60,7 @@ func TopicAddMessageListenerHandle(clientMessage *ClientMessage,
 	handleEventTopic TopicAddMessageListenerHandleEventTopicFunc) {
 	// Event handler
 	messageType := clientMessage.MessageType()
-	if messageType == common.EventTopic && handleEventTopic != nil {
+	if messageType == bufutil.EventTopic && handleEventTopic != nil {
 		handleEventTopic(TopicAddMessageListenerEventTopicDecode(clientMessage))
 	}
 }

--- a/internal/protocol/topic_publish.go
+++ b/internal/protocol/topic_publish.go
@@ -21,8 +21,8 @@ import (
 func TopicPublishCalculateSize(name *string, message *serialization.Data) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += DataCalculateSize(message)
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(message)
 	return dataSize
 }
 

--- a/internal/protocol/topic_removemessagelistener.go
+++ b/internal/protocol/topic_removemessagelistener.go
@@ -17,8 +17,8 @@ package protocol
 func TopicRemoveMessageListenerCalculateSize(name *string, registrationID *string) int {
 	// Calculates the request payload size
 	dataSize := 0
-	dataSize += StringCalculateSize(name)
-	dataSize += StringCalculateSize(registrationID)
+	dataSize += stringCalculateSize(name)
+	dataSize += stringCalculateSize(registrationID)
 	return dataSize
 }
 

--- a/internal/protocol/util.go
+++ b/internal/protocol/util.go
@@ -15,27 +15,27 @@
 package protocol
 
 import (
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
 const ClientType = "GOO"
 
-func DataCalculateSize(d *serialization.Data) int {
-	return len(d.Buffer()) + common.Int32SizeInBytes
+func dataCalculateSize(d *serialization.Data) int {
+	return len(d.Buffer()) + bufutil.Int32SizeInBytes
 }
 
-func StringCalculateSize(str *string) int {
-	return len(*str) + common.Int32SizeInBytes
+func stringCalculateSize(str *string) int {
+	return len(*str) + bufutil.Int32SizeInBytes
 }
 
-func Int64CalculateSize(v int64) int {
-	return common.Int64SizeInBytes
+func int64CalculateSize(v int64) int {
+	return bufutil.Int64SizeInBytes
 }
 
-func AddressCalculateSize(a *Address) int {
+func addressCalculateSize(a *Address) int {
 	dataSize := 0
-	dataSize += StringCalculateSize(&a.host)
-	dataSize += common.Int32SizeInBytes
+	dataSize += stringCalculateSize(&a.host)
+	dataSize += bufutil.Int32SizeInBytes
 	return dataSize
 }

--- a/internal/proxy.go
+++ b/internal/proxy.go
@@ -16,8 +16,8 @@ package internal
 
 import (
 	"github.com/hazelcast/hazelcast-go-client/core"
+	"github.com/hazelcast/hazelcast-go-client/internal/colutil"
 	"github.com/hazelcast/hazelcast-go-client/internal/common"
-	"github.com/hazelcast/hazelcast-go-client/internal/common/collection"
 	"github.com/hazelcast/hazelcast-go-client/internal/protocol"
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
@@ -109,7 +109,7 @@ func (p *proxy) validateAndSerializeSlice(elements []interface{}) (elementsData 
 	if elements == nil {
 		return nil, core.NewHazelcastSerializationError(common.NilSliceIsNotAllowed, nil)
 	}
-	elementsData, err = collection.ObjectToDataCollection(elements, p.client.SerializationService)
+	elementsData, err = colutil.ObjectToDataCollection(elements, p.client.SerializationService)
 	return
 }
 
@@ -175,7 +175,7 @@ func (p *proxy) decodeToInterfaceSliceAndError(responseMessage *protocol.ClientM
 	if inputError != nil {
 		return nil, inputError
 	}
-	return collection.DataToObjectCollection(decodeFunc(responseMessage)(), p.client.SerializationService)
+	return colutil.DataToObjectCollection(decodeFunc(responseMessage)(), p.client.SerializationService)
 }
 
 func (p *proxy) decodeToPairSliceAndError(responseMessage *protocol.ClientMessage, inputError error,
@@ -183,7 +183,7 @@ func (p *proxy) decodeToPairSliceAndError(responseMessage *protocol.ClientMessag
 	if inputError != nil {
 		return nil, inputError
 	}
-	return collection.DataToObjectPairCollection(decodeFunc(responseMessage)(), p.client.SerializationService)
+	return colutil.DataToObjectPairCollection(decodeFunc(responseMessage)(), p.client.SerializationService)
 }
 
 func (p *proxy) decodeToInt32AndError(responseMessage *protocol.ClientMessage, inputError error,

--- a/internal/proxy.go
+++ b/internal/proxy.go
@@ -17,8 +17,8 @@ package internal
 import (
 	"github.com/hazelcast/hazelcast-go-client/core"
 	"github.com/hazelcast/hazelcast-go-client/internal/colutil"
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
 	"github.com/hazelcast/hazelcast-go-client/internal/protocol"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
@@ -55,7 +55,7 @@ func (p *proxy) ServiceName() string {
 
 func (p *proxy) validateAndSerialize(arg1 interface{}) (arg1Data *serialization.Data, err error) {
 	if arg1 == nil {
-		return nil, core.NewHazelcastNilPointerError(common.NilArgIsNotAllowed, nil)
+		return nil, core.NewHazelcastNilPointerError(bufutil.NilArgIsNotAllowed, nil)
 	}
 	arg1Data, err = p.toData(arg1)
 	return
@@ -64,10 +64,10 @@ func (p *proxy) validateAndSerialize(arg1 interface{}) (arg1Data *serialization.
 func (p *proxy) validateAndSerialize2(arg1 interface{}, arg2 interface{}) (arg1Data *serialization.Data,
 	arg2Data *serialization.Data, err error) {
 	if arg1 == nil {
-		return nil, nil, core.NewHazelcastNilPointerError(common.NilArgIsNotAllowed, nil)
+		return nil, nil, core.NewHazelcastNilPointerError(bufutil.NilArgIsNotAllowed, nil)
 	}
 	if arg2 == nil {
-		return nil, nil, core.NewHazelcastNilPointerError(common.NilArgIsNotAllowed, nil)
+		return nil, nil, core.NewHazelcastNilPointerError(bufutil.NilArgIsNotAllowed, nil)
 	}
 	arg1Data, err = p.toData(arg1)
 	if err != nil {
@@ -80,10 +80,10 @@ func (p *proxy) validateAndSerialize2(arg1 interface{}, arg2 interface{}) (arg1D
 func (p *proxy) validateAndSerialize3(arg1 interface{}, arg2 interface{}, arg3 interface{}) (arg1Data *serialization.Data,
 	arg2Data *serialization.Data, arg3Data *serialization.Data, err error) {
 	if arg1 == nil {
-		return nil, nil, nil, core.NewHazelcastNilPointerError(common.NilArgIsNotAllowed, nil)
+		return nil, nil, nil, core.NewHazelcastNilPointerError(bufutil.NilArgIsNotAllowed, nil)
 	}
 	if arg2 == nil || arg3 == nil {
-		return nil, nil, nil, core.NewHazelcastNilPointerError(common.NilArgIsNotAllowed, nil)
+		return nil, nil, nil, core.NewHazelcastNilPointerError(bufutil.NilArgIsNotAllowed, nil)
 	}
 	arg1Data, err = p.toData(arg1)
 	if err != nil {
@@ -99,7 +99,7 @@ func (p *proxy) validateAndSerialize3(arg1 interface{}, arg2 interface{}, arg3 i
 
 func (p *proxy) validateAndSerializePredicate(arg1 interface{}) (arg1Data *serialization.Data, err error) {
 	if arg1 == nil {
-		return nil, core.NewHazelcastSerializationError(common.NilPredicateIsNotAllowed, nil)
+		return nil, core.NewHazelcastSerializationError(bufutil.NilPredicateIsNotAllowed, nil)
 	}
 	arg1Data, err = p.toData(arg1)
 	return
@@ -107,7 +107,7 @@ func (p *proxy) validateAndSerializePredicate(arg1 interface{}) (arg1Data *seria
 
 func (p *proxy) validateAndSerializeSlice(elements []interface{}) (elementsData []*serialization.Data, err error) {
 	if elements == nil {
-		return nil, core.NewHazelcastSerializationError(common.NilSliceIsNotAllowed, nil)
+		return nil, core.NewHazelcastSerializationError(bufutil.NilSliceIsNotAllowed, nil)
 	}
 	elementsData, err = colutil.ObjectToDataCollection(elements, p.client.SerializationService)
 	return
@@ -115,7 +115,7 @@ func (p *proxy) validateAndSerializeSlice(elements []interface{}) (elementsData 
 
 func (p *proxy) validateAndSerializeMapAndGetPartitions(entries map[interface{}]interface{}) (map[int32][]*protocol.Pair, error) {
 	if entries == nil {
-		return nil, core.NewHazelcastNilPointerError(common.NilMapIsNotAllowed, nil)
+		return nil, core.NewHazelcastNilPointerError(bufutil.NilMapIsNotAllowed, nil)
 	}
 	partitions := make(map[int32][]*protocol.Pair)
 	for key, value := range entries {
@@ -225,11 +225,11 @@ func (p *proxy) createOnItemEvent(listener interface{}) func(itemData *serializa
 		item, _ = p.toObject(itemData)
 		member := p.client.ClusterService.GetMemberByUUID(*uuid)
 		itemEvent := protocol.NewItemEvent(p.name, item, eventType, member.(*protocol.Member))
-		if eventType == common.ItemAdded {
+		if eventType == bufutil.ItemAdded {
 			if _, ok := listener.(core.ItemAddedListener); ok {
 				listener.(core.ItemAddedListener).ItemAdded(itemEvent)
 			}
-		} else if eventType == common.ItemRemoved {
+		} else if eventType == bufutil.ItemRemoved {
 			if _, ok := listener.(core.ItemRemovedListener); ok {
 				listener.(core.ItemRemovedListener).ItemRemoved(itemEvent)
 			}

--- a/internal/proxy_manager.go
+++ b/internal/proxy_manager.go
@@ -19,8 +19,8 @@ import (
 	"sync/atomic"
 
 	"github.com/hazelcast/hazelcast-go-client/core"
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
 	"github.com/hazelcast/hazelcast-go-client/internal/protocol"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 )
 
 type proxyManager struct {
@@ -93,25 +93,25 @@ func (pm *proxyManager) findNextProxyAddress() *protocol.Address {
 }
 
 func (pm *proxyManager) getProxyByNameSpace(serviceName *string, name *string) (core.DistributedObject, error) {
-	if common.ServiceNameMap == *serviceName {
+	if bufutil.ServiceNameMap == *serviceName {
 		return newMapProxy(pm.client, serviceName, name)
-	} else if common.ServiceNameList == *serviceName {
+	} else if bufutil.ServiceNameList == *serviceName {
 		return newListProxy(pm.client, serviceName, name)
-	} else if common.ServiceNameSet == *serviceName {
+	} else if bufutil.ServiceNameSet == *serviceName {
 		return newSetProxy(pm.client, serviceName, name)
-	} else if common.ServiceNameTopic == *serviceName {
+	} else if bufutil.ServiceNameTopic == *serviceName {
 		return newTopicProxy(pm.client, serviceName, name)
-	} else if common.ServiceNameMultiMap == *serviceName {
+	} else if bufutil.ServiceNameMultiMap == *serviceName {
 		return newMultiMapProxy(pm.client, serviceName, name)
-	} else if common.ServiceNameReplicatedMap == *serviceName {
+	} else if bufutil.ServiceNameReplicatedMap == *serviceName {
 		return newReplicatedMapProxy(pm.client, serviceName, name)
-	} else if common.ServiceNameQueue == *serviceName {
+	} else if bufutil.ServiceNameQueue == *serviceName {
 		return newQueueProxy(pm.client, serviceName, name)
-	} else if common.ServiceNameRingbufferService == *serviceName {
+	} else if bufutil.ServiceNameRingbufferService == *serviceName {
 		return newRingbufferProxy(pm.client, serviceName, name)
-	} else if common.ServiceNamePNCounter == *serviceName {
+	} else if bufutil.ServiceNamePNCounter == *serviceName {
 		return newPNCounterProxy(pm.client, serviceName, name)
-	} else if common.ServiceNameIDGenerator == *serviceName {
+	} else if bufutil.ServiceNameIDGenerator == *serviceName {
 		return newFlakeIDGenerator(pm.client, serviceName, name)
 	}
 	return nil, nil

--- a/internal/queue.go
+++ b/internal/queue.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hazelcast/hazelcast-go-client/internal/protocol"
 	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/timeutil"
 )
 
 type queueProxy struct {
@@ -131,7 +132,7 @@ func (qp *queueProxy) OfferWithTimeout(item interface{}, timeout time.Duration) 
 	if err != nil {
 		return false, err
 	}
-	timeoutInMilliSeconds := bufutil.GetTimeInMilliSeconds(timeout)
+	timeoutInMilliSeconds := timeutil.GetTimeInMilliSeconds(timeout)
 	request := protocol.QueueOfferEncodeRequest(qp.name, itemData, timeoutInMilliSeconds)
 	responseMessage, err := qp.invoke(request)
 	return qp.decodeToBoolAndError(responseMessage, err, protocol.QueueOfferDecodeResponse)
@@ -150,7 +151,7 @@ func (qp *queueProxy) Poll() (item interface{}, err error) {
 }
 
 func (qp *queueProxy) PollWithTimeout(timeout time.Duration) (item interface{}, err error) {
-	timeoutInMilliSeconds := bufutil.GetTimeInMilliSeconds(timeout)
+	timeoutInMilliSeconds := timeutil.GetTimeInMilliSeconds(timeout)
 	request := protocol.QueuePollEncodeRequest(qp.name, timeoutInMilliSeconds)
 	responseMessage, err := qp.invoke(request)
 	return qp.decodeToObjectAndError(responseMessage, err, protocol.QueuePollDecodeResponse)

--- a/internal/queue.go
+++ b/internal/queue.go
@@ -18,8 +18,8 @@ import (
 	"time"
 
 	"github.com/hazelcast/hazelcast-go-client/core"
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
 	"github.com/hazelcast/hazelcast-go-client/internal/protocol"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
@@ -84,7 +84,7 @@ func (qp *queueProxy) ContainsAll(items []interface{}) (foundAll bool, err error
 
 func (qp *queueProxy) DrainTo(slice *[]interface{}) (movedAmount int32, err error) {
 	if slice == nil {
-		return 0, core.NewHazelcastNilPointerError(common.NilSliceIsNotAllowed, nil)
+		return 0, core.NewHazelcastNilPointerError(bufutil.NilSliceIsNotAllowed, nil)
 	}
 	request := protocol.QueueDrainToEncodeRequest(qp.name)
 	responseMessage, err := qp.invoke(request)
@@ -98,7 +98,7 @@ func (qp *queueProxy) DrainTo(slice *[]interface{}) (movedAmount int32, err erro
 
 func (qp *queueProxy) DrainToWithMaxSize(slice *[]interface{}, maxElements int32) (movedAmount int32, err error) {
 	if slice == nil {
-		return 0, core.NewHazelcastNilPointerError(common.NilSliceIsNotAllowed, nil)
+		return 0, core.NewHazelcastNilPointerError(bufutil.NilSliceIsNotAllowed, nil)
 	}
 	request := protocol.QueueDrainToMaxSizeEncodeRequest(qp.name, maxElements)
 	responseMessage, err := qp.invoke(request)
@@ -131,7 +131,7 @@ func (qp *queueProxy) OfferWithTimeout(item interface{}, timeout time.Duration) 
 	if err != nil {
 		return false, err
 	}
-	timeoutInMilliSeconds := common.GetTimeInMilliSeconds(timeout)
+	timeoutInMilliSeconds := bufutil.GetTimeInMilliSeconds(timeout)
 	request := protocol.QueueOfferEncodeRequest(qp.name, itemData, timeoutInMilliSeconds)
 	responseMessage, err := qp.invoke(request)
 	return qp.decodeToBoolAndError(responseMessage, err, protocol.QueueOfferDecodeResponse)
@@ -150,7 +150,7 @@ func (qp *queueProxy) Poll() (item interface{}, err error) {
 }
 
 func (qp *queueProxy) PollWithTimeout(timeout time.Duration) (item interface{}, err error) {
-	timeoutInMilliSeconds := common.GetTimeInMilliSeconds(timeout)
+	timeoutInMilliSeconds := bufutil.GetTimeInMilliSeconds(timeout)
 	request := protocol.QueuePollEncodeRequest(qp.name, timeoutInMilliSeconds)
 	responseMessage, err := qp.invoke(request)
 	return qp.decodeToObjectAndError(responseMessage, err, protocol.QueuePollDecodeResponse)

--- a/internal/replicated_map.go
+++ b/internal/replicated_map.go
@@ -19,8 +19,8 @@ import (
 	"time"
 
 	"github.com/hazelcast/hazelcast-go-client/core"
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
 	"github.com/hazelcast/hazelcast-go-client/internal/protocol"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
@@ -45,7 +45,7 @@ func (rmp *replicatedMapProxy) PutWithTTL(key interface{}, value interface{},
 	if err != nil {
 		return nil, err
 	}
-	ttlInMillis := common.GetTimeInMilliSeconds(ttl)
+	ttlInMillis := bufutil.GetTimeInMilliSeconds(ttl)
 	request := protocol.ReplicatedMapPutEncodeRequest(rmp.name, keyData, valueData, ttlInMillis)
 	responseMessage, err := rmp.invokeOnKey(request, keyData)
 	return rmp.decodeToObjectAndError(responseMessage, err, protocol.ReplicatedMapPutDecodeResponse)
@@ -53,7 +53,7 @@ func (rmp *replicatedMapProxy) PutWithTTL(key interface{}, value interface{},
 
 func (rmp *replicatedMapProxy) PutAll(entries map[interface{}]interface{}) (err error) {
 	if entries == nil {
-		return core.NewHazelcastNilPointerError(common.NilMapIsNotAllowed, nil)
+		return core.NewHazelcastNilPointerError(bufutil.NilMapIsNotAllowed, nil)
 	}
 	pairs := make([]*protocol.Pair, len(entries))
 	index := 0
@@ -221,15 +221,15 @@ func (rmp *replicatedMapProxy) onEntryEvent(keyData *serialization.Data, oldValu
 	entryEvent := protocol.NewEntryEvent(key, oldValue, value, mergingValue, eventType, uuid)
 	mapEvent := protocol.NewMapEvent(eventType, uuid, numberOfAffectedEntries)
 	switch eventType {
-	case common.EntryEventAdded:
+	case bufutil.EntryEventAdded:
 		listener.(protocol.EntryAddedListener).EntryAdded(entryEvent)
-	case common.EntryEventRemoved:
+	case bufutil.EntryEventRemoved:
 		listener.(protocol.EntryRemovedListener).EntryRemoved(entryEvent)
-	case common.EntryEventUpdated:
+	case bufutil.EntryEventUpdated:
 		listener.(protocol.EntryUpdatedListener).EntryUpdated(entryEvent)
-	case common.EntryEventEvicted:
+	case bufutil.EntryEventEvicted:
 		listener.(protocol.EntryEvictedListener).EntryEvicted(entryEvent)
-	case common.EntryEventClearAll:
+	case bufutil.EntryEventClearAll:
 		listener.(protocol.EntryClearAllListener).EntryClearAll(mapEvent)
 	}
 }

--- a/internal/replicated_map.go
+++ b/internal/replicated_map.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hazelcast/hazelcast-go-client/internal/protocol"
 	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/internal/timeutil"
 )
 
 type replicatedMapProxy struct {
@@ -45,7 +46,7 @@ func (rmp *replicatedMapProxy) PutWithTTL(key interface{}, value interface{},
 	if err != nil {
 		return nil, err
 	}
-	ttlInMillis := bufutil.GetTimeInMilliSeconds(ttl)
+	ttlInMillis := timeutil.GetTimeInMilliSeconds(ttl)
 	request := protocol.ReplicatedMapPutEncodeRequest(rmp.name, keyData, valueData, ttlInMillis)
 	responseMessage, err := rmp.invokeOnKey(request, keyData)
 	return rmp.decodeToObjectAndError(responseMessage, err, protocol.ReplicatedMapPutDecodeResponse)

--- a/internal/serialization/bufferutil/buffer_util.go
+++ b/internal/serialization/bufferutil/buffer_util.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package common
+package bufferutil
 
 import (
 	"encoding/binary"

--- a/internal/serialization/bufferutil/buffer_util_test.go
+++ b/internal/serialization/bufferutil/buffer_util_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package common
+package bufferutil
 
 import (
 	"bytes"

--- a/internal/serialization/data.go
+++ b/internal/serialization/data.go
@@ -18,7 +18,7 @@ import (
 	"encoding/binary"
 	"math"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/murmur"
 )
 
 const (
@@ -58,5 +58,5 @@ func (d *Data) DataSize() int {
 }
 
 func (d *Data) GetPartitionHash() int32 {
-	return common.Murmur3ADefault(d.Payload, DataOffset, d.DataSize())
+	return murmur.Default3A(d.Payload, DataOffset, d.DataSize())
 }

--- a/internal/serialization/default_portable_reader.go
+++ b/internal/serialization/default_portable_reader.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 
 	"github.com/hazelcast/hazelcast-go-client/core"
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization/classdef"
 	"github.com/hazelcast/hazelcast-go-client/serialization"
 )
@@ -98,7 +98,7 @@ func (pr *DefaultPortableReader) positionByField(fieldName string, fieldType int
 	if field.Type() != fieldType {
 		return 0, core.NewHazelcastSerializationError(fmt.Sprintf("not a %s field: %s", TypeByID(fieldType), fieldName), nil)
 	}
-	pos, err := pr.input.(*ObjectDataInput).ReadInt32WithPosition(pr.offset + field.Index()*common.Int32SizeInBytes)
+	pos, err := pr.input.(*ObjectDataInput).ReadInt32WithPosition(pr.offset + field.Index()*bufutil.Int32SizeInBytes)
 	if err != nil {
 		return 0, err
 	}
@@ -106,7 +106,7 @@ func (pr *DefaultPortableReader) positionByField(fieldName string, fieldType int
 	if err != nil {
 		return 0, err
 	}
-	return pos + common.Int16SizeInBytes + int32(length) + 1, nil
+	return pos + bufutil.Int16SizeInBytes + int32(length) + 1, nil
 }
 
 func (pr *DefaultPortableReader) ReadByte(fieldName string) (byte, error) {
@@ -289,7 +289,7 @@ func (pr *DefaultPortableReader) ReadPortableArray(fieldName string) ([]serializ
 	}
 	pr.input.SetPosition(pos)
 	length, err := pr.input.ReadInt32()
-	if err != nil || length == common.NilArrayLength {
+	if err != nil || length == bufutil.NilArrayLength {
 		return nil, err
 	}
 	factoryID, err := pr.input.ReadInt32()
@@ -304,7 +304,7 @@ func (pr *DefaultPortableReader) ReadPortableArray(fieldName string) ([]serializ
 	if length > 0 {
 		offset := pr.input.Position()
 		for i := int32(0); i < length; i++ {
-			start, err := pr.input.(*ObjectDataInput).ReadInt32WithPosition(offset + i*common.Int32SizeInBytes)
+			start, err := pr.input.(*ObjectDataInput).ReadInt32WithPosition(offset + i*bufutil.Int32SizeInBytes)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/serialization/default_portable_writer.go
+++ b/internal/serialization/default_portable_writer.go
@@ -15,7 +15,7 @@
 package serialization
 
 import (
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization/classdef"
 	"github.com/hazelcast/hazelcast-go-client/serialization"
 )
@@ -34,7 +34,7 @@ func NewDefaultPortableWriter(serializer *PortableSerializer, output serializati
 	output.WriteZeroBytes(4)
 	output.WriteInt32(int32(classDefinition.FieldCount()))
 	offset := output.Position()
-	fieldIndexesLength := (classDefinition.FieldCount() + 1) * common.Int32SizeInBytes
+	fieldIndexesLength := (classDefinition.FieldCount() + 1) * bufutil.Int32SizeInBytes
 	output.WriteZeroBytes(fieldIndexesLength)
 	return &DefaultPortableWriter{serializer, output, classDefinition, begin, offset}
 }
@@ -160,7 +160,7 @@ func (pw *DefaultPortableWriter) WritePortableArray(fieldName string, portableAr
 	if portableArray != nil {
 		length = int32(len(portableArray))
 	} else {
-		length = common.NilArrayLength
+		length = bufutil.NilArrayLength
 	}
 	pw.output.WriteInt32(length)
 	pw.output.WriteInt32(fieldDefinition.FactoryID())
@@ -172,7 +172,7 @@ func (pw *DefaultPortableWriter) WritePortableArray(fieldName string, portableAr
 		for i := int32(0); i < length; i++ {
 			sample = portableArray[i]
 			posVal := pw.output.Position()
-			pw.output.PWriteInt32(innerOffset+i*common.Int32SizeInBytes, posVal)
+			pw.output.PWriteInt32(innerOffset+i*bufutil.Int32SizeInBytes, posVal)
 			err := pw.serializer.WriteObject(pw.output, sample)
 			if err != nil {
 				return err
@@ -186,7 +186,7 @@ func (pw *DefaultPortableWriter) setPosition(fieldName string, fieldType int32) 
 	field := pw.classDefinition.Field(fieldName)
 	pos := pw.output.Position()
 	index := field.Index()
-	pw.output.PWriteInt32(pw.offset+index*common.Int32SizeInBytes, pos)
+	pw.output.PWriteInt32(pw.offset+index*bufutil.Int32SizeInBytes, pos)
 	pw.output.WriteInt16(int16(len(fieldName)))
 	pw.output.WriteBytes(fieldName)
 	pw.output.WriteByte(byte(fieldType))

--- a/internal/serialization/object_data.go
+++ b/internal/serialization/object_data.go
@@ -19,7 +19,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/hazelcast/hazelcast-go-client/core"
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization/bufferutil"
 	"github.com/hazelcast/hazelcast-go-client/serialization"
 )
@@ -74,51 +74,51 @@ func (o *ObjectDataOutput) EnsureAvailable(size int) {
 }
 
 func (o *ObjectDataOutput) WriteByte(v byte) {
-	o.EnsureAvailable(common.ByteSizeInBytes)
+	o.EnsureAvailable(bufutil.ByteSizeInBytes)
 	bufferutil.WriteUInt8(o.buffer, o.position, v)
-	o.position += common.ByteSizeInBytes
+	o.position += bufutil.ByteSizeInBytes
 }
 
 func (o *ObjectDataOutput) WriteBool(v bool) {
-	o.EnsureAvailable(common.BoolSizeInBytes)
+	o.EnsureAvailable(bufutil.BoolSizeInBytes)
 	bufferutil.WriteBool(o.buffer, o.position, v)
-	o.position += common.BoolSizeInBytes
+	o.position += bufutil.BoolSizeInBytes
 }
 
 func (o *ObjectDataOutput) WriteUInt16(v uint16) {
-	o.EnsureAvailable(common.Uint16SizeInBytes)
+	o.EnsureAvailable(bufutil.Uint16SizeInBytes)
 	bufferutil.WriteUInt16(o.buffer, o.position, v, o.bigEndian)
-	o.position += common.Uint16SizeInBytes
+	o.position += bufutil.Uint16SizeInBytes
 }
 
 func (o *ObjectDataOutput) WriteInt16(v int16) {
-	o.EnsureAvailable(common.Int16SizeInBytes)
+	o.EnsureAvailable(bufutil.Int16SizeInBytes)
 	bufferutil.WriteInt16(o.buffer, o.position, v, o.bigEndian)
-	o.position += common.Int16SizeInBytes
+	o.position += bufutil.Int16SizeInBytes
 }
 
 func (o *ObjectDataOutput) WriteInt32(v int32) {
-	o.EnsureAvailable(common.Int32SizeInBytes)
+	o.EnsureAvailable(bufutil.Int32SizeInBytes)
 	bufferutil.WriteInt32(o.buffer, o.position, v, o.bigEndian)
-	o.position += common.Int32SizeInBytes
+	o.position += bufutil.Int32SizeInBytes
 }
 
 func (o *ObjectDataOutput) WriteInt64(v int64) {
-	o.EnsureAvailable(common.Int64SizeInBytes)
+	o.EnsureAvailable(bufutil.Int64SizeInBytes)
 	bufferutil.WriteInt64(o.buffer, o.position, v, o.bigEndian)
-	o.position += common.Int64SizeInBytes
+	o.position += bufutil.Int64SizeInBytes
 }
 
 func (o *ObjectDataOutput) WriteFloat32(v float32) {
-	o.EnsureAvailable(common.Float32SizeInBytes)
+	o.EnsureAvailable(bufutil.Float32SizeInBytes)
 	bufferutil.WriteFloat32(o.buffer, o.position, v, o.bigEndian)
-	o.position += common.Float32SizeInBytes
+	o.position += bufutil.Float32SizeInBytes
 }
 
 func (o *ObjectDataOutput) WriteFloat64(v float64) {
-	o.EnsureAvailable(common.Float64SizeInBytes)
+	o.EnsureAvailable(bufutil.Float64SizeInBytes)
 	bufferutil.WriteFloat64(o.buffer, o.position, v, o.bigEndian)
-	o.position += common.Float64SizeInBytes
+	o.position += bufutil.Float64SizeInBytes
 }
 
 func (o *ObjectDataOutput) WriteUTF(v string) {
@@ -143,7 +143,7 @@ func (o *ObjectDataOutput) WriteByteArray(v []byte) {
 	if v != nil {
 		length = int32(len(v))
 	} else {
-		length = common.NilArrayLength
+		length = bufutil.NilArrayLength
 	}
 	o.WriteInt32(length)
 	for j := int32(0); j < length; j++ {
@@ -156,7 +156,7 @@ func (o *ObjectDataOutput) WriteBoolArray(v []bool) {
 	if v != nil {
 		length = int32(len(v))
 	} else {
-		length = common.NilArrayLength
+		length = bufutil.NilArrayLength
 	}
 	o.WriteInt32(length)
 	for j := int32(0); j < length; j++ {
@@ -169,7 +169,7 @@ func (o *ObjectDataOutput) WriteUInt16Array(v []uint16) {
 	if v != nil {
 		length = int32(len(v))
 	} else {
-		length = common.NilArrayLength
+		length = bufutil.NilArrayLength
 	}
 	o.WriteInt32(length)
 	for j := int32(0); j < length; j++ {
@@ -182,7 +182,7 @@ func (o *ObjectDataOutput) WriteInt16Array(v []int16) {
 	if v != nil {
 		length = int32(len(v))
 	} else {
-		length = common.NilArrayLength
+		length = bufutil.NilArrayLength
 	}
 	o.WriteInt32(length)
 	for j := int32(0); j < length; j++ {
@@ -195,7 +195,7 @@ func (o *ObjectDataOutput) WriteInt32Array(v []int32) {
 	if v != nil {
 		length = int32(len(v))
 	} else {
-		length = common.NilArrayLength
+		length = bufutil.NilArrayLength
 	}
 	o.WriteInt32(length)
 	for j := int32(0); j < length; j++ {
@@ -208,7 +208,7 @@ func (o *ObjectDataOutput) WriteInt64Array(v []int64) {
 	if v != nil {
 		length = int32(len(v))
 	} else {
-		length = common.NilArrayLength
+		length = bufutil.NilArrayLength
 	}
 	o.WriteInt32(length)
 	for j := int32(0); j < length; j++ {
@@ -221,7 +221,7 @@ func (o *ObjectDataOutput) WriteFloat32Array(v []float32) {
 	if v != nil {
 		length = int32(len(v))
 	} else {
-		length = common.NilArrayLength
+		length = bufutil.NilArrayLength
 	}
 	o.WriteInt32(length)
 	for j := int32(0); j < length; j++ {
@@ -234,7 +234,7 @@ func (o *ObjectDataOutput) WriteFloat64Array(v []float64) {
 	if v != nil {
 		length = int32(len(v))
 	} else {
-		length = common.NilArrayLength
+		length = bufutil.NilArrayLength
 	}
 	o.WriteInt32(length)
 	for j := int32(0); j < length; j++ {
@@ -247,7 +247,7 @@ func (o *ObjectDataOutput) WriteUTFArray(v []string) {
 	if v != nil {
 		length = int32(len(v))
 	} else {
-		length = common.NilArrayLength
+		length = bufutil.NilArrayLength
 	}
 	o.WriteInt32(length)
 	for j := int32(0); j < length; j++ {
@@ -264,7 +264,7 @@ func (o *ObjectDataOutput) WriteBytes(v string) {
 func (o *ObjectDataOutput) WriteData(data serialization.IData) {
 	var length int32
 	if data == nil {
-		length = common.NilArrayLength
+		length = bufutil.NilArrayLength
 	} else {
 		length = int32(data.TotalSize())
 	}
@@ -313,18 +313,18 @@ func (i *ObjectDataInput) SetPosition(pos int32) {
 }
 
 func (i *ObjectDataInput) ReadByte() (byte, error) {
-	var err = i.AssertAvailable(common.ByteSizeInBytes)
+	var err = i.AssertAvailable(bufutil.ByteSizeInBytes)
 	var ret byte
 	if err == nil {
 		ret = bufferutil.ReadUInt8(i.buffer, i.position)
-		i.position += common.ByteSizeInBytes
+		i.position += bufutil.ByteSizeInBytes
 		return ret, err
 	}
 	return ret, err
 }
 
 func (i *ObjectDataInput) ReadByteWithPosition(pos int32) (byte, error) {
-	var err = i.AssertAvailable(common.ByteSizeInBytes)
+	var err = i.AssertAvailable(bufutil.ByteSizeInBytes)
 	var ret byte
 	if err == nil {
 		ret = bufferutil.ReadUInt8(i.buffer, pos)
@@ -334,18 +334,18 @@ func (i *ObjectDataInput) ReadByteWithPosition(pos int32) (byte, error) {
 }
 
 func (i *ObjectDataInput) ReadBool() (bool, error) {
-	var err = i.AssertAvailable(common.BoolSizeInBytes)
+	var err = i.AssertAvailable(bufutil.BoolSizeInBytes)
 	var ret bool
 	if err == nil {
 		ret = bufferutil.ReadBool(i.buffer, i.position)
-		i.position += common.BoolSizeInBytes
+		i.position += bufutil.BoolSizeInBytes
 		return ret, err
 	}
 	return ret, err
 }
 
 func (i *ObjectDataInput) ReadBoolWithPosition(pos int32) (bool, error) {
-	var err = i.AssertAvailable(common.BoolSizeInBytes)
+	var err = i.AssertAvailable(bufutil.BoolSizeInBytes)
 	var ret bool
 	if err == nil {
 		ret = bufferutil.ReadBool(i.buffer, pos)
@@ -355,18 +355,18 @@ func (i *ObjectDataInput) ReadBoolWithPosition(pos int32) (bool, error) {
 }
 
 func (i *ObjectDataInput) ReadUInt16() (uint16, error) {
-	var err = i.AssertAvailable(common.Uint16SizeInBytes)
+	var err = i.AssertAvailable(bufutil.Uint16SizeInBytes)
 	var ret uint16
 	if err == nil {
 		ret = bufferutil.ReadUInt16(i.buffer, i.position, i.bigEndian)
-		i.position += common.Uint16SizeInBytes
+		i.position += bufutil.Uint16SizeInBytes
 		return ret, err
 	}
 	return ret, err
 }
 
 func (i *ObjectDataInput) ReadUInt16WithPosition(pos int32) (uint16, error) {
-	var err = i.AssertAvailable(common.Uint16SizeInBytes)
+	var err = i.AssertAvailable(bufutil.Uint16SizeInBytes)
 	var ret uint16
 	if err == nil {
 		ret = bufferutil.ReadUInt16(i.buffer, pos, i.bigEndian)
@@ -376,18 +376,18 @@ func (i *ObjectDataInput) ReadUInt16WithPosition(pos int32) (uint16, error) {
 }
 
 func (i *ObjectDataInput) ReadInt16() (int16, error) {
-	var err = i.AssertAvailable(common.Int16SizeInBytes)
+	var err = i.AssertAvailable(bufutil.Int16SizeInBytes)
 	var ret int16
 	if err == nil {
 		ret = bufferutil.ReadInt16(i.buffer, i.position, i.bigEndian)
-		i.position += common.Int16SizeInBytes
+		i.position += bufutil.Int16SizeInBytes
 		return ret, err
 	}
 	return ret, err
 }
 
 func (i *ObjectDataInput) ReadInt16WithPosition(pos int32) (int16, error) {
-	var err = i.AssertAvailable(common.Int16SizeInBytes)
+	var err = i.AssertAvailable(bufutil.Int16SizeInBytes)
 	var ret int16
 	if err == nil {
 		ret = bufferutil.ReadInt16(i.buffer, pos, i.bigEndian)
@@ -397,18 +397,18 @@ func (i *ObjectDataInput) ReadInt16WithPosition(pos int32) (int16, error) {
 }
 
 func (i *ObjectDataInput) ReadInt32() (int32, error) {
-	var err = i.AssertAvailable(common.Int32SizeInBytes)
+	var err = i.AssertAvailable(bufutil.Int32SizeInBytes)
 	var ret int32
 	if err == nil {
 		ret = bufferutil.ReadInt32(i.buffer, i.position, i.bigEndian)
-		i.position += common.Int32SizeInBytes
+		i.position += bufutil.Int32SizeInBytes
 		return ret, err
 	}
 	return ret, err
 }
 
 func (i *ObjectDataInput) ReadInt32WithPosition(pos int32) (int32, error) {
-	var err = i.AssertAvailable(common.Int32SizeInBytes)
+	var err = i.AssertAvailable(bufutil.Int32SizeInBytes)
 	var ret int32
 	if err == nil {
 		ret = bufferutil.ReadInt32(i.buffer, pos, i.bigEndian)
@@ -418,18 +418,18 @@ func (i *ObjectDataInput) ReadInt32WithPosition(pos int32) (int32, error) {
 }
 
 func (i *ObjectDataInput) ReadInt64() (int64, error) {
-	var err = i.AssertAvailable(common.Int64SizeInBytes)
+	var err = i.AssertAvailable(bufutil.Int64SizeInBytes)
 	var ret int64
 	if err == nil {
 		ret = bufferutil.ReadInt64(i.buffer, i.position, i.bigEndian)
-		i.position += common.Int64SizeInBytes
+		i.position += bufutil.Int64SizeInBytes
 		return ret, err
 	}
 	return ret, err
 }
 
 func (i *ObjectDataInput) ReadInt64WithPosition(pos int32) (int64, error) {
-	var err = i.AssertAvailable(common.Int64SizeInBytes)
+	var err = i.AssertAvailable(bufutil.Int64SizeInBytes)
 	var ret int64
 	if err == nil {
 		ret = bufferutil.ReadInt64(i.buffer, pos, i.bigEndian)
@@ -439,18 +439,18 @@ func (i *ObjectDataInput) ReadInt64WithPosition(pos int32) (int64, error) {
 }
 
 func (i *ObjectDataInput) ReadFloat32() (float32, error) {
-	var err = i.AssertAvailable(common.Float32SizeInBytes)
+	var err = i.AssertAvailable(bufutil.Float32SizeInBytes)
 	var ret float32
 	if err == nil {
 		ret = bufferutil.ReadFloat32(i.buffer, i.position, i.bigEndian)
-		i.position += common.Float32SizeInBytes
+		i.position += bufutil.Float32SizeInBytes
 		return ret, err
 	}
 	return ret, err
 }
 
 func (i *ObjectDataInput) ReadFloat32WithPosition(pos int32) (float32, error) {
-	var err = i.AssertAvailable(common.Float32SizeInBytes)
+	var err = i.AssertAvailable(bufutil.Float32SizeInBytes)
 	var ret float32
 	if err == nil {
 		ret = bufferutil.ReadFloat32(i.buffer, pos, i.bigEndian)
@@ -460,18 +460,18 @@ func (i *ObjectDataInput) ReadFloat32WithPosition(pos int32) (float32, error) {
 }
 
 func (i *ObjectDataInput) ReadFloat64() (float64, error) {
-	var err = i.AssertAvailable(common.Float64SizeInBytes)
+	var err = i.AssertAvailable(bufutil.Float64SizeInBytes)
 	var ret float64
 	if err == nil {
 		ret = bufferutil.ReadFloat64(i.buffer, i.position, i.bigEndian)
-		i.position += common.Float64SizeInBytes
+		i.position += bufutil.Float64SizeInBytes
 		return ret, err
 	}
 	return ret, err
 }
 
 func (i *ObjectDataInput) ReadFloat64WithPosition(pos int32) (float64, error) {
-	var err = i.AssertAvailable(common.Float64SizeInBytes)
+	var err = i.AssertAvailable(bufutil.Float64SizeInBytes)
 	var ret float64
 	if err == nil {
 		ret = bufferutil.ReadFloat64(i.buffer, pos, i.bigEndian)
@@ -482,7 +482,7 @@ func (i *ObjectDataInput) ReadFloat64WithPosition(pos int32) (float64, error) {
 
 func (i *ObjectDataInput) ReadUTF() (string, error) {
 	length, err := i.ReadInt32()
-	if err != nil || length == common.NilArrayLength {
+	if err != nil || length == bufutil.NilArrayLength {
 		return "", err
 	}
 	var ret = make([]rune, length)
@@ -496,10 +496,10 @@ func (i *ObjectDataInput) ReadUTF() (string, error) {
 
 func (i *ObjectDataInput) ReadUTFWithPosition(pos int32) (string, error) {
 	length, err := i.ReadInt32WithPosition(pos)
-	if err != nil || length == common.NilArrayLength {
+	if err != nil || length == bufutil.NilArrayLength {
 		return "", err
 	}
-	pos += common.Int32SizeInBytes
+	pos += bufutil.Int32SizeInBytes
 	var ret = make([]rune, length)
 	for j := 0; j < int(length); j++ {
 		r, n := utf8.DecodeRune(i.buffer[pos:])
@@ -515,7 +515,7 @@ func (i *ObjectDataInput) ReadObject() (interface{}, error) {
 
 func (i *ObjectDataInput) ReadByteArray() ([]byte, error) {
 	length, err := i.ReadInt32()
-	if err != nil || length == common.NilArrayLength {
+	if err != nil || length == bufutil.NilArrayLength {
 		return nil, err
 	}
 	var arr = make([]byte, length)
@@ -532,7 +532,7 @@ func (i *ObjectDataInput) ReadByteArrayWithPosition(pos int32) ([]byte, error) {
 	backupPos := i.position
 	i.position = pos
 	length, err := i.ReadInt32()
-	if err != nil || length == common.NilArrayLength {
+	if err != nil || length == bufutil.NilArrayLength {
 		return nil, err
 	}
 	var arr = make([]byte, length)
@@ -548,7 +548,7 @@ func (i *ObjectDataInput) ReadByteArrayWithPosition(pos int32) ([]byte, error) {
 
 func (i *ObjectDataInput) ReadBoolArray() ([]bool, error) {
 	length, err := i.ReadInt32()
-	if err != nil || length == common.NilArrayLength {
+	if err != nil || length == bufutil.NilArrayLength {
 		return nil, err
 	}
 	var arr = make([]bool, length)
@@ -565,7 +565,7 @@ func (i *ObjectDataInput) ReadBoolArrayWithPosition(pos int32) ([]bool, error) {
 	backupPos := i.position
 	i.position = pos
 	length, err := i.ReadInt32()
-	if err != nil || length == common.NilArrayLength {
+	if err != nil || length == bufutil.NilArrayLength {
 		return nil, err
 	}
 	var arr = make([]bool, length)
@@ -581,7 +581,7 @@ func (i *ObjectDataInput) ReadBoolArrayWithPosition(pos int32) ([]bool, error) {
 
 func (i *ObjectDataInput) ReadUInt16Array() ([]uint16, error) {
 	length, err := i.ReadInt32()
-	if err != nil || length == common.NilArrayLength {
+	if err != nil || length == bufutil.NilArrayLength {
 		return nil, err
 	}
 	var arr = make([]uint16, length)
@@ -598,7 +598,7 @@ func (i *ObjectDataInput) ReadUInt16ArrayWithPosition(pos int32) ([]uint16, erro
 	backupPos := i.position
 	i.position = pos
 	length, err := i.ReadInt32()
-	if err != nil || length == common.NilArrayLength {
+	if err != nil || length == bufutil.NilArrayLength {
 		return nil, err
 	}
 	var arr = make([]uint16, length)
@@ -614,7 +614,7 @@ func (i *ObjectDataInput) ReadUInt16ArrayWithPosition(pos int32) ([]uint16, erro
 
 func (i *ObjectDataInput) ReadInt16Array() ([]int16, error) {
 	length, err := i.ReadInt32()
-	if err != nil || length == common.NilArrayLength {
+	if err != nil || length == bufutil.NilArrayLength {
 		return nil, err
 	}
 	var arr = make([]int16, length)
@@ -631,7 +631,7 @@ func (i *ObjectDataInput) ReadInt16ArrayWithPosition(pos int32) ([]int16, error)
 	backupPos := i.position
 	i.position = pos
 	length, err := i.ReadInt32()
-	if err != nil || length == common.NilArrayLength {
+	if err != nil || length == bufutil.NilArrayLength {
 		return nil, err
 	}
 	var arr = make([]int16, length)
@@ -647,7 +647,7 @@ func (i *ObjectDataInput) ReadInt16ArrayWithPosition(pos int32) ([]int16, error)
 
 func (i *ObjectDataInput) ReadInt32Array() ([]int32, error) {
 	length, err := i.ReadInt32()
-	if err != nil || length == common.NilArrayLength {
+	if err != nil || length == bufutil.NilArrayLength {
 		return nil, err
 	}
 	var arr = make([]int32, length)
@@ -664,7 +664,7 @@ func (i *ObjectDataInput) ReadInt32ArrayWithPosition(pos int32) ([]int32, error)
 	backupPos := i.position
 	i.position = pos
 	length, err := i.ReadInt32()
-	if err != nil || length == common.NilArrayLength {
+	if err != nil || length == bufutil.NilArrayLength {
 		return nil, err
 	}
 	var arr = make([]int32, length)
@@ -680,7 +680,7 @@ func (i *ObjectDataInput) ReadInt32ArrayWithPosition(pos int32) ([]int32, error)
 
 func (i *ObjectDataInput) ReadInt64Array() ([]int64, error) {
 	length, err := i.ReadInt32()
-	if err != nil || length == common.NilArrayLength {
+	if err != nil || length == bufutil.NilArrayLength {
 		return nil, err
 	}
 	var arr = make([]int64, length)
@@ -697,7 +697,7 @@ func (i *ObjectDataInput) ReadInt64ArrayWithPosition(pos int32) ([]int64, error)
 	backupPos := i.position
 	i.position = pos
 	length, err := i.ReadInt32()
-	if err != nil || length == common.NilArrayLength {
+	if err != nil || length == bufutil.NilArrayLength {
 		return nil, err
 	}
 	var arr = make([]int64, length)
@@ -713,7 +713,7 @@ func (i *ObjectDataInput) ReadInt64ArrayWithPosition(pos int32) ([]int64, error)
 
 func (i *ObjectDataInput) ReadFloat32Array() ([]float32, error) {
 	length, err := i.ReadInt32()
-	if err != nil || length == common.NilArrayLength {
+	if err != nil || length == bufutil.NilArrayLength {
 		return nil, err
 	}
 	var arr = make([]float32, length)
@@ -730,7 +730,7 @@ func (i *ObjectDataInput) ReadFloat32ArrayWithPosition(pos int32) ([]float32, er
 	backupPos := i.position
 	i.position = pos
 	length, err := i.ReadInt32()
-	if err != nil || length == common.NilArrayLength {
+	if err != nil || length == bufutil.NilArrayLength {
 		return nil, err
 	}
 	var arr = make([]float32, length)
@@ -746,7 +746,7 @@ func (i *ObjectDataInput) ReadFloat32ArrayWithPosition(pos int32) ([]float32, er
 
 func (i *ObjectDataInput) ReadFloat64Array() ([]float64, error) {
 	length, err := i.ReadInt32()
-	if err != nil || length == common.NilArrayLength {
+	if err != nil || length == bufutil.NilArrayLength {
 		return nil, err
 	}
 	var arr = make([]float64, length)
@@ -763,7 +763,7 @@ func (i *ObjectDataInput) ReadFloat64ArrayWithPosition(pos int32) ([]float64, er
 	backupPos := i.position
 	i.position = pos
 	length, err := i.ReadInt32()
-	if err != nil || length == common.NilArrayLength {
+	if err != nil || length == bufutil.NilArrayLength {
 		return nil, err
 	}
 	var arr = make([]float64, length)
@@ -779,7 +779,7 @@ func (i *ObjectDataInput) ReadFloat64ArrayWithPosition(pos int32) ([]float64, er
 
 func (i *ObjectDataInput) ReadUTFArray() ([]string, error) {
 	length, err := i.ReadInt32()
-	if err != nil || length == common.NilArrayLength {
+	if err != nil || length == bufutil.NilArrayLength {
 		return nil, err
 	}
 	var arr = make([]string, length)
@@ -796,7 +796,7 @@ func (i *ObjectDataInput) ReadUTFArrayWithPosition(pos int32) ([]string, error) 
 	backupPos := i.position
 	i.position = pos
 	length, err := i.ReadInt32()
-	if err != nil || length == common.NilArrayLength {
+	if err != nil || length == bufutil.NilArrayLength {
 		return nil, err
 	}
 	var arr = make([]string, length)

--- a/internal/serialization/object_data.go
+++ b/internal/serialization/object_data.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/hazelcast/hazelcast-go-client/core"
 	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization/bufferutil"
 	"github.com/hazelcast/hazelcast-go-client/serialization"
 )
 
@@ -74,49 +75,49 @@ func (o *ObjectDataOutput) EnsureAvailable(size int) {
 
 func (o *ObjectDataOutput) WriteByte(v byte) {
 	o.EnsureAvailable(common.ByteSizeInBytes)
-	common.WriteUInt8(o.buffer, o.position, v)
+	bufferutil.WriteUInt8(o.buffer, o.position, v)
 	o.position += common.ByteSizeInBytes
 }
 
 func (o *ObjectDataOutput) WriteBool(v bool) {
 	o.EnsureAvailable(common.BoolSizeInBytes)
-	common.WriteBool(o.buffer, o.position, v)
+	bufferutil.WriteBool(o.buffer, o.position, v)
 	o.position += common.BoolSizeInBytes
 }
 
 func (o *ObjectDataOutput) WriteUInt16(v uint16) {
 	o.EnsureAvailable(common.Uint16SizeInBytes)
-	common.WriteUInt16(o.buffer, o.position, v, o.bigEndian)
+	bufferutil.WriteUInt16(o.buffer, o.position, v, o.bigEndian)
 	o.position += common.Uint16SizeInBytes
 }
 
 func (o *ObjectDataOutput) WriteInt16(v int16) {
 	o.EnsureAvailable(common.Int16SizeInBytes)
-	common.WriteInt16(o.buffer, o.position, v, o.bigEndian)
+	bufferutil.WriteInt16(o.buffer, o.position, v, o.bigEndian)
 	o.position += common.Int16SizeInBytes
 }
 
 func (o *ObjectDataOutput) WriteInt32(v int32) {
 	o.EnsureAvailable(common.Int32SizeInBytes)
-	common.WriteInt32(o.buffer, o.position, v, o.bigEndian)
+	bufferutil.WriteInt32(o.buffer, o.position, v, o.bigEndian)
 	o.position += common.Int32SizeInBytes
 }
 
 func (o *ObjectDataOutput) WriteInt64(v int64) {
 	o.EnsureAvailable(common.Int64SizeInBytes)
-	common.WriteInt64(o.buffer, o.position, v, o.bigEndian)
+	bufferutil.WriteInt64(o.buffer, o.position, v, o.bigEndian)
 	o.position += common.Int64SizeInBytes
 }
 
 func (o *ObjectDataOutput) WriteFloat32(v float32) {
 	o.EnsureAvailable(common.Float32SizeInBytes)
-	common.WriteFloat32(o.buffer, o.position, v, o.bigEndian)
+	bufferutil.WriteFloat32(o.buffer, o.position, v, o.bigEndian)
 	o.position += common.Float32SizeInBytes
 }
 
 func (o *ObjectDataOutput) WriteFloat64(v float64) {
 	o.EnsureAvailable(common.Float64SizeInBytes)
-	common.WriteFloat64(o.buffer, o.position, v, o.bigEndian)
+	bufferutil.WriteFloat64(o.buffer, o.position, v, o.bigEndian)
 	o.position += common.Float64SizeInBytes
 }
 
@@ -315,7 +316,7 @@ func (i *ObjectDataInput) ReadByte() (byte, error) {
 	var err = i.AssertAvailable(common.ByteSizeInBytes)
 	var ret byte
 	if err == nil {
-		ret = common.ReadUInt8(i.buffer, i.position)
+		ret = bufferutil.ReadUInt8(i.buffer, i.position)
 		i.position += common.ByteSizeInBytes
 		return ret, err
 	}
@@ -326,7 +327,7 @@ func (i *ObjectDataInput) ReadByteWithPosition(pos int32) (byte, error) {
 	var err = i.AssertAvailable(common.ByteSizeInBytes)
 	var ret byte
 	if err == nil {
-		ret = common.ReadUInt8(i.buffer, pos)
+		ret = bufferutil.ReadUInt8(i.buffer, pos)
 		return ret, err
 	}
 	return ret, err
@@ -336,7 +337,7 @@ func (i *ObjectDataInput) ReadBool() (bool, error) {
 	var err = i.AssertAvailable(common.BoolSizeInBytes)
 	var ret bool
 	if err == nil {
-		ret = common.ReadBool(i.buffer, i.position)
+		ret = bufferutil.ReadBool(i.buffer, i.position)
 		i.position += common.BoolSizeInBytes
 		return ret, err
 	}
@@ -347,7 +348,7 @@ func (i *ObjectDataInput) ReadBoolWithPosition(pos int32) (bool, error) {
 	var err = i.AssertAvailable(common.BoolSizeInBytes)
 	var ret bool
 	if err == nil {
-		ret = common.ReadBool(i.buffer, pos)
+		ret = bufferutil.ReadBool(i.buffer, pos)
 		return ret, err
 	}
 	return ret, err
@@ -357,7 +358,7 @@ func (i *ObjectDataInput) ReadUInt16() (uint16, error) {
 	var err = i.AssertAvailable(common.Uint16SizeInBytes)
 	var ret uint16
 	if err == nil {
-		ret = common.ReadUInt16(i.buffer, i.position, i.bigEndian)
+		ret = bufferutil.ReadUInt16(i.buffer, i.position, i.bigEndian)
 		i.position += common.Uint16SizeInBytes
 		return ret, err
 	}
@@ -368,7 +369,7 @@ func (i *ObjectDataInput) ReadUInt16WithPosition(pos int32) (uint16, error) {
 	var err = i.AssertAvailable(common.Uint16SizeInBytes)
 	var ret uint16
 	if err == nil {
-		ret = common.ReadUInt16(i.buffer, pos, i.bigEndian)
+		ret = bufferutil.ReadUInt16(i.buffer, pos, i.bigEndian)
 		return ret, err
 	}
 	return ret, err
@@ -378,7 +379,7 @@ func (i *ObjectDataInput) ReadInt16() (int16, error) {
 	var err = i.AssertAvailable(common.Int16SizeInBytes)
 	var ret int16
 	if err == nil {
-		ret = common.ReadInt16(i.buffer, i.position, i.bigEndian)
+		ret = bufferutil.ReadInt16(i.buffer, i.position, i.bigEndian)
 		i.position += common.Int16SizeInBytes
 		return ret, err
 	}
@@ -389,7 +390,7 @@ func (i *ObjectDataInput) ReadInt16WithPosition(pos int32) (int16, error) {
 	var err = i.AssertAvailable(common.Int16SizeInBytes)
 	var ret int16
 	if err == nil {
-		ret = common.ReadInt16(i.buffer, pos, i.bigEndian)
+		ret = bufferutil.ReadInt16(i.buffer, pos, i.bigEndian)
 		return ret, err
 	}
 	return ret, err
@@ -399,7 +400,7 @@ func (i *ObjectDataInput) ReadInt32() (int32, error) {
 	var err = i.AssertAvailable(common.Int32SizeInBytes)
 	var ret int32
 	if err == nil {
-		ret = common.ReadInt32(i.buffer, i.position, i.bigEndian)
+		ret = bufferutil.ReadInt32(i.buffer, i.position, i.bigEndian)
 		i.position += common.Int32SizeInBytes
 		return ret, err
 	}
@@ -410,7 +411,7 @@ func (i *ObjectDataInput) ReadInt32WithPosition(pos int32) (int32, error) {
 	var err = i.AssertAvailable(common.Int32SizeInBytes)
 	var ret int32
 	if err == nil {
-		ret = common.ReadInt32(i.buffer, pos, i.bigEndian)
+		ret = bufferutil.ReadInt32(i.buffer, pos, i.bigEndian)
 		return ret, err
 	}
 	return ret, err
@@ -420,7 +421,7 @@ func (i *ObjectDataInput) ReadInt64() (int64, error) {
 	var err = i.AssertAvailable(common.Int64SizeInBytes)
 	var ret int64
 	if err == nil {
-		ret = common.ReadInt64(i.buffer, i.position, i.bigEndian)
+		ret = bufferutil.ReadInt64(i.buffer, i.position, i.bigEndian)
 		i.position += common.Int64SizeInBytes
 		return ret, err
 	}
@@ -431,7 +432,7 @@ func (i *ObjectDataInput) ReadInt64WithPosition(pos int32) (int64, error) {
 	var err = i.AssertAvailable(common.Int64SizeInBytes)
 	var ret int64
 	if err == nil {
-		ret = common.ReadInt64(i.buffer, pos, i.bigEndian)
+		ret = bufferutil.ReadInt64(i.buffer, pos, i.bigEndian)
 		return ret, err
 	}
 	return ret, err
@@ -441,7 +442,7 @@ func (i *ObjectDataInput) ReadFloat32() (float32, error) {
 	var err = i.AssertAvailable(common.Float32SizeInBytes)
 	var ret float32
 	if err == nil {
-		ret = common.ReadFloat32(i.buffer, i.position, i.bigEndian)
+		ret = bufferutil.ReadFloat32(i.buffer, i.position, i.bigEndian)
 		i.position += common.Float32SizeInBytes
 		return ret, err
 	}
@@ -452,7 +453,7 @@ func (i *ObjectDataInput) ReadFloat32WithPosition(pos int32) (float32, error) {
 	var err = i.AssertAvailable(common.Float32SizeInBytes)
 	var ret float32
 	if err == nil {
-		ret = common.ReadFloat32(i.buffer, pos, i.bigEndian)
+		ret = bufferutil.ReadFloat32(i.buffer, pos, i.bigEndian)
 		return ret, err
 	}
 	return ret, err
@@ -462,7 +463,7 @@ func (i *ObjectDataInput) ReadFloat64() (float64, error) {
 	var err = i.AssertAvailable(common.Float64SizeInBytes)
 	var ret float64
 	if err == nil {
-		ret = common.ReadFloat64(i.buffer, i.position, i.bigEndian)
+		ret = bufferutil.ReadFloat64(i.buffer, i.position, i.bigEndian)
 		i.position += common.Float64SizeInBytes
 		return ret, err
 	}
@@ -473,7 +474,7 @@ func (i *ObjectDataInput) ReadFloat64WithPosition(pos int32) (float64, error) {
 	var err = i.AssertAvailable(common.Float64SizeInBytes)
 	var ret float64
 	if err == nil {
-		ret = common.ReadFloat64(i.buffer, pos, i.bigEndian)
+		ret = bufferutil.ReadFloat64(i.buffer, pos, i.bigEndian)
 		return ret, err
 	}
 	return ret, err
@@ -829,33 +830,33 @@ func NewPositionalObjectDataOutput(length int, service *Service, bigEndian bool)
 }
 
 func (p *PositionalObjectDataOutput) PWriteByte(pos int32, v byte) {
-	common.WriteUInt8(p.buffer, pos, v)
+	bufferutil.WriteUInt8(p.buffer, pos, v)
 }
 
 func (p *PositionalObjectDataOutput) PWriteBool(pos int32, v bool) {
-	common.WriteBool(p.buffer, pos, v)
+	bufferutil.WriteBool(p.buffer, pos, v)
 }
 
 func (p *PositionalObjectDataOutput) PWriteUInt16(pos int32, v uint16) {
-	common.WriteUInt16(p.buffer, pos, v, p.bigEndian)
+	bufferutil.WriteUInt16(p.buffer, pos, v, p.bigEndian)
 }
 
 func (p *PositionalObjectDataOutput) PWriteInt16(pos int32, v int16) {
-	common.WriteInt16(p.buffer, pos, v, p.bigEndian)
+	bufferutil.WriteInt16(p.buffer, pos, v, p.bigEndian)
 }
 
 func (p *PositionalObjectDataOutput) PWriteInt32(pos int32, v int32) {
-	common.WriteInt32(p.buffer, pos, v, p.bigEndian)
+	bufferutil.WriteInt32(p.buffer, pos, v, p.bigEndian)
 }
 
 func (p *PositionalObjectDataOutput) PWriteInt64(pos int32, v int64) {
-	common.WriteInt64(p.buffer, pos, v, p.bigEndian)
+	bufferutil.WriteInt64(p.buffer, pos, v, p.bigEndian)
 }
 
 func (p *PositionalObjectDataOutput) PWriteFloat32(pos int32, v float32) {
-	common.WriteFloat32(p.buffer, pos, v, p.bigEndian)
+	bufferutil.WriteFloat32(p.buffer, pos, v, p.bigEndian)
 }
 
 func (p *PositionalObjectDataOutput) PWriteFloat64(pos int32, v float64) {
-	common.WriteFloat64(p.buffer, pos, v, p.bigEndian)
+	bufferutil.WriteFloat64(p.buffer, pos, v, p.bigEndian)
 }

--- a/internal/serialization/portable_context.go
+++ b/internal/serialization/portable_context.go
@@ -15,7 +15,7 @@
 package serialization
 
 import (
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 	internalclassdef "github.com/hazelcast/hazelcast-go-client/internal/serialization/classdef"
 	"github.com/hazelcast/hazelcast-go-client/serialization"
 	"github.com/hazelcast/hazelcast-go-client/serialization/classdef"
@@ -46,7 +46,7 @@ func (c *PortableContext) ReadClassDefinitionFromInput(input serialization.DataI
 	}
 	offset := input.Position()
 	for i := int32(0); i < fieldCount; i++ {
-		pos, err := input.(*ObjectDataInput).ReadInt32WithPosition(offset + i*common.Int32SizeInBytes)
+		pos, err := input.(*ObjectDataInput).ReadInt32WithPosition(offset + i*bufutil.Int32SizeInBytes)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/timeutil/util.go
+++ b/internal/timeutil/util.go
@@ -12,38 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package bufutil
+package timeutil
 
 import (
-	"crypto/rand"
-	"fmt"
-	"io"
 	"math"
-	"net"
-	"strconv"
-	"strings"
 	"time"
 )
-
-func IsValidIPAddress(addr string) bool {
-	return net.ParseIP(addr) != nil
-}
-
-func GetIPAndPort(addr string) (string, int32) {
-	var port int
-	var err error
-	parts := strings.Split(addr, ":")
-	if len(parts) == 2 {
-		port, err = strconv.Atoi(parts[1])
-		if err != nil {
-			port = 5701 // Default port
-		}
-	} else {
-		port = -1
-	}
-	addr = parts[0]
-	return addr, int32(port)
-}
 
 func GetTimeInMilliSeconds(duration time.Duration) int64 {
 	if duration == -1 {
@@ -69,16 +43,4 @@ func ConvertMillisToUnixTime(timeInMillis int64) time.Time {
 		return time.Unix(0, timeInMillis)
 	}
 	return time.Unix(0, timeInMillis*int64(time.Millisecond))
-}
-
-// NewUUID generates a random uuid according to RFC 4122
-func NewUUID() (string, error) {
-	uuid := make([]byte, 16)
-	n, err := io.ReadFull(rand.Reader, uuid)
-	if n != len(uuid) || err != nil {
-		return "", err
-	}
-	uuid[8] = uuid[8]&^0xc0 | 0x80
-	uuid[6] = uuid[6]&^0xf0 | 0x40
-	return fmt.Sprintf("%x-%x-%x-%x-%x", uuid[0:4], uuid[4:6], uuid[6:8], uuid[8:10], uuid[10:]), nil
 }

--- a/internal/timeutil/util_test.go
+++ b/internal/timeutil/util_test.go
@@ -12,37 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package bufutil
+package timeutil
 
 import (
 	"testing"
 	"time"
 )
-
-func TestIsValidIPAddress(t *testing.T) {
-	ip := "142.1.2.4"
-	if ok := IsValidIPAddress(ip); !ok {
-		t.Fatal("IsValidIPAddress failed")
-	}
-	ip = "123.2.1"
-	if ok := IsValidIPAddress(ip); ok {
-		t.Fatal("IsValidIPAddress failed")
-	}
-}
-
-func TestGetIpAndPort(t *testing.T) {
-	testAddress := "121.1.23.3:1231"
-	if ip, port := GetIPAndPort(testAddress); ip != "121.1.23.3" || port != 1231 {
-		t.Fatal("GetIPAndPort failed.")
-	}
-}
-
-func TestGetIpWithoutPort(t *testing.T) {
-	testAddress := "121.1.23.3"
-	if ip, port := GetIPAndPort(testAddress); ip != "121.1.23.3" || port != -1 {
-		t.Fatal("GetIPAndPort failed.")
-	}
-}
 
 func TestGetTimeInMilliSeconds(t *testing.T) {
 	var expected int64 = 100

--- a/tests/compatibility/binary_compatibility_test.go
+++ b/tests/compatibility/binary_compatibility_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	"github.com/hazelcast/hazelcast-go-client/config"
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
 
@@ -82,7 +82,7 @@ func TestBinaryCompatibility(t *testing.T) {
 	for i.Available() != 0 {
 		objectKey, _ := i.ReadUTF()
 		length, _ := i.ReadInt32()
-		if length != common.NilArrayLength {
+		if length != bufutil.NilArrayLength {
 			payload := dat[i.Position() : i.Position()+length]
 			i.SetPosition(i.Position() + length)
 			if supporteds[index] == objectKey {

--- a/tests/proxy/map/map_test.go
+++ b/tests/proxy/map/map_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/hazelcast/hazelcast-go-client"
 	"github.com/hazelcast/hazelcast-go-client/core"
 	"github.com/hazelcast/hazelcast-go-client/core/predicates"
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 	"github.com/hazelcast/hazelcast-go-client/rc"
 	"github.com/hazelcast/hazelcast-go-client/serialization"
 	"github.com/hazelcast/hazelcast-go-client/tests"
@@ -61,7 +61,7 @@ func TestMapProxy_Name(t *testing.T) {
 }
 
 func TestMapProxy_ServiceName(t *testing.T) {
-	serviceName := common.ServiceNameMap
+	serviceName := bufutil.ServiceNameMap
 	if serviceName != mp.ServiceName() {
 		t.Error("ServiceName() failed")
 	}

--- a/tests/proxy/map/proxy_test.go
+++ b/tests/proxy/map/proxy_test.go
@@ -4,13 +4,13 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 	"github.com/hazelcast/hazelcast-go-client/tests/assert"
 )
 
 func TestProxy_Destroy(t *testing.T) {
 	name := "testMap"
-	serviceName := common.ServiceNameMap
+	serviceName := bufutil.ServiceNameMap
 	testMap, err := client.GetDistributedObject(serviceName, name)
 	assert.ErrorNil(t, err)
 	res, err := testMap.Destroy()
@@ -28,7 +28,7 @@ func TestProxy_Destroy(t *testing.T) {
 
 func TestProxy_GetDistributedObject(t *testing.T) {
 	name := "testMap"
-	serviceName := common.ServiceNameMap
+	serviceName := bufutil.ServiceNameMap
 	mp, _ := client.GetDistributedObject(serviceName, name)
 	mp2, _ := client.GetDistributedObject(serviceName, name)
 

--- a/tests/proxy/pn_counter/pn_counter_test.go
+++ b/tests/proxy/pn_counter/pn_counter_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/hazelcast/hazelcast-go-client"
 	"github.com/hazelcast/hazelcast-go-client/core"
 	"github.com/hazelcast/hazelcast-go-client/internal"
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 	"github.com/hazelcast/hazelcast-go-client/rc"
 	"github.com/hazelcast/hazelcast-go-client/tests"
 	"github.com/hazelcast/hazelcast-go-client/tests/assert"
@@ -64,7 +64,7 @@ func TestPNCounter_Name(t *testing.T) {
 }
 
 func TestPNCounter_ServiceName(t *testing.T) {
-	serviceName := common.ServiceNamePNCounter
+	serviceName := bufutil.ServiceNamePNCounter
 	if serviceName != counter.ServiceName() {
 		t.Error("PNCounter.ServiceName failed")
 	}

--- a/tests/proxy/ringbuffer/ringbuffer_test.go
+++ b/tests/proxy/ringbuffer/ringbuffer_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/hazelcast/hazelcast-go-client"
 	"github.com/hazelcast/hazelcast-go-client/core"
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/protocol/bufutil"
 	"github.com/hazelcast/hazelcast-go-client/rc"
 	"github.com/hazelcast/hazelcast-go-client/tests"
 	"github.com/hazelcast/hazelcast-go-client/tests/assert"
@@ -53,7 +53,7 @@ func TestRingbufferProxy_Name(t *testing.T) {
 }
 
 func TestRingbufferProxy_ServiceName(t *testing.T) {
-	serviceName := common.ServiceNameRingbufferService
+	serviceName := bufutil.ServiceNameRingbufferService
 	if serviceName != ringbuffer.ServiceName() {
 		t.Error("ServiceName() failed")
 	}


### PR DESCRIPTION
This pr removes `internal/common` package and creates more meaningful packages.

`Iputil, timeutil, bufutil murmur` packages are created. These packages help organize the code better.

#245.


