### PR TITLE
implement aggregators

### DIFF
--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -21,7 +21,8 @@
     ".*DataOffset should have comment.*",
     ".*TypePortable should have comment.*",
     ".*LifecycleStateStarting should have comment.*",
-    ".*includedValue is unused.*"
+    ".*includedValue is unused.*",
+    ".*aggregator_hook.go.* is unused*"
   ],
   "EnableGC": true,
   "WarnUnmatchedDirective": true,

--- a/core/aggregator/aggregators.go
+++ b/core/aggregator/aggregators.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package aggregator is a utility package to create basic aggregators.
+// Min/Max/Average aggregators are type specific, so an integerAvg() aggregator
+// expects all elements to be integers.
+// There is no conversion executed while accumulating on the server side, so if there is any other type met an exception
+// will be thrown on the server side.
+//
+// The attributePath given in the factory method allows the aggregator to operate on the value extracted by navigating
+// to the given attributePath on each object that has been returned from a query.
+// The attribute path may be simple, e.g. "name", or nested "address.city".
+// The given attribute path should not be empty, otherwise an error will be returned from client side.
+//
+// Server version should be at least 3.8.
+package aggregator
+
+import (
+	"github.com/hazelcast/hazelcast-go-client/internal/aggregation"
+)
+
+// Count returns a Count aggregator that counts the input values from
+// the given attribute path.
+// The given attribute path should not be empty, otherwise an error will be returned.
+func Count(attributePath string) (*aggregation.Count, error) {
+	return aggregation.NewCount(attributePath)
+}
+
+// Float64Average returns a Float64Average aggregator that counts the input values from
+// the given attribute path.
+// The given attribute path should not be empty, otherwise an error will be returned.
+func Float64Average(attributePath string) (*aggregation.Float64Average, error) {
+	return aggregation.NewFloat64Average(attributePath)
+}
+
+// Float64Sum returns a Float64Sum aggregator that counts the input values from
+// the given attribute path.
+// The given attribute path should not be empty, otherwise an error will be returned.
+func Float64Sum(attributePath string) (*aggregation.Float64Sum, error) {
+	return aggregation.NewFloat64Sum(attributePath)
+}
+
+// FixedPointSum returns a FixedPointSum aggregator that counts the input values from
+// the given attribute path.
+// The given attribute path should not be empty, otherwise an error will be returned.
+func FixedPointSum(attributePath string) (*aggregation.FixedPointSum, error) {
+	return aggregation.NewFixedPointSum(attributePath)
+}
+
+// FloatingPointSum returns a FloatingPointSum aggregator that counts the input values from
+// the given attribute path.
+// The given attribute path should not be empty, otherwise an error will be returned.
+func FloatingPointSum(attributePath string) (*aggregation.FloatingPointSum, error) {
+	return aggregation.NewFloatingPointSum(attributePath)
+}
+
+// Max returns a Max aggregator that counts the input values from
+// the given attribute path.
+// The given attribute path should not be empty, otherwise an error will be returned.
+func Max(attributePath string) (*aggregation.Max, error) {
+	return aggregation.NewMax(attributePath)
+}
+
+// Min returns a Min aggregator that counts the input values from
+// the given attribute path.
+// The given attribute path should not be empty, otherwise an error will be returned.
+func Min(attributePath string) (*aggregation.Min, error) {
+	return aggregation.NewMin(attributePath)
+}
+
+// Int32Average returns a Int32Average aggregator that counts the input values from
+// the given attribute path.
+// The given attribute path should not be empty, otherwise an error will be returned.
+func Int32Average(attributePath string) (*aggregation.Int32Average, error) {
+	return aggregation.NewInt32Average(attributePath)
+}
+
+// Int32Sum returns a Int32Sum aggregator that counts the input values from
+// the given attribute path.
+// The given attribute path should not be empty, otherwise an error will be returned.
+func Int32Sum(attributePath string) (*aggregation.Int32Sum, error) {
+	return aggregation.NewInt32Sum(attributePath)
+}
+
+// Int64Average returns a Int64Average aggregator that counts the input values from
+// the given attribute path.
+// The given attribute path should not be empty, otherwise an error will be returned.
+func Int64Average(attributePath string) (*aggregation.Int64Average, error) {
+	return aggregation.NewInt64Average(attributePath)
+}
+
+// Int64Sum returns a Int64Sum aggregator that counts the input values from
+// the given attribute path.
+// The given attribute path should not be empty, otherwise an error will be returned.
+func Int64Sum(attributePath string) (*aggregation.Int64Sum, error) {
+	return aggregation.NewInt64Sum(attributePath)
+}

--- a/internal/aggregation/aggregator_hook.go
+++ b/internal/aggregation/aggregator_hook.go
@@ -12,13 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package common
+package aggregation
 
-import "github.com/hazelcast/hazelcast-go-client/core"
-
-func CheckHasText(argument string, errorMessage string) (err error) {
-	if argument == "" {
-		err = core.NewHazelcastIllegalArgumentError(errorMessage, nil)
-	}
-	return
-}
+const (
+	bigDecimalAvg = iota // not applicable to Go
+	bigDecimalSum        // not applicable to Go
+	bigIntAvg            // not applicable to Go
+	bigIntSum            // not applicable to Go
+	count
+	distinct // returns java serializable, not applicable to Go
+	float64Avg
+	float64Sum
+	fixedPointSum
+	floatingPointSum
+	int32Avg
+	int32Sum
+	int64Avg
+	int64Sum
+	max
+	min
+	numberAvg
+	maxBY
+	minBY
+)

--- a/internal/aggregation/aggregator_impl.go
+++ b/internal/aggregation/aggregator_impl.go
@@ -1,0 +1,364 @@
+// Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aggregation
+
+import (
+	"github.com/hazelcast/hazelcast-go-client/internal/precond"
+	"github.com/hazelcast/hazelcast-go-client/serialization"
+)
+
+type aggregator struct {
+	id int32
+}
+
+func (ag *aggregator) WriteData(output serialization.DataOutput) (err error) {
+	return
+}
+
+func (ag *aggregator) ReadData(input serialization.DataInput) (err error) {
+	return
+}
+
+func (*aggregator) FactoryID() int32 {
+	return FactoryID
+}
+
+func (ag *aggregator) ClassID() int32 {
+	return ag.id
+}
+
+func newAggregator(id int32) *aggregator {
+	return &aggregator{id: id}
+}
+
+type Count struct {
+	*aggregator
+	attributePath string
+}
+
+func NewCount(attributePath string) (*Count, error) {
+	err := precond.CheckHasText(attributePath, "attributePath should not be empty")
+	if err != nil {
+		return nil, err
+	}
+	return &Count{aggregator: newAggregator(count), attributePath: attributePath}, nil
+}
+
+func (c *Count) ReadData(input serialization.DataInput) (err error) {
+	c.aggregator = newAggregator(count)
+	c.attributePath, err = input.ReadUTF()
+	// member side field, not used in client
+	input.ReadInt64()
+	return
+}
+
+func (c *Count) WriteData(output serialization.DataOutput) (err error) {
+	output.WriteUTF(c.attributePath)
+	// member side field, not used in client
+	output.WriteInt64(0)
+	return
+}
+
+type Float64Average struct {
+	*aggregator
+	attributePath string
+}
+
+func NewFloat64Average(attributePath string) (*Float64Average, error) {
+	err := precond.CheckHasText(attributePath, "attributePath should not be empty")
+	if err != nil {
+		return nil, err
+	}
+	return &Float64Average{aggregator: newAggregator(float64Avg), attributePath: attributePath}, nil
+}
+
+func (f *Float64Average) ReadData(input serialization.DataInput) (err error) {
+	f.aggregator = newAggregator(float64Avg)
+	f.attributePath, err = input.ReadUTF()
+	// member side field, not used in client
+	input.ReadFloat64()
+	input.ReadInt64()
+	return
+}
+
+func (f *Float64Average) WriteData(output serialization.DataOutput) (err error) {
+	output.WriteUTF(f.attributePath)
+	// member side field, not used in client
+	output.WriteFloat64(0)
+	output.WriteInt64(0)
+	return
+}
+
+type Float64Sum struct {
+	*aggregator
+	attributePath string
+}
+
+func NewFloat64Sum(attributePath string) (*Float64Sum, error) {
+	err := precond.CheckHasText(attributePath, "attributePath should not be empty")
+	if err != nil {
+		return nil, err
+	}
+	return &Float64Sum{aggregator: newAggregator(float64Sum), attributePath: attributePath}, nil
+}
+
+func (f *Float64Sum) ReadData(input serialization.DataInput) (err error) {
+	f.aggregator = newAggregator(float64Sum)
+	f.attributePath, err = input.ReadUTF()
+	// member side field, not used in client
+	input.ReadFloat64()
+	input.ReadFloat64()
+	return
+}
+
+func (f *Float64Sum) WriteData(output serialization.DataOutput) (err error) {
+	output.WriteUTF(f.attributePath)
+	// member side field, not used in client
+	output.WriteFloat64(0)
+	output.WriteFloat64(0)
+	return
+}
+
+type FixedPointSum struct {
+	*aggregator
+	attributePath string
+}
+
+func NewFixedPointSum(attributePath string) (*FixedPointSum, error) {
+	err := precond.CheckHasText(attributePath, "attributePath should not be empty")
+	if err != nil {
+		return nil, err
+	}
+	return &FixedPointSum{aggregator: newAggregator(fixedPointSum), attributePath: attributePath}, nil
+}
+
+func (f *FixedPointSum) ReadData(input serialization.DataInput) (err error) {
+	f.aggregator = newAggregator(fixedPointSum)
+	f.attributePath, err = input.ReadUTF()
+	// member side field, not used in client
+	input.ReadInt64()
+	return
+}
+
+func (f *FixedPointSum) WriteData(output serialization.DataOutput) (err error) {
+	output.WriteUTF(f.attributePath)
+	// member side field, not used in client
+	output.WriteInt64(0)
+	return
+}
+
+type FloatingPointSum struct {
+	*aggregator
+	attributePath string
+}
+
+func NewFloatingPointSum(attributePath string) (*FloatingPointSum, error) {
+	err := precond.CheckHasText(attributePath, "attributePath should not be empty")
+	if err != nil {
+		return nil, err
+	}
+	return &FloatingPointSum{aggregator: newAggregator(floatingPointSum), attributePath: attributePath}, nil
+}
+
+func (f *FloatingPointSum) ReadData(input serialization.DataInput) (err error) {
+	f.aggregator = newAggregator(floatingPointSum)
+	f.attributePath, err = input.ReadUTF()
+	// member side field, not used in client
+	input.ReadFloat64()
+	return
+}
+
+func (f *FloatingPointSum) WriteData(output serialization.DataOutput) (err error) {
+	output.WriteUTF(f.attributePath)
+	// member side field, not used in client
+	output.WriteFloat64(0)
+	return
+}
+
+type Max struct {
+	*aggregator
+	attributePath string
+}
+
+func NewMax(attributePath string) (*Max, error) {
+	err := precond.CheckHasText(attributePath, "attributePath should not be empty")
+	if err != nil {
+		return nil, err
+	}
+	return &Max{aggregator: newAggregator(max), attributePath: attributePath}, nil
+}
+
+func (m *Max) ReadData(input serialization.DataInput) (err error) {
+	m.aggregator = newAggregator(max)
+	m.attributePath, err = input.ReadUTF()
+	// member side field, not used in client
+	input.ReadObject()
+	return
+}
+
+func (m *Max) WriteData(output serialization.DataOutput) (err error) {
+	output.WriteUTF(m.attributePath)
+	// member side field, not used in client
+	output.WriteObject(nil)
+	return
+}
+
+type Min struct {
+	*aggregator
+	attributePath string
+}
+
+func NewMin(attributePath string) (*Min, error) {
+	err := precond.CheckHasText(attributePath, "attributePath should not be empty")
+	if err != nil {
+		return nil, err
+	}
+	return &Min{aggregator: newAggregator(min), attributePath: attributePath}, nil
+}
+
+func (m *Min) ReadData(input serialization.DataInput) (err error) {
+	m.aggregator = newAggregator(min)
+	m.attributePath, err = input.ReadUTF()
+	// member side field, not used in client
+	input.ReadObject()
+	return
+}
+
+func (m *Min) WriteData(output serialization.DataOutput) (err error) {
+	output.WriteUTF(m.attributePath)
+	// member side field, not used in client
+	output.WriteObject(nil)
+	return
+}
+
+type Int32Average struct {
+	*aggregator
+	attributePath string
+}
+
+func NewInt32Average(attributePath string) (*Int32Average, error) {
+	err := precond.CheckHasText(attributePath, "attributePath should not be empty")
+	if err != nil {
+		return nil, err
+	}
+	return &Int32Average{aggregator: newAggregator(int32Avg), attributePath: attributePath}, nil
+}
+
+func (i *Int32Average) ReadData(input serialization.DataInput) (err error) {
+	i.aggregator = newAggregator(int32Avg)
+	i.attributePath, err = input.ReadUTF()
+	// member side field, not used in client
+	input.ReadInt64()
+	input.ReadInt64()
+	return
+}
+
+func (i *Int32Average) WriteData(output serialization.DataOutput) (err error) {
+	output.WriteUTF(i.attributePath)
+	// member side field, not used in client
+	output.WriteInt64(0)
+	output.WriteInt64(0)
+	return
+}
+
+type Int32Sum struct {
+	*aggregator
+	attributePath string
+}
+
+func NewInt32Sum(attributePath string) (*Int32Sum, error) {
+	err := precond.CheckHasText(attributePath, "attributePath should not be empty")
+	if err != nil {
+		return nil, err
+	}
+	return &Int32Sum{aggregator: newAggregator(int32Sum), attributePath: attributePath}, nil
+}
+
+func (i *Int32Sum) ReadData(input serialization.DataInput) (err error) {
+	i.aggregator = newAggregator(int32Sum)
+	i.attributePath, err = input.ReadUTF()
+	// member side field, not used in client
+	input.ReadInt64()
+	input.ReadInt64()
+	return
+}
+
+func (i *Int32Sum) WriteData(output serialization.DataOutput) (err error) {
+	output.WriteUTF(i.attributePath)
+	// member side field, not used in client
+	output.WriteInt64(0)
+	output.WriteInt64(0)
+	return
+}
+
+type Int64Average struct {
+	*aggregator
+	attributePath string
+}
+
+func NewInt64Average(attributePath string) (*Int64Average, error) {
+	err := precond.CheckHasText(attributePath, "attributePath should not be empty")
+	if err != nil {
+		return nil, err
+	}
+	return &Int64Average{aggregator: newAggregator(int64Avg), attributePath: attributePath}, nil
+}
+
+func (i *Int64Average) ReadData(input serialization.DataInput) (err error) {
+	i.aggregator = newAggregator(int64Avg)
+	i.attributePath, err = input.ReadUTF()
+	// member side field, not used in client
+	input.ReadInt64()
+	input.ReadInt64()
+	return
+}
+
+func (i *Int64Average) WriteData(output serialization.DataOutput) (err error) {
+	output.WriteUTF(i.attributePath)
+	// member side field, not used in client
+	output.WriteInt64(0)
+	output.WriteInt64(0)
+	return
+}
+
+type Int64Sum struct {
+	*aggregator
+	attributePath string
+}
+
+func NewInt64Sum(attributePath string) (*Int64Sum, error) {
+	err := precond.CheckHasText(attributePath, "attributePath should not be empty")
+	if err != nil {
+		return nil, err
+	}
+	return &Int64Sum{aggregator: newAggregator(int64Sum), attributePath: attributePath}, nil
+}
+
+func (i *Int64Sum) ReadData(input serialization.DataInput) (err error) {
+	i.aggregator = newAggregator(int64Sum)
+	i.attributePath, err = input.ReadUTF()
+	// member side field, not used in client
+	input.ReadInt64()
+	input.ReadInt64()
+	return
+}
+
+func (i *Int64Sum) WriteData(output serialization.DataOutput) (err error) {
+	output.WriteUTF(i.attributePath)
+	// member side field, not used in client
+	output.WriteInt64(0)
+	output.WriteInt64(0)
+	return
+}

--- a/internal/aggregation/factory.go
+++ b/internal/aggregation/factory.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aggregation
+
+import "github.com/hazelcast/hazelcast-go-client/serialization"
+
+const FactoryID = -41
+
+type Factory struct {
+}
+
+func NewFactory() *Factory {
+	return &Factory{}
+}
+
+func (*Factory) Create(id int32) serialization.IdentifiedDataSerializable {
+	switch id {
+	case count:
+		return &Count{}
+	case float64Avg:
+		return &Float64Average{}
+	case float64Sum:
+		return &Float64Sum{}
+	case fixedPointSum:
+		return &FixedPointSum{}
+	case floatingPointSum:
+		return &FloatingPointSum{}
+	case int32Avg:
+		return &Int32Average{}
+	case int32Sum:
+		return &Int32Sum{}
+	case int64Avg:
+		return &Int64Average{}
+	case int64Sum:
+		return &Int64Sum{}
+	case max:
+		return &Max{}
+	case min:
+		return &Min{}
+	default:
+		return nil
+	}
+}

--- a/internal/map.go
+++ b/internal/map.go
@@ -121,11 +121,23 @@ func (mp *mapProxy) Size() (size int32, err error) {
 }
 
 func (mp *mapProxy) Aggregate(aggregator interface{}) (result interface{}, err error) {
-	panic("implement me")
+	aggregatorData, err := mp.validateAndSerialize(aggregator)
+	if err != nil {
+		return nil, err
+	}
+	request := protocol.MapAggregateEncodeRequest(mp.name, aggregatorData)
+	responseMessage, err := mp.invokeOnRandomTarget(request)
+	return mp.decodeToObjectAndError(responseMessage, err, protocol.MapAggregateDecodeResponse)
 }
 
 func (mp *mapProxy) AggregateWithPredicate(aggregator interface{}, predicate interface{}) (result interface{}, err error) {
-	panic("implement me")
+	aggregatorData, predicateData, err := mp.validateAndSerialize2(aggregator, predicate)
+	if err != nil {
+		return nil, err
+	}
+	request := protocol.MapAggregateWithPredicateEncodeRequest(mp.name, aggregatorData, predicateData)
+	responseMessage, err := mp.invokeOnRandomTarget(request)
+	return mp.decodeToObjectAndError(responseMessage, err, protocol.MapAggregateWithPredicateDecodeResponse)
 }
 
 func (mp *mapProxy) Project(projection interface{}) (result []interface{}, err error) {

--- a/internal/precond/preconditions.go
+++ b/internal/precond/preconditions.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package precond
+
+import "github.com/hazelcast/hazelcast-go-client/core"
+
+func CheckHasText(argument string, errorMessage string) (err error) {
+	if argument == "" {
+		err = core.NewHazelcastIllegalArgumentError(errorMessage, nil)
+	}
+	return
+}

--- a/internal/precond/preconditions_test.go
+++ b/internal/precond/preconditions_test.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package precond
+
+import "testing"
+
+func TestCheckHasText_NonEmptyText(t *testing.T) {
+	err := CheckHasText("aa", "error")
+	if err != nil {
+		t.Fatal("CheckHasText should not return an error with a nonempty text")
+	}
+
+}
+
+func TestCheckHasText_EmptyText(t *testing.T) {
+	err := CheckHasText("", "error")
+	if err == nil {
+		t.Fatal("CheckHasText should return an error with a nonempty text")
+	}
+
+}

--- a/internal/projection/projections_impl.go
+++ b/internal/projection/projections_impl.go
@@ -15,7 +15,7 @@
 package projection
 
 import (
-	"github.com/hazelcast/hazelcast-go-client/internal/common"
+	"github.com/hazelcast/hazelcast-go-client/internal/precond"
 	"github.com/hazelcast/hazelcast-go-client/serialization"
 )
 
@@ -26,7 +26,7 @@ type SingleAttribute struct {
 }
 
 func NewSingleAttribute(attributePath string) (*SingleAttribute, error) {
-	err := common.CheckHasText(attributePath, "attributePath must not be empty")
+	err := precond.CheckHasText(attributePath, "attributePath must not be empty")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/protocol/map_aggregate.go
+++ b/internal/protocol/map_aggregate.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package protocol
+
+import (
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
+)
+
+func MapAggregateCalculateSize(name string, aggregator *serialization.Data) int {
+	// Calculates the request payload size
+	dataSize := 0
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(aggregator)
+	return dataSize
+}
+
+func MapAggregateEncodeRequest(name string, aggregator *serialization.Data) *ClientMessage {
+	// Encode request into clientMessage
+	clientMessage := NewClientMessage(nil, MapAggregateCalculateSize(name, aggregator))
+	clientMessage.SetMessageType(mapAggregate)
+	clientMessage.IsRetryable = true
+	clientMessage.AppendString(name)
+	clientMessage.AppendData(aggregator)
+	clientMessage.UpdateFrameLength()
+	return clientMessage
+}
+
+func MapAggregateDecodeResponse(clientMessage *ClientMessage) func() (response *serialization.Data) {
+	// Decode response from client message
+	return func() (response *serialization.Data) {
+		if clientMessage.IsComplete() {
+			return
+		}
+
+		if !clientMessage.ReadBool() {
+			response = clientMessage.ReadData()
+		}
+		return
+	}
+}

--- a/internal/protocol/map_aggregatewithpredicate.go
+++ b/internal/protocol/map_aggregatewithpredicate.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package protocol
+
+import (
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
+)
+
+func MapAggregateWithPredicateCalculateSize(name string, aggregator *serialization.Data, predicate *serialization.Data) int {
+	// Calculates the request payload size
+	dataSize := 0
+	dataSize += stringCalculateSize(name)
+	dataSize += dataCalculateSize(aggregator)
+	dataSize += dataCalculateSize(predicate)
+	return dataSize
+}
+
+func MapAggregateWithPredicateEncodeRequest(name string, aggregator *serialization.Data, predicate *serialization.Data) *ClientMessage {
+	// Encode request into clientMessage
+	clientMessage := NewClientMessage(nil, MapAggregateWithPredicateCalculateSize(name, aggregator, predicate))
+	clientMessage.SetMessageType(mapAggregateWithPredicate)
+	clientMessage.IsRetryable = true
+	clientMessage.AppendString(name)
+	clientMessage.AppendData(aggregator)
+	clientMessage.AppendData(predicate)
+	clientMessage.UpdateFrameLength()
+	return clientMessage
+}
+
+func MapAggregateWithPredicateDecodeResponse(clientMessage *ClientMessage) func() (response *serialization.Data) {
+	// Decode response from client message
+	return func() (response *serialization.Data) {
+		if clientMessage.IsComplete() {
+			return
+		}
+
+		if !clientMessage.ReadBool() {
+			response = clientMessage.ReadData()
+		}
+		return
+	}
+}

--- a/internal/serialization/serialization.go
+++ b/internal/serialization/serialization.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/hazelcast/hazelcast-go-client/config"
 	"github.com/hazelcast/hazelcast-go-client/core"
+	"github.com/hazelcast/hazelcast-go-client/internal/aggregation"
 	"github.com/hazelcast/hazelcast-go-client/internal/predicates"
 	"github.com/hazelcast/hazelcast-go-client/internal/projection"
 	"github.com/hazelcast/hazelcast-go-client/serialization"
@@ -278,6 +279,7 @@ func (s *Service) registerIdentifiedFactories() error {
 
 	factories[predicates.FactoryID] = predicates.NewFactory()
 	factories[projection.FactoryID] = projection.NewFactory()
+	factories[aggregation.FactoryID] = aggregation.NewFactory()
 
 	//factories[RELIABLE_TOPIC_MESSAGE_FACTORY_ID] = new ReliableTopicMessageFactory()
 	//factories[CLUSTER_DATA_FACTORY_ID] = new ClusterDataFactory()

--- a/tests/proxy/map/aggregators_test.go
+++ b/tests/proxy/map/aggregators_test.go
@@ -1,0 +1,268 @@
+// Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package _map
+
+import (
+	"testing"
+
+	"reflect"
+
+	"github.com/hazelcast/hazelcast-go-client/core/aggregator"
+	"github.com/hazelcast/hazelcast-go-client/core/predicates"
+	"github.com/hazelcast/hazelcast-go-client/tests/assert"
+)
+
+func testSerializationOfAggregation(t *testing.T, aggregator interface{}) {
+	aggregationData, err := serializationService.ToData(aggregator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	retAggregator, err := serializationService.ToObject(aggregationData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(aggregator, retAggregator.(interface{})) {
+		t.Fatalf("%s is not serialized/deseserialized correctly", reflect.TypeOf(aggregator))
+	}
+}
+
+func TestMapProxy_AggregateNilAggregator(t *testing.T) {
+	defer mp.Clear()
+	_, err := mp.Aggregate(nil)
+	assert.ErrorNotNil(t, err, "Map.Aggreate should return an error for nil aggregator")
+}
+
+func TestMapProxy_AggregateWithPredicateNilAggregator(t *testing.T) {
+	defer mp.Clear()
+	_, err := mp.AggregateWithPredicate(nil,
+		predicates.GreaterEqual("this", 4))
+	assert.ErrorNotNil(t, err, "Map.AggreateWithPredicate should return an error for nil aggregator")
+}
+
+func TestMapProxy_AggregateWithPredicateNilPredicate(t *testing.T) {
+	defer mp.Clear()
+	countAgg, _ := aggregator.Count("this")
+	_, err := mp.AggregateWithPredicate(countAgg, nil)
+	assert.ErrorNotNil(t, err, "Map.AggreateWithPredicate should return an error for nil predicate")
+}
+
+func TestMapProxy_Aggregate_Count(t *testing.T) {
+	defer mp.Clear()
+	expectedCount := 50
+	FillMapWithInt64(expectedCount)
+	countAgg, _ := aggregator.Count("this")
+	result, err := mp.Aggregate(countAgg)
+	assert.Equalf(t, err, result, int64(expectedCount), "Map.Aggregate Count failed")
+	testSerializationOfAggregation(t, countAgg)
+}
+
+func TestMapProxy_Aggregate_CountEmpty(t *testing.T) {
+	_, err := aggregator.Count("")
+	assert.ErrorNotNil(t, err, "aggregator.Count should return an error for empty attributePath")
+}
+
+func TestMapProxy_Aggregate_CountWithPredicate(t *testing.T) {
+	defer mp.Clear()
+	FillMapWithInt64(50)
+	countAgg, _ := aggregator.Count("this")
+	result, err := mp.AggregateWithPredicate(countAgg,
+		predicates.GreaterEqual("this", 1))
+	assert.Equalf(t, err, result, int64(49), "Map.AggregateWithPredicate Count failed")
+}
+
+func TestMapProxy_Aggregate_FixedPointSum(t *testing.T) {
+	defer mp.Clear()
+	FillMapWithInt64(50)
+	fixedPointSumAgg, _ := aggregator.FixedPointSum("this")
+	result, err := mp.Aggregate(fixedPointSumAgg)
+	assert.Equalf(t, err, result, int64(1225), "Map.Aggregate FixedPointSum failed")
+	testSerializationOfAggregation(t, fixedPointSumAgg)
+}
+
+func TestMapProxy_Aggregate_FixedPointSumEmpty(t *testing.T) {
+	_, err := aggregator.FixedPointSum("")
+	assert.ErrorNotNil(t, err, "aggregator.FixedPointSum should return an error for empty attributePath")
+}
+
+func TestMapProxy_Aggregate_FloatingPointSum(t *testing.T) {
+	defer mp.Clear()
+	FillMapWithFloat64(50)
+	floatingPointSumAgg, _ := aggregator.FloatingPointSum("this")
+	result, err := mp.Aggregate(floatingPointSumAgg)
+	assert.Equalf(t, err, result, float64(1225), "Map.Aggregate FloatingPointSum failed")
+	testSerializationOfAggregation(t, floatingPointSumAgg)
+}
+
+func TestMapProxy_Aggregate_FloatingPointSumEmpty(t *testing.T) {
+	_, err := aggregator.FloatingPointSum("")
+	assert.ErrorNotNil(t, err, "aggregator.FloatingPointSum should return an error for empty attributePath")
+}
+
+func TestMapProxy_Aggregate_FloatingPointSumWithPredicate(t *testing.T) {
+	defer mp.Clear()
+	FillMapWithFloat64(50)
+	FloatingPointSumAgg, _ := aggregator.FloatingPointSum("this")
+	result, err := mp.AggregateWithPredicate(FloatingPointSumAgg,
+		predicates.GreaterEqual("this", 47))
+	assert.Equalf(t, err, result, float64(144), "Map.AggregateWithPredicate FloatingPointSum failed")
+}
+
+func TestMapProxy_Aggregate_Max(t *testing.T) {
+	defer mp.Clear()
+	FillMapWithInt64(50)
+	maxAgg, _ := aggregator.Max("this")
+	result, err := mp.Aggregate(maxAgg)
+	assert.Equalf(t, err, result, int64(49), "Map.Aggregate Max failed")
+	testSerializationOfAggregation(t, maxAgg)
+}
+
+func TestMapProxy_Aggregate_MaxEmpty(t *testing.T) {
+	_, err := aggregator.Max("")
+	assert.ErrorNotNil(t, err, "aggregator.Max should return an error for empty attributePath")
+}
+
+func TestMapProxy_Aggregate_MaxWithPredicate(t *testing.T) {
+	defer mp.Clear()
+	FillMapWithInt64(50)
+	maxAgg, _ := aggregator.Max("this")
+	result, err := mp.AggregateWithPredicate(maxAgg,
+		predicates.LessEqual("this", 3))
+	assert.Equalf(t, err, result, int64(3), "Map.AggregateWithPredicate Max failed")
+}
+
+func TestMapProxy_Aggregate_Min(t *testing.T) {
+	defer mp.Clear()
+	FillMapWithInt64(50)
+	minAgg, _ := aggregator.Min("this")
+	result, err := mp.Aggregate(minAgg)
+	assert.Equalf(t, err, result, int64(0), "Map.Aggregate Min failed")
+	testSerializationOfAggregation(t, minAgg)
+}
+
+func TestMapProxy_Aggregate_MinEmpty(t *testing.T) {
+	_, err := aggregator.Min("")
+	assert.ErrorNotNil(t, err, "aggregator.Min should return an error for empty attributePath")
+}
+
+func TestMapProxy_Aggregate_MinWithPredicate(t *testing.T) {
+	defer mp.Clear()
+	FillMapWithInt64(50)
+	minAgg, _ := aggregator.Min("this")
+	result, err := mp.AggregateWithPredicate(minAgg,
+		predicates.GreaterEqual("this", 3))
+	assert.Equalf(t, err, result, int64(3), "Map.AggregateWithPredicate Min failed")
+}
+
+func TestMapProxy_Aggregate_Int64Average(t *testing.T) {
+	defer mp.Clear()
+	FillMapWithInt64(50)
+	int64AvgAgg, _ := aggregator.Int64Average("this")
+	result, err := mp.Aggregate(int64AvgAgg)
+	assert.Equalf(t, err, result, float64(24.5), "Map.Aggregate Int64Average failed")
+	testSerializationOfAggregation(t, int64AvgAgg)
+}
+
+func TestMapProxy_Aggregate_Int64AverageEmpty(t *testing.T) {
+	_, err := aggregator.Count("")
+	assert.ErrorNotNil(t, err, "aggregator.Int64Average should return an error for empty attributePath")
+}
+
+func TestMapProxy_Aggregate_Int64Sum(t *testing.T) {
+	defer mp.Clear()
+	FillMapWithInt64(50)
+	int64SumAgg, _ := aggregator.Int64Sum("this")
+	result, err := mp.Aggregate(int64SumAgg)
+	assert.Equalf(t, err, result, int64(1225), "Map.Aggregate Int64Sum failed")
+	testSerializationOfAggregation(t, int64SumAgg)
+}
+
+func TestMapProxy_Aggregate_Int64SumEmpty(t *testing.T) {
+	_, err := aggregator.Int64Sum("")
+	assert.ErrorNotNil(t, err, "aggregator.Int64Sum should return an error for empty attributePath")
+}
+
+func TestMapProxy_Aggregate_Float64Sum(t *testing.T) {
+	defer mp.Clear()
+	FillMapWithFloat64(50)
+	float64SumAgg, _ := aggregator.Float64Sum("this")
+	result, err := mp.Aggregate(float64SumAgg)
+	assert.Equalf(t, err, result, float64(1225), "Map.Aggregate Float64Sum failed")
+	testSerializationOfAggregation(t, float64SumAgg)
+}
+
+func TestMapProxy_Aggregate_Float64SumEmpty(t *testing.T) {
+	_, err := aggregator.Float64Sum("")
+	assert.ErrorNotNil(t, err, "aggregator.Float64Sum should return an error for empty attributePath")
+}
+
+func TestMapProxy_Aggregate_Int32Average(t *testing.T) {
+	defer mp.Clear()
+	FillMapWithInt32(50)
+	int32AvgAgg, _ := aggregator.Int32Average("this")
+	result, err := mp.Aggregate(int32AvgAgg)
+	assert.Equalf(t, err, result, float64(24.5), "Map.Aggregate Int32Average failed")
+	testSerializationOfAggregation(t, int32AvgAgg)
+}
+
+func TestMapProxy_Aggregate_Int32AverageEmpty(t *testing.T) {
+	_, err := aggregator.Int32Average("")
+	assert.ErrorNotNil(t, err, "aggregator.Int32Average should return an error for empty attributePath")
+}
+
+func TestMapProxy_Aggregate_Int32Sum(t *testing.T) {
+	defer mp.Clear()
+	FillMapWithInt32(50)
+	int32SumAgg, _ := aggregator.Int32Sum("this")
+	result, err := mp.Aggregate(int32SumAgg)
+	assert.Equalf(t, err, result, int64(1225), "Map.Aggregate Int32Sum failed")
+	testSerializationOfAggregation(t, int32SumAgg)
+}
+
+func TestMapProxy_Aggregate_Int32SumEmpty(t *testing.T) {
+	_, err := aggregator.Int32Sum("")
+	assert.ErrorNotNil(t, err, "aggregator.Int32Sum should return an error for empty attributePath")
+}
+
+func TestMapProxy_Aggregate_Float64Average(t *testing.T) {
+	defer mp.Clear()
+	FillMapWithFloat64(50)
+	float64AvgAgg, _ := aggregator.Float64Average("this")
+	result, err := mp.Aggregate(float64AvgAgg)
+	assert.Equalf(t, err, result, float64(24.5), "Map.Aggregate NumberAverage failed")
+	testSerializationOfAggregation(t, float64AvgAgg)
+}
+
+func TestMapProxy_Aggregate_Float64AverageEmpty(t *testing.T) {
+	_, err := aggregator.Float64Average("")
+	assert.ErrorNotNil(t, err, "aggregator.Float64Average should return an error for empty attributePath")
+}
+
+func FillMapWithFloat64(expectedCount int) {
+	for i := 0; i < expectedCount; i++ {
+		mp.Put(float64(i), float64(i))
+	}
+}
+
+func FillMapWithInt64(expectedCount int) {
+	for i := 0; i < expectedCount; i++ {
+		mp.Put(i, i)
+	}
+}
+
+func FillMapWithInt32(expectedCount int) {
+	for i := 0; i < expectedCount; i++ {
+		mp.Put(int32(i), int32(i))
+	}
+}


### PR DESCRIPTION
This PR implements aggregations, it doesnt implement the ones that are not applicable to Go, also the warnings for unused variables for `aggregator_hook.go` is suppressed. 
 
Fixes #205.