### PR TITLE
implement cloud discovery

### DIFF
--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -21,7 +21,7 @@
     ".*TypePortable should have comment.*",
     ".*LifecycleStateStarting should have comment.*",
     ".*aggregator_hook.go.* is unused*",
-    "address can be fmt.Stringer \\(interfacer\\)"
+    ".*can be fmt.Stringer \\(interfacer\\)"
   ],
   "EnableGC": true,
   "WarnUnmatchedDirective": true,

--- a/config/client_cloud.go
+++ b/config/client_cloud.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+// ClientCloud is used as hazelcast.cloud configuration to let the client connect
+// the cluster via hazelcast.cloud.
+type ClientCloud struct {
+	discoveryToken string
+	enabled        bool
+}
+
+// NewClientCloud returns a clientCloud.
+// ClientCloud is used as hazelcast.cloud configuration to let the client connect
+// the cluster via hazelcast.cloud.
+func NewClientCloud() *ClientCloud {
+	return &ClientCloud{}
+}
+
+// SetDiscoveryToken sets the discovery token as the given token.
+func (cc *ClientCloud) SetDiscoveryToken(discoveryToken string) {
+	cc.discoveryToken = discoveryToken
+}
+
+// DiscoveryToken returns the discovery token.
+func (cc *ClientCloud) DiscoveryToken() string {
+	return cc.discoveryToken
+}
+
+// IsEnabled returns true if client cloud discovery is enabled, false otherwise.
+func (cc *ClientCloud) IsEnabled() bool {
+	return cc.enabled
+}
+
+// SetEnabled sets the enabled field of clientCloud.
+func (cc *ClientCloud) SetEnabled(enabled bool) {
+	cc.enabled = enabled
+}

--- a/config/config.go
+++ b/config/config.go
@@ -333,6 +333,9 @@ type NetworkConfig struct {
 	// executed on the owner.
 	// The cached table is updated every 10 seconds.
 	smartRouting bool
+
+	// cloudConfig is the config for cloud discovery.
+	cloudConfig *ClientCloud
 }
 
 // NewNetworkConfig returns a new NetworkConfig with default configuration.
@@ -344,6 +347,7 @@ func NewNetworkConfig() *NetworkConfig {
 		connectionTimeout:       5 * time.Second,
 		redoOperation:           false,
 		smartRouting:            true,
+		cloudConfig:             NewClientCloud(),
 	}
 }
 
@@ -422,4 +426,14 @@ func (nc *NetworkConfig) SetRedoOperation(redoOperation bool) {
 // Default value is true.
 func (nc *NetworkConfig) SetSmartRouting(smartRouting bool) {
 	nc.smartRouting = smartRouting
+}
+
+// CloudConfig returns the cloud config.
+func (nc *NetworkConfig) CloudConfig() *ClientCloud {
+	return nc.cloudConfig
+}
+
+// SetCloudConfig sets the Cloud Config as the given config.
+func (nc *NetworkConfig) SetCloudConfig(cloudConfig *ClientCloud) {
+	nc.cloudConfig = cloudConfig
 }

--- a/config/property/client_properties.go
+++ b/config/property/client_properties.go
@@ -42,4 +42,7 @@ var (
 	// InvocationRetryPause time is the pause time between each retry cycle of an invocation in milliseconds.
 	InvocationRetryPause = NewHazelcastPropertyInt64WithTimeUnit("hazelcast.client.invocation.retry.pause.millis",
 		1000, time.Millisecond)
+
+	// HazelcastCloudDiscoveryToken is a token to use discovering cluster via hazelcast.cloud.
+	HazelcastCloudDiscoveryToken = NewHazelcastProperty("hazelcast.client.cloud.discovery.token")
 )

--- a/config/property/hazelcast_property.go
+++ b/config/property/hazelcast_property.go
@@ -46,6 +46,13 @@ func NewHazelcastPropertyInt64WithTimeUnit(name string, defaultValue int64, time
 	}
 }
 
+// NewHazelcastProperty returns a Hazelcast property with the given name.
+func NewHazelcastProperty(name string) *HazelcastProperty {
+	return &HazelcastProperty{
+		name: name,
+	}
+}
+
 // NewHazelcastPropertyString returns a Hazelcast property with the given defaultValue.
 func NewHazelcastPropertyString(name string, defaultValue string) *HazelcastProperty {
 	return &HazelcastProperty{

--- a/core/errors.go
+++ b/core/errors.go
@@ -112,6 +112,11 @@ type HazelcastUnsupportedOperationError struct {
 	*HazelcastErrorType
 }
 
+// HazelcastCertificateError is returned when there is an error in certificates.
+type HazelcastCertificateError struct {
+	*HazelcastErrorType
+}
+
 // HazelcastConsistencyLostError is an error that indicates that the consistency guarantees provided by
 // some service has been lost. The exact guarantees depend on the service.
 type HazelcastConsistencyLostError struct {
@@ -196,4 +201,9 @@ func NewHazelcastUnsupportedOperationError(message string, cause error) *Hazelca
 // NewHazelcastConsistencyLostError returns a HazelcastConsistencyLostError.
 func NewHazelcastConsistencyLostError(message string, cause error) *HazelcastConsistencyLostError {
 	return &HazelcastConsistencyLostError{&HazelcastErrorType{message: message, cause: cause}}
+}
+
+// NewHazelcastCertificateError returns a HazelcastCertificateError.
+func NewHazelcastCertificateError(message string, cause error) *HazelcastCertificateError {
+	return &HazelcastCertificateError{&HazelcastErrorType{message: message, cause: cause}}
 }

--- a/internal/address_provider.go
+++ b/internal/address_provider.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"github.com/hazelcast/hazelcast-go-client/config"
+	"github.com/hazelcast/hazelcast-go-client/core"
+)
+
+type AddressProvider interface {
+	LoadAddresses() []core.Address
+}
+
+type defaultAddressProvider struct {
+	networkConfig     *config.NetworkConfig
+	isNoOtherProvider bool
+}
+
+func newDefaultAddressProvider(networkConfig *config.NetworkConfig, isNoOtherProvider bool) *defaultAddressProvider {
+	return &defaultAddressProvider{
+		networkConfig:     networkConfig,
+		isNoOtherProvider: isNoOtherProvider,
+	}
+}
+
+func (dap *defaultAddressProvider) LoadAddresses() []core.Address {
+	addresses := dap.networkConfig.Addresses()
+	possibleAddrs := createAddressFromString(addresses)
+	addrs := make([]core.Address, len(possibleAddrs))
+	for i := 0; i < len(possibleAddrs); i++ {
+		addrs[i] = core.Address(&possibleAddrs[i])
+	}
+	return addrs
+}

--- a/internal/address_translator.go
+++ b/internal/address_translator.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import "github.com/hazelcast/hazelcast-go-client/core"
+
+// AddressTranslator is used to resolve private ip address of cloud services.
+type AddressTranslator interface {
+
+	// Translate translates the given address to another address specific
+	// to network or service
+	Translate(address core.Address) core.Address
+
+	// Refresh refreshes the internal lookup table if necessary.
+	Refresh()
+}
+
+// defaultAddressTranslator is a no-op. It always returns the given address.
+type defaultAddressTranslator struct {
+}
+
+func newDefaultAddressTranslator() *defaultAddressTranslator {
+	return &defaultAddressTranslator{}
+}
+
+func (dat *defaultAddressTranslator) Translate(address core.Address) core.Address {
+	return address
+}
+
+func (dat *defaultAddressTranslator) Refresh() {
+
+}

--- a/internal/cluster_test.go
+++ b/internal/cluster_test.go
@@ -29,13 +29,9 @@ func Test_getPossibleAddresses(t *testing.T) {
 		"132.63.211.12:5010",
 		"12.63.31.12:501",
 	}
-	members := []*proto.Member{
-		proto.NewMember(*proto.NewAddressWithParameters("132.63.211.12", 5012), "", false, nil),
-		proto.NewMember(*proto.NewAddressWithParameters("55.63.211.112", 5011), "", false, nil),
-	}
-	addresses := getPossibleAddresses(configAddresses, members)
-	if len(addresses) != 5 {
-		t.Fatal("getPossibleAddresses failed")
+	addresses := createAddressFromString(configAddresses)
+	if len(addresses) != 4 {
+		t.Fatalf("createAddressFromString failed expected %d got %d", 4, len(addresses))
 	}
 	addressesInMap := make(map[proto.Address]struct{}, len(addresses))
 	for _, address := range addresses {
@@ -44,26 +40,20 @@ func Test_getPossibleAddresses(t *testing.T) {
 	for _, address := range configAddresses {
 		ip, port := iputil.GetIPAndPort(address)
 		if _, found := addressesInMap[*proto.NewAddressWithParameters(ip, port)]; !found {
-			t.Fatal("getPossibleAddresses failed")
-		}
-	}
-	for _, member := range members {
-		if _, found := addressesInMap[*proto.NewAddressWithParameters(member.Address().Host(),
-			int32(member.Address().Port()))]; !found {
-			t.Fatal("getPossibleAddresses failed")
+			t.Fatal("createAddressFromString failed")
 		}
 	}
 }
 
 func Test_getPossibleAddressesWithEmptyParamters(t *testing.T) {
-	addresses := getPossibleAddresses(nil, nil)
+	addresses := createAddressFromString(nil)
 	if len(addresses) != 1 {
-		t.Fatal("getPossibleAddresses failed")
+		t.Fatal("createAddressFromString failed")
 	}
 	defaultAddress := proto.NewAddressWithParameters(defaultAddress, defaultPort)
 	for _, address := range addresses {
 		if address != *defaultAddress {
-			t.Fatal("getPossibleAddresses failed")
+			t.Fatal("createAddressFromString failed")
 		}
 	}
 

--- a/internal/discovery/hazelcast_cloud_discovery.go
+++ b/internal/discovery/hazelcast_cloud_discovery.go
@@ -1,0 +1,137 @@
+// Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package discovery
+
+import (
+	"net/http"
+
+	"encoding/json"
+
+	"io/ioutil"
+
+	"strings"
+
+	"time"
+
+	"github.com/hazelcast/hazelcast-go-client/core"
+	"github.com/hazelcast/hazelcast-go-client/internal/iputil"
+	"github.com/hazelcast/hazelcast-go-client/internal/proto"
+)
+
+const (
+	cloudURL          = "https://coordinator.hazelcast.cloud/cluster/discovery?token="
+	privateAddressStr = "private-address"
+	publicAddressStr  = "public-address"
+)
+
+type nodeDiscoverer func() (map[string]core.Address, error)
+
+type HazelcastCloud struct {
+	endPointURL       string
+	connectionTimeout time.Duration
+	discoverNodes     nodeDiscoverer
+}
+
+func NewHazelcastCloud(cloudToken string, connectionTimeout time.Duration) *HazelcastCloud {
+	hzCloud := &HazelcastCloud{}
+	hzCloud.endPointURL = cloudURL + cloudToken
+	hzCloud.connectionTimeout = connectionTimeout
+	hzCloud.discoverNodes = hzCloud.discoverNodesInternal
+	return hzCloud
+}
+
+func (hzC *HazelcastCloud) discoverNodesInternal() (map[string]core.Address, error) {
+	return hzC.callService()
+}
+
+func (hzC *HazelcastCloud) callService() (map[string]core.Address, error) {
+	url := hzC.endPointURL
+	client := http.Client{
+		Timeout: hzC.connectionTimeout,
+	}
+	resp, err := client.Get(url)
+	// Check certificates
+	if !hzC.checkCertificates(resp) {
+		return nil, core.NewHazelcastCertificateError("invalid certificate from hazelcast.cloud endpoint",
+			nil)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, core.NewHazelcastIOError("got a status :"+resp.Status, nil)
+	}
+
+	return hzC.parseResponse(resp)
+}
+
+func (hzC *HazelcastCloud) checkCertificates(response *http.Response) bool {
+	for _, cert := range response.TLS.PeerCertificates {
+		if !cert.BasicConstraintsValid {
+			return false
+		}
+	}
+	return true
+}
+
+func (hzC *HazelcastCloud) parseResponse(response *http.Response) (map[string]core.Address, error) {
+	// We could have used a struct instead of an interface that has private-address and public-address
+	// fields to decode the JSON response to make things easier, but those fields names are not valid
+	// because of the '-' in them.
+	var target = make([]interface{}, 0)
+	var privateToPublicAddrs = make(map[string]core.Address)
+	resp, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return nil, err
+	}
+	if err = json.Unmarshal(resp, &target); err != nil {
+		return nil, err
+	}
+
+	// Here target is slice of maps
+	for _, elem := range target {
+		if mp, ok := elem.(map[string]interface{}); ok {
+			var privateAddr string
+			var publicAddr string
+			for k, v := range mp {
+				if strings.Compare(k, privateAddressStr) == 0 {
+					if res, ok := v.(string); ok {
+						privateAddr = res
+					}
+				}
+				if strings.Compare(k, publicAddressStr) == 0 {
+					if res, ok := v.(string); ok {
+						publicAddr = res
+					}
+				}
+			}
+			publicAddress := hzC.createAddress(publicAddr)
+
+			// TODO:: what if privateAddress is not okay ?
+			// TODO:: use addressProvider
+			privateAddress := proto.NewAddressWithParameters(privateAddr, int32(publicAddress.Port()))
+			privateToPublicAddrs[privateAddress.String()] = publicAddress
+		}
+	}
+
+	return privateToPublicAddrs, nil
+}
+
+func (hzC *HazelcastCloud) createAddress(hostname string) core.Address {
+	ip, port := iputil.GetIPAndPort(hostname)
+	addr := proto.NewAddressWithParameters(ip, port)
+	return addr
+}

--- a/internal/discovery/hz_cloud_addr_provider.go
+++ b/internal/discovery/hz_cloud_addr_provider.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package discovery
+
+import (
+	"log"
+
+	"time"
+
+	"github.com/hazelcast/hazelcast-go-client/core"
+	"github.com/hazelcast/hazelcast-go-client/internal/iputil"
+	"github.com/hazelcast/hazelcast-go-client/internal/proto"
+)
+
+// HzCloudAddrProvider provides initial addresses for hazelcast.cloud
+type HzCloudAddrProvider struct {
+	cloudDiscovery *HazelcastCloud
+}
+
+// NewHzCloudAddrProvider returns a HzCloudAddrProvider with the given parameters.
+func NewHzCloudAddrProvider(cloudToken string, connectionTimeout time.Duration) *HzCloudAddrProvider {
+	return NewHzCloudAddrProviderWithCloudDisc(
+		NewHazelcastCloud(
+			cloudToken,
+			connectionTimeout,
+		),
+	)
+}
+
+// NewHzCloudAddrProviderWithCloudDisc returns a HzCloudAddrProvider with the given parameters.
+func NewHzCloudAddrProviderWithCloudDisc(cloudDisc *HazelcastCloud) *HzCloudAddrProvider {
+	return &HzCloudAddrProvider{
+		cloudDiscovery: cloudDisc,
+	}
+}
+
+// LoadAddresses returns a slice of addresses.
+func (ap *HzCloudAddrProvider) LoadAddresses() []core.Address {
+	privateToPublicAddrs, err := ap.cloudDiscovery.discoverNodes()
+	if err != nil {
+		log.Println("Failed to load addresses from hazelcast.cloud ", err)
+	}
+	addrSlice := make([]core.Address, 0)
+	// Appends private keys
+	for address := range privateToPublicAddrs {
+		ip, port := iputil.GetIPAndPort(address)
+		addrSlice = append(addrSlice, proto.NewAddressWithParameters(ip, port))
+	}
+	return addrSlice
+}

--- a/internal/discovery/hz_cloud_addr_provider_test.go
+++ b/internal/discovery/hz_cloud_addr_provider_test.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package discovery
+
+import (
+	"testing"
+
+	"errors"
+
+	"github.com/hazelcast/hazelcast-go-client/core"
+	"github.com/hazelcast/hazelcast-go-client/internal/proto"
+	"github.com/hazelcast/hazelcast-go-client/test/assert"
+)
+
+var expectedAddresses map[string]core.Address
+var provider *HzCloudAddrProvider
+var provider2 *HzCloudAddrProvider
+
+func TestHzCloudAddrProvider(t *testing.T) {
+	expectedAddresses = make(map[string]core.Address)
+	expectedAddresses["10.0.0.1:5701"] = proto.NewAddressWithParameters("198.51.100.1", 5701)
+	expectedAddresses["10.0.0.1:5702"] = proto.NewAddressWithParameters("198.51.100.1", 5702)
+	expectedAddresses["10.0.0.2:5701"] = proto.NewAddressWithParameters("198.51.100.2", 5701)
+	var mockProvider = func() (map[string]core.Address, error) {
+		return expectedAddresses, nil
+	}
+
+	hazelcastCloudDiscovery := NewHazelcastCloud("", 0)
+	hazelcastCloudDiscovery.discoverNodes = mockProvider // mock the discoverNode function
+
+	provider = NewHzCloudAddrProvider("", 0)
+	provider.cloudDiscovery = hazelcastCloudDiscovery
+	provider2 = NewHzCloudAddrProviderWithCloudDisc(hazelcastCloudDiscovery)
+	testHzCloudAddrProviderLoadAddresses(t)
+	testHzCloudAddrProviderLoadAddressesNone(t)
+}
+
+func testHzCloudAddrProviderLoadAddresses(t *testing.T) {
+	addresses := provider.LoadAddresses()
+	assert.Equal(t, nil, 3, len(addresses))
+	for key := range expectedAddresses {
+		found := false
+		for _, addr := range addresses {
+			if addr.String() == key {
+				found = true
+			}
+		}
+		assert.Equal(t, nil, true, found)
+	}
+}
+
+func testHzCloudAddrProviderLoadAddressesNone(t *testing.T) {
+	var mockProvider2 = func() (map[string]core.Address, error) {
+		return nil, errors.New("error")
+	}
+	provider2.cloudDiscovery.discoverNodes = mockProvider2
+	addresses := provider2.LoadAddresses()
+	assert.Equal(t, nil, 0, len(addresses))
+}

--- a/internal/discovery/hz_cloud_addr_translator.go
+++ b/internal/discovery/hz_cloud_addr_translator.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package discovery
+
+import (
+	"log"
+
+	"time"
+
+	"github.com/hazelcast/hazelcast-go-client/core"
+)
+
+// HzCloudAddrTranslator is used to translate private addresses to public addresses.
+type HzCloudAddrTranslator struct {
+	cloudDiscovery  *HazelcastCloud
+	privateToPublic map[string]core.Address
+}
+
+// NewHzCloudAddrTranslator returns a HzCloudAddrTranslator with the given parameters.
+func NewHzCloudAddrTranslator(cloudToken string, connectionTimeout time.Duration) *HzCloudAddrTranslator {
+	return NewHzCloudAddrTranslatorWithCloudDisc(
+		NewHazelcastCloud(
+			cloudToken,
+			connectionTimeout,
+		),
+	)
+}
+
+// NewHzCloudAddrTranslatorWithCloudDisc returns a HzCloudAddrTranslator with the given parameters.
+func NewHzCloudAddrTranslatorWithCloudDisc(cloudDisc *HazelcastCloud) *HzCloudAddrTranslator {
+	return &HzCloudAddrTranslator{
+		cloudDiscovery: cloudDisc,
+	}
+}
+
+// Translate translates the given addr to its public address.
+func (at *HzCloudAddrTranslator) Translate(addr core.Address) core.Address {
+	if addr == nil {
+		return nil
+	}
+
+	if publicAddr, found := at.privateToPublic[addr.String()]; found {
+		return publicAddr
+	}
+
+	at.Refresh()
+
+	if publicAddr, found := at.privateToPublic[addr.String()]; found {
+		return publicAddr
+	}
+
+	return nil
+}
+
+// Refresh refreshes the internal lookup table.
+func (at *HzCloudAddrTranslator) Refresh() {
+	privateToPublic, err := at.cloudDiscovery.discoverNodes()
+	if err != nil {
+		log.Println("Failed to load addresses from hazelcast.cloud ", err)
+	} else {
+		at.privateToPublic = privateToPublic
+	}
+}

--- a/internal/discovery/hz_cloud_addr_translator_test.go
+++ b/internal/discovery/hz_cloud_addr_translator_test.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package discovery
+
+import (
+	"testing"
+
+	"github.com/hazelcast/hazelcast-go-client/core"
+	"github.com/hazelcast/hazelcast-go-client/internal/proto"
+	"github.com/hazelcast/hazelcast-go-client/test/assert"
+)
+
+var lookup map[string]core.Address
+var privateAddress core.Address
+var publicAddress core.Address
+var translator *HzCloudAddrTranslator
+
+func TestHzCloudAddrTranslator_Translate(t *testing.T) {
+	lookup = make(map[string]core.Address)
+	privateAddress = proto.NewAddressWithParameters("127.0.0.1", 5701)
+	publicAddress = proto.NewAddressWithParameters("192.168.0.1", 5701)
+	lookup[privateAddress.String()] = publicAddress
+	lookup["127.0.0.2:5701"] = proto.NewAddressWithParameters("192.168.0.2", 5701)
+	var mockProvider = func() (map[string]core.Address, error) {
+		return lookup, nil
+	}
+
+	hazelcastCloudDiscovery := NewHazelcastCloud("", 0)
+	hazelcastCloudDiscovery.discoverNodes = mockProvider // mock the discoverNode function
+
+	translator = NewHzCloudAddrTranslator("", 0)
+	translator.cloudDiscovery = hazelcastCloudDiscovery
+
+	testHzCloudAddrTranslatorTranslateNil(t)
+	testHzCloudAddrTranslatorTranslatePrivateToPublic(t)
+	testHzCloudAddrTranslatorTranslateWhenNotFoundReturnNil(t)
+	testHzCloudAddrTranslatorTranslateAfterRefresh(t)
+
+}
+
+func testHzCloudAddrTranslatorTranslateNil(t *testing.T) {
+	if actual := translator.Translate(nil); actual != nil {
+		t.Error("hzCloudAddrTranslator.Translate() should return nil for nil address.")
+	}
+}
+
+func testHzCloudAddrTranslatorTranslatePrivateToPublic(t *testing.T) {
+	actual := translator.Translate(privateAddress)
+	assert.Equal(t, nil, publicAddress.Host(), actual.Host())
+	assert.Equal(t, nil, privateAddress.Port(), actual.Port())
+}
+
+func testHzCloudAddrTranslatorTranslateWhenNotFoundReturnNil(t *testing.T) {
+	notAvailableAddr := proto.NewAddressWithParameters("127.0.0.3", 5701)
+
+	if actual := translator.Translate(notAvailableAddr); actual != nil {
+		t.Error("hzCloudAddTranslator.Translate() should return nil for not found address.")
+	}
+
+}
+
+func testHzCloudAddrTranslatorTranslateAfterRefresh(t *testing.T) {
+	translator.Refresh()
+	actual := translator.Translate(privateAddress)
+
+	assert.Equal(t, nil, publicAddress.Host(), actual.Host())
+	assert.Equal(t, nil, privateAddress.Port(), actual.Port())
+
+}

--- a/test/discovery/cloud_config_test.go
+++ b/test/discovery/cloud_config_test.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package discovery
+
+import (
+	"testing"
+
+	"os"
+
+	"github.com/hazelcast/hazelcast-go-client"
+	"github.com/hazelcast/hazelcast-go-client/config"
+	"github.com/hazelcast/hazelcast-go-client/core"
+	"github.com/hazelcast/hazelcast-go-client/test/assert"
+)
+
+var testDiscoveryToken = "testDiscoveryToken"
+
+func TestCloudConfigDefaults(t *testing.T) {
+	cfg := hazelcast.NewConfig()
+	cloudConfig := cfg.NetworkConfig().CloudConfig()
+	assert.Equalf(t, nil, false, cloudConfig.IsEnabled(), "Default cloud config should be disabled.")
+	assert.Equalf(t, nil, "", cloudConfig.DiscoveryToken(), "Default cloud config discovery token"+
+		" should be empty.")
+}
+
+func TestCloudConfig(t *testing.T) {
+	cfg := hazelcast.NewConfig()
+	cloudConfig := config.NewClientCloud()
+	cloudConfig.SetEnabled(true)
+	cloudConfig.SetDiscoveryToken(testDiscoveryToken)
+	cfg.NetworkConfig().SetCloudConfig(cloudConfig)
+	returnedCloudCfg := cfg.NetworkConfig().CloudConfig()
+	assert.Equalf(t, nil, true, returnedCloudCfg.IsEnabled(), "Cloud discovery should be enabled.")
+	assert.Equalf(t, nil, testDiscoveryToken, returnedCloudCfg.DiscoveryToken(), "Cloud discovery token "+
+		"should be set.")
+}
+
+func TestCloudConfigWithPropertySet(t *testing.T) {
+	cloudConfig := config.NewClientCloud()
+	cloudConfig.SetEnabled(true)
+	os.Setenv("hazelcast.client.cloud.discovery.token", testDiscoveryToken)
+	cfg := hazelcast.NewConfig()
+	cfg.NetworkConfig().SetCloudConfig(cloudConfig)
+	_, err := hazelcast.NewClientWithConfig(cfg)
+	if _, ok := err.(*core.HazelcastIllegalStateError); !ok {
+		t.Error("Cloud discovery should have returned an error for both property and client configuration based" +
+			" setup")
+	}
+}


### PR DESCRIPTION
This pr implements hazelcast cloud discovery with tests. fixes #276.

Address provider and translators are added for better modularity. fixes #278.

Currently the only way to enable cloud discovery is through programmatic configuration, it should be extended further after the implementation of `hazelcastProperty`. 

