### PR TITLE
remove duplicate vet from build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -40,10 +40,6 @@ bash ./start-rc.sh
 
 sleep 10
 
-
-# Run vet tools (Compiler warning plugin)
-go vet $CLIENT_IMPORT_PATH > vet.txt
-
 go get github.com/t-yuki/gocover-cobertura
 go get github.com/tebeka/go2xunit
 


### PR DESCRIPTION
We already do vet analysis in `linter.sh` with gometalinter. This pr removes the redundant one.