### PR TITLE
add hazelcast property

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -24,10 +24,11 @@ import (
 )
 
 const (
-	defaultGroupName         = "dev"
-	defaultGroupPassword     = "dev-pass"
-	defaultInvocationTimeout = 120 * time.Second
+	defaultGroupName     = "dev"
+	defaultGroupPassword = "dev-pass"
 )
+
+type Properties map[string]string
 
 // Config is the main configuration to setup a Hazelcast client.
 type Config struct {
@@ -46,14 +47,10 @@ type Config struct {
 	// serializationConfig is the serialization configuration of the client.
 	serializationConfig *SerializationConfig
 
-	// heartbeatTimeout is the timeout value for heartbeat.
-	heartbeatTimeout time.Duration
-
-	// heartbeatInterval is heartbeat internal.
-	heartbeatInterval time.Duration
-
 	// flakeIDGeneratorConfigMap is mapping of names to flakeIDGeneratorConfigs.
 	flakeIDGeneratorConfigMap map[string]*FlakeIDGeneratorConfig
+
+	properties Properties
 }
 
 // New returns a new Config with default configuration.
@@ -64,6 +61,7 @@ func New() *Config {
 		serializationConfig:       NewSerializationConfig(),
 		lifecycleListeners:        make([]interface{}, 0),
 		flakeIDGeneratorConfigMap: make(map[string]*FlakeIDGeneratorConfig),
+		properties:                make(Properties),
 	}
 }
 
@@ -92,26 +90,14 @@ func (cc *Config) SerializationConfig() *SerializationConfig {
 	return cc.serializationConfig
 }
 
-// SetHeartbeatTimeout sets the heartbeat timeout value to given timeout value.
-func (cc *Config) SetHeartbeatTimeout(heartbeatTimeout time.Duration) *Config {
-	cc.heartbeatTimeout = heartbeatTimeout
-	return cc
+// SetProperty sets a new pair of property as (name, value).
+func (cc *Config) SetProperty(name string, value string) {
+	cc.properties[name] = value
 }
 
-// HeartbeatTimeout returns heartbeat timeout
-func (cc *Config) HeartbeatTimeout() time.Duration {
-	return cc.heartbeatTimeout
-}
-
-// SetHeartbeatInterval sets the heartbeat timeout value to given interval value.
-func (cc *Config) SetHeartbeatInterval(heartbeatInterval time.Duration) *Config {
-	cc.heartbeatInterval = heartbeatInterval
-	return cc
-}
-
-// HeartbeatInterval returns heartbeat interval.
-func (cc *Config) HeartbeatInterval() time.Duration {
-	return cc.heartbeatInterval
+// Properties returns the properties of the config.
+func (cc *Config) Properties() Properties {
+	return cc.properties
 }
 
 // GetFlakeIDGeneratorConfig returns the FlakeIDGeneratorConfig for the given name, creating one
@@ -347,9 +333,6 @@ type NetworkConfig struct {
 	// executed on the owner.
 	// The cached table is updated every 10 seconds.
 	smartRouting bool
-
-	// invocationTimeout is the invocation timeout for sending invocation.
-	invocationTimeout time.Duration
 }
 
 // NewNetworkConfig returns a new NetworkConfig with default configuration.
@@ -361,7 +344,6 @@ func NewNetworkConfig() *NetworkConfig {
 		connectionTimeout:       5 * time.Second,
 		redoOperation:           false,
 		smartRouting:            true,
-		invocationTimeout:       defaultInvocationTimeout,
 	}
 }
 
@@ -393,11 +375,6 @@ func (nc *NetworkConfig) IsRedoOperation() bool {
 // IsSmartRouting returns true if client is smart.
 func (nc *NetworkConfig) IsSmartRouting() bool {
 	return nc.smartRouting
-}
-
-// InvocationTimeout returns the invocation timeout
-func (nc *NetworkConfig) InvocationTimeout() time.Duration {
-	return nc.invocationTimeout
 }
 
 // AddAddress adds given addresses to candidate address list that client will use to establish initial connection.
@@ -445,9 +422,4 @@ func (nc *NetworkConfig) SetRedoOperation(redoOperation bool) {
 // Default value is true.
 func (nc *NetworkConfig) SetSmartRouting(smartRouting bool) {
 	nc.smartRouting = smartRouting
-}
-
-// SetInvocationTimeout sets the invocation timeout for sending invocation.
-func (nc *NetworkConfig) SetInvocationTimeout(invocationTimeout time.Duration) {
-	nc.invocationTimeout = invocationTimeout
 }

--- a/config/property/client_properties.go
+++ b/config/property/client_properties.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package property
+
+import "time"
+
+var (
+
+	// HeartbeatTimeout is the duration for client sending heartbeat messages to the members.
+	// If there is not any message passing between the client and member within the given time via this property,
+	// the connection will be closed.
+	HeartbeatTimeout = NewHazelcastPropertyInt64WithTimeUnit("hazelcast.client.heartbeat.timeout", 60000,
+		time.Millisecond)
+
+	// HeartbeatInterval is the time interval between the heartbeats sent by the client to the nodes.
+	HeartbeatInterval = NewHazelcastPropertyInt64WithTimeUnit("hazelcast.client.heartbeat.interval", 5000,
+		time.Millisecond)
+
+	// InvocationTimeoutSeconds is used when an invocation gets an error because :
+	//  * Member throws an exception.
+	//  * Connection between the client and member is closed.
+	//  * Client's heartbeat requests are timed out.
+	// Time passed since invocation started is compared with this property.
+	// If the time is already passed, then the error is delegated to the user. If not, the invocation is retried.
+	// Note that, if invocation gets no error and it is a long running one, then it will not get any error,
+	// no matter how small this timeout is set.
+	InvocationTimeoutSeconds = NewHazelcastPropertyInt64WithTimeUnit("hazelcast.client.invocation.timeout.seconds",
+		120, time.Second)
+
+	// InvocationRetryPause time is the pause time between each retry cycle of an invocation in milliseconds.
+	InvocationRetryPause = NewHazelcastPropertyInt64WithTimeUnit("hazelcast.client.invocation.retry.pause.millis",
+		1000, time.Millisecond)
+)

--- a/config/property/hazelcast_properties.go
+++ b/config/property/hazelcast_properties.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package property
+
+import (
+	"os"
+
+	"strings"
+
+	"time"
+
+	"strconv"
+
+	"fmt"
+
+	"github.com/hazelcast/hazelcast-go-client/config"
+)
+
+// HazelcastProperties is a container for configured Hazelcast properties.
+// A Hazelcast property can be set via:
+//  * an environmental variable
+//  * programmatic configuration Config.SetProperty
+type HazelcastProperties struct {
+	properties config.Properties
+}
+
+// NewHazelcastProperties returns HazelcastProperties with the given properties.
+func NewHazelcastProperties(properties config.Properties) *HazelcastProperties {
+	hp := &HazelcastProperties{}
+	hp.properties = make(config.Properties)
+	if properties != nil {
+		hp.properties = properties
+	}
+	return hp
+}
+
+// GetString returns the value for the given property.
+// It first checks config, then environment variables, and lastly
+// if it is not found in those it returns the default value.
+func (hp *HazelcastProperties) GetString(property *HazelcastProperty) string {
+	// First check if property exists in config
+	if prop, found := hp.properties[property.Name()]; found {
+		return prop
+	}
+	// Check if exists in environment variables
+	if prop, found := os.LookupEnv(property.Name()); found {
+		return prop
+	}
+	return property.DefaultValue()
+
+}
+
+// GetBoolean returns the boolean value of the given property.
+// It returns true if the value is equal to "true" (case-insensitive).
+func (hp *HazelcastProperties) GetBoolean(property *HazelcastProperty) bool {
+	str := hp.GetString(property)
+	return strings.Compare(strings.ToLower(str), "true") == 0
+}
+
+// GetDuration returns the time duration from the given property.
+// It returns the default value if the set time duration cannot be parsed.
+// It panics if the set and default values cannot be parsed to time.Duration.
+func (hp *HazelcastProperties) GetDuration(property *HazelcastProperty) time.Duration {
+	str := hp.GetString(property)
+	if _, err := strconv.Atoi(str); err != nil {
+		str = property.DefaultValue()
+		if _, err = strconv.Atoi(str); err != nil {
+			panic(fmt.Sprintf("%s cannot be parsed to int", str))
+		}
+	}
+	// If we come to this line, there cannot be any error during conversion of str
+	coeff, _ := strconv.Atoi(str)
+	duration := time.Duration(coeff) * property.TimeUnit()
+	return duration
+}
+
+// GetPositiveDuration returns the time duration as GetDuration except it returns the default value
+// if the set time duration is a non-positive value.
+func (hp *HazelcastProperties) GetPositiveDuration(property *HazelcastProperty) time.Duration {
+	duration := hp.GetDuration(property)
+	if duration <= 0 {
+		defaultValInt, _ := strconv.Atoi(property.DefaultValue())
+		duration = time.Duration(defaultValInt) * property.TimeUnit()
+	}
+	return duration
+}

--- a/config/property/hazelcast_properties_test.go
+++ b/config/property/hazelcast_properties_test.go
@@ -1,0 +1,162 @@
+// Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package property
+
+import (
+	"testing"
+
+	"os"
+
+	"time"
+
+	"github.com/hazelcast/hazelcast-go-client/config"
+)
+
+func TestHazelcastProperties_GetStringWithConfig(t *testing.T) {
+	cfg := config.New()
+
+	property := NewHazelcastPropertyString("testName", "testDefaultValue")
+
+	cfg.SetProperty("testName", "testValue")
+
+	properties := NewHazelcastProperties(cfg.Properties())
+
+	if value := properties.GetString(property); value != "testValue" {
+		t.Errorf("expected %s got %s", "testValue", value)
+	}
+
+}
+
+func TestHazelcastProperties_GetStringWithDefaultValue(t *testing.T) {
+	cfg := config.New()
+	expected := "testDefaultValue"
+	property := NewHazelcastPropertyString("testName", expected)
+
+	properties := NewHazelcastProperties(cfg.Properties())
+
+	if value := properties.GetString(property); value != expected {
+		t.Errorf("expected %s got %s", expected, value)
+	}
+
+}
+
+func TestHazelcastProperties_GetStringWithEnvironmentVariable(t *testing.T) {
+	cfg := config.New()
+
+	expected := "testValue"
+	property := NewHazelcastPropertyString("testName", "testDefaultValue")
+
+	os.Setenv("testName", expected)
+	properties := NewHazelcastProperties(cfg.Properties())
+
+	if value := properties.GetString(property); value != expected {
+		t.Errorf("expected %s got %s", expected, value)
+	}
+
+}
+
+func TestHazelcastProperties_GetStringConfigAndEnvironmentBothSet(t *testing.T) {
+	cfg := config.New()
+
+	expected := "testValue"
+	name := "testName"
+	property := NewHazelcastPropertyString(name, "testDefaultValue")
+
+	os.Setenv(name, "testEnvVal")
+
+	cfg.SetProperty(name, expected)
+	properties := NewHazelcastProperties(cfg.Properties())
+
+	if value := properties.GetString(property); value != expected {
+		t.Errorf("expected %s got %s", expected, value)
+	}
+
+}
+
+func TestHazelcastProperties_GetBoolean(t *testing.T) {
+	name := "testBoolName"
+
+	property := NewHazelcastPropertyBool(name, true)
+	properties := NewHazelcastProperties(nil)
+
+	if value := properties.GetBoolean(property); !value {
+		t.Errorf("expected true for %s", name)
+	}
+
+	cfg := config.New()
+	cfg.SetProperty(name, "false")
+
+	properties = NewHazelcastProperties(cfg.Properties())
+	if value := properties.GetBoolean(property); value {
+		t.Errorf("expected false for %s", name)
+	}
+
+}
+
+func TestHazelcastProperties_GetDuration(t *testing.T) {
+	name := "testDuration"
+	coeff := int64(5)
+	timeUnit := time.Second
+	duration := time.Duration(coeff) * timeUnit
+
+	property := NewHazelcastPropertyInt64WithTimeUnit(name, coeff, timeUnit)
+	properties := NewHazelcastProperties(nil)
+
+	if value := properties.GetDuration(property); value != duration {
+		t.Errorf("expected %s got %s", duration, value)
+	}
+
+}
+
+func TestHazelcastProperties_GetDurationFromEnv(t *testing.T) {
+	name := "testDuration"
+	timeUnit := time.Millisecond
+	os.Setenv(name, "300")
+	property := NewHazelcastPropertyInt64WithTimeUnit(name, 500, timeUnit)
+	properties := NewHazelcastProperties(nil)
+	expected := time.Duration(300) * timeUnit
+	if value := properties.GetDuration(property); value != expected {
+		t.Errorf("expected %s got %s", expected, value)
+	}
+
+}
+
+func TestHazelcastProperties_GetDurationFromEnvWhenIncorrectFormat(t *testing.T) {
+	name := "testDuration"
+	coeff := int64(5)
+	timeUnit := time.Second
+	duration := time.Duration(coeff) * timeUnit
+
+	os.Setenv(name, "AAA300")
+	property := NewHazelcastPropertyInt64WithTimeUnit(name, coeff, timeUnit)
+	properties := NewHazelcastProperties(nil)
+	if value := properties.GetDuration(property); value != duration {
+		t.Errorf("expected %s got %s", duration, value)
+	}
+}
+
+func TestHazelcastProperties_GetPositiveDurationFromEnv(t *testing.T) {
+	name := "testDuration"
+	coeff := int64(5)
+	timeUnit := time.Second
+	duration := time.Duration(coeff) * timeUnit
+	os.Setenv(name, "-300")
+	property := NewHazelcastPropertyInt64WithTimeUnit(name, coeff, timeUnit)
+	properties := NewHazelcastProperties(nil)
+	if value := properties.GetPositiveDuration(property); value != duration {
+		t.Errorf("expected %s got %s", duration, value)
+	}
+
+}

--- a/config/property/hazelcast_property.go
+++ b/config/property/hazelcast_property.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package property
+
+import (
+	"strconv"
+	"time"
+)
+
+// HazelcastProperty is a struct for client properties.
+type HazelcastProperty struct {
+	name         string
+	defaultValue string
+	timeUnit     time.Duration
+}
+
+// NewHazelcastPropertyBool returns a Hazelcast property with the given defaultValue.
+func NewHazelcastPropertyBool(name string, defaultValue bool) *HazelcastProperty {
+	h := &HazelcastProperty{}
+	h.name = name
+	if defaultValue {
+		h.defaultValue = "true"
+	} else {
+		h.defaultValue = "false"
+	}
+	return h
+}
+
+func NewHazelcastPropertyInt64WithTimeUnit(name string, defaultValue int64, timeUnit time.Duration) *HazelcastProperty {
+	return &HazelcastProperty{
+		name:         name,
+		defaultValue: strconv.Itoa(int(defaultValue)),
+		timeUnit:     timeUnit,
+	}
+}
+
+// NewHazelcastPropertyString returns a Hazelcast property with the given defaultValue.
+func NewHazelcastPropertyString(name string, defaultValue string) *HazelcastProperty {
+	return &HazelcastProperty{
+		name:         name,
+		defaultValue: defaultValue,
+	}
+}
+
+// Name returns the name of this Hazelcast property.
+func (h *HazelcastProperty) Name() string {
+	return h.name
+}
+
+// SetName sets the name of this Hazelcast property as the given name.
+func (h *HazelcastProperty) SetName(name string) {
+	h.name = name
+}
+
+func (h *HazelcastProperty) String() string {
+	return h.Name()
+}
+
+// TimeUnit returns the time unit for this property.
+func (h *HazelcastProperty) TimeUnit() time.Duration {
+	return h.timeUnit
+}
+
+// DefaultValue returns the default value of this Hazelcast property.
+func (h *HazelcastProperty) DefaultValue() string {
+	return h.defaultValue
+}

--- a/internal/client.go
+++ b/internal/client.go
@@ -16,6 +16,7 @@ package internal
 
 import (
 	"github.com/hazelcast/hazelcast-go-client/config"
+	"github.com/hazelcast/hazelcast-go-client/config/property"
 	"github.com/hazelcast/hazelcast-go-client/core"
 	"github.com/hazelcast/hazelcast-go-client/internal/proto/bufutil"
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
@@ -33,10 +34,12 @@ type HazelcastClient struct {
 	ProxyManager         *proxyManager
 	LoadBalancer         *randomLoadBalancer
 	HeartBeatService     *heartBeatService
+	properties           *property.HazelcastProperties
 }
 
 func NewHazelcastClient(config *config.Config) (*HazelcastClient, error) {
 	client := HazelcastClient{ClientConfig: config}
+	client.properties = property.NewHazelcastProperties(config.Properties())
 	err := client.init()
 	return &client, err
 }

--- a/internal/heartbeat.go
+++ b/internal/heartbeat.go
@@ -20,12 +20,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/hazelcast/hazelcast-go-client/config/property"
 	"github.com/hazelcast/hazelcast-go-client/internal/proto"
-)
-
-const (
-	defaultHeartBeatInterval = 10 * time.Second
-	defaultHeartBeatTimeout  = 60 * time.Second
 )
 
 type heartBeatService struct {
@@ -38,16 +34,12 @@ type heartBeatService struct {
 }
 
 func newHeartBeatService(client *HazelcastClient) *heartBeatService {
-	heartBeat := heartBeatService{client: client, heartBeatInterval: defaultHeartBeatInterval,
-		heartBeatTimeout: defaultHeartBeatTimeout,
-		cancel:           make(chan struct{}),
+	heartBeat := heartBeatService{client: client,
+		heartBeatInterval: client.properties.GetPositiveDuration(property.HeartbeatInterval),
+		heartBeatTimeout:  client.properties.GetPositiveDuration(property.HeartbeatTimeout),
+		cancel:            make(chan struct{}),
 	}
-	if client.ClientConfig.HeartbeatTimeout() > 0 {
-		heartBeat.heartBeatTimeout = client.ClientConfig.HeartbeatTimeout()
-	}
-	if client.ClientConfig.HeartbeatInterval() > 0 {
-		heartBeat.heartBeatInterval = client.ClientConfig.HeartbeatInterval()
-	}
+
 	heartBeat.listeners.Store(make([]interface{}, 0)) //initialize
 	return &heartBeat
 }

--- a/internal/invocation.go
+++ b/internal/invocation.go
@@ -22,13 +22,12 @@ import (
 
 	"sync"
 
+	"github.com/hazelcast/hazelcast-go-client/config/property"
 	"github.com/hazelcast/hazelcast-go-client/core"
 	"github.com/hazelcast/hazelcast-go-client/internal/proto"
 	"github.com/hazelcast/hazelcast-go-client/internal/proto/bufutil"
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 )
-
-const RetryWaitTime = 1 * time.Second
 
 type invocation struct {
 	request         atomic.Value
@@ -49,13 +48,14 @@ type invocationResult interface {
 
 func newInvocation(request *proto.ClientMessage, partitionID int32, address core.Address,
 	connection *Connection, client *HazelcastClient) *invocation {
+	invocationTimeout := client.properties.GetPositiveDuration(property.InvocationTimeoutSeconds)
 	invocation := &invocation{
 		partitionID:     partitionID,
 		address:         address,
 		boundConnection: connection,
 		response:        make(chan interface{}, 1),
 		isComplete:      0,
-		deadline:        time.Now().Add(client.ClientConfig.NetworkConfig().InvocationTimeout()),
+		deadline:        time.Now().Add(invocationTimeout),
 	}
 	invocation.request.Store(request)
 	return invocation
@@ -405,8 +405,9 @@ func (is *invocationServiceImpl) handleError(invocation *invocation, err error) 
 		invocation.complete(core.NewHazelcastTimeoutError("invocation timed out by"+timeSinceDeadline.String(), nil))
 		return
 	}
+	retryPauseTime := is.client.properties.GetPositiveDuration(property.InvocationRetryPause)
 	if is.shouldRetryInvocation(invocation, err) {
-		time.AfterFunc(RetryWaitTime, func() {
+		time.AfterFunc(retryPauseTime, func() {
 			is.retryInvocation(invocation, err)
 		})
 		return

--- a/internal/listener.go
+++ b/internal/listener.go
@@ -18,6 +18,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hazelcast/hazelcast-go-client/config/property"
 	"github.com/hazelcast/hazelcast-go-client/core"
 	"github.com/hazelcast/hazelcast-go-client/internal/iputil"
 	"github.com/hazelcast/hazelcast-go-client/internal/proto"
@@ -326,7 +327,7 @@ func (ls *listenerService) trySyncConnectToAllConnections() error {
 	if !ls.client.ClientConfig.NetworkConfig().IsSmartRouting() {
 		return nil
 	}
-	remainingTime := ls.client.ClientConfig.NetworkConfig().InvocationTimeout()
+	remainingTime := ls.client.properties.GetPositiveDuration(property.InvocationTimeoutSeconds)
 	for ls.client.LifecycleService.isLive.Load().(bool) && remainingTime > 0 {
 		members := ls.client.GetCluster().GetMembers()
 		start := time.Now()

--- a/test/heartbeat_test.go
+++ b/test/heartbeat_test.go
@@ -17,9 +17,9 @@ package test
 import (
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/hazelcast/hazelcast-go-client"
+	"github.com/hazelcast/hazelcast-go-client/config/property"
 	"github.com/hazelcast/hazelcast-go-client/internal"
 	"github.com/hazelcast/hazelcast-go-client/test/assert"
 )
@@ -44,8 +44,8 @@ func TestHeartbeatStoppedForConnection(t *testing.T) {
 	member, _ := remoteController.StartMember(cluster.ID)
 	config := hazelcast.NewConfig()
 	config.NetworkConfig().SetConnectionAttemptLimit(100)
-	config.SetHeartbeatInterval(3 * time.Second)
-	config.SetHeartbeatTimeout(5 * time.Second)
+	config.SetProperty(property.HeartbeatInterval.Name(), "3000")
+	config.SetProperty(property.HeartbeatTimeout.Name(), "5000")
 	client, _ := hazelcast.NewClientWithConfig(config)
 	wg.Add(1)
 	client.(*internal.HazelcastClient).HeartBeatService.AddHeartbeatListener(heartbeatListener)

--- a/test/invocation_test.go
+++ b/test/invocation_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/hazelcast/hazelcast-go-client"
+	"github.com/hazelcast/hazelcast-go-client/config/property"
 	"github.com/hazelcast/hazelcast-go-client/core"
 	"github.com/hazelcast/hazelcast-go-client/internal"
 	"github.com/hazelcast/hazelcast-go-client/test/assert"
@@ -72,7 +73,7 @@ func TestInvocationTimeout(t *testing.T) {
 	config := hazelcast.NewConfig()
 	config.NetworkConfig().SetRedoOperation(true)
 	config.NetworkConfig().SetConnectionAttemptLimit(100)
-	config.NetworkConfig().SetInvocationTimeout(5 * time.Second)
+	config.SetProperty(property.InvocationTimeoutSeconds.Name(), "5")
 	client, _ := hazelcast.NewClientWithConfig(config)
 	mp, _ := client.GetMap("testMap")
 	remoteController.ShutdownMember(cluster.ID, member1.UUID)
@@ -134,7 +135,7 @@ func TestInvocationNotSent(t *testing.T) {
 	config := hazelcast.NewConfig()
 	config.NetworkConfig().SetRedoOperation(true)
 	config.NetworkConfig().SetConnectionAttemptLimit(100)
-	config.NetworkConfig().SetInvocationTimeout(10 * time.Second)
+	config.SetProperty(property.InvocationTimeoutSeconds.Name(), "10")
 	config.NetworkConfig().SetConnectionAttemptPeriod(1 * time.Second)
 	client, _ := hazelcast.NewClientWithConfig(config)
 	mp, _ := client.GetMap("testMap")


### PR DESCRIPTION
This PR adds Hazelcast Property as explained in #280.

It also removes some of the methods from config that do not exist in Java and uses `Hazelcast Property` instead. 


fixes #280.