### PR TITLE
return proper error when data type is unknown

### DIFF
--- a/internal/serialization/serialization.go
+++ b/internal/serialization/serialization.go
@@ -66,10 +66,14 @@ func (s *Service) ToObject(data *Data) (interface{}, error) {
 	if data == nil {
 		return nil, nil
 	}
-	if data.GetType() == 0 {
+	typeID := data.GetType()
+	if typeID == 0 {
 		return data, nil
 	}
-	var serializer = s.registry[data.GetType()]
+	serializer, ok := s.registry[typeID]
+	if !ok {
+		return nil, core.NewHazelcastSerializationError(fmt.Sprintf("there is no suitable de-serializer for type %d", typeID), nil)
+	}
 	dataInput := NewObjectDataInput(data.Buffer(), DataOffset, s, s.serializationConfig.IsBigEndian())
 	return serializer.Read(dataInput)
 }

--- a/internal/serialization/serialization_test.go
+++ b/internal/serialization/serialization_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/hazelcast/hazelcast-go-client/config"
 	"github.com/hazelcast/hazelcast-go-client/serialization"
+	"github.com/hazelcast/hazelcast-go-client/test/assert"
 )
 
 const (
@@ -284,4 +285,15 @@ func TestSerializeData(t *testing.T) {
 	if !reflect.DeepEqual(data, serializedData) {
 		t.Error("data type should not be serialized")
 	}
+}
+
+func TestUndefinedDataDeserialization(t *testing.T) {
+	s, _ := NewSerializationService(config.NewSerializationConfig())
+	dataOutput := NewPositionalObjectDataOutput(1, s, s.serializationConfig.IsBigEndian())
+	dataOutput.WriteInt32(0) // partition
+	dataOutput.WriteInt32(-100)
+	dataOutput.WriteUTF("Furkan")
+	data := &Data{dataOutput.buffer}
+	_, err := s.ToObject(data)
+	assert.ErrorNotNil(t, err, "err should not be nil")
 }


### PR DESCRIPTION
If a data serialized by an unknown serializer is tried to deserialize on Go side, it causes a panic. This pr fixes it with a proper error message.

fixes #274 