### PR TITLE
remove confusing error message from sendToAddress

### DIFF
--- a/internal/invocation.go
+++ b/internal/invocation.go
@@ -309,7 +309,7 @@ func (is *invocationServiceImpl) sendToConnection(invocation *invocation, connec
 func (is *invocationServiceImpl) sendToAddress(invocation *invocation, address core.Address) {
 	connection, err := is.client.ConnectionManager.getOrTriggerConnect(address)
 	if err != nil {
-		log.Println("the following error occurred while trying to send the invocation ", err)
+		// TODO:: add the error to debugging level logging
 		is.handleNotSentInvocation(invocation.request.Load().(*proto.ClientMessage).CorrelationID(), err)
 		return
 	}


### PR DESCRIPTION
When there is no connection to an address and it will be triggered we log this line and it seems like there was a problem even though the connection will be opened. This is confusing for users and this should be at debug level. 