### PR TITLE
return error in getDistributedObject when no service found

### DIFF
--- a/core/errors.go
+++ b/core/errors.go
@@ -107,6 +107,11 @@ type HazelcastNoDataMemberInClusterError struct {
 	*HazelcastErrorType
 }
 
+// HazelcastClientServiceNotFoundError indicates that a requested client service doesn't exist.
+type HazelcastClientServiceNotFoundError struct {
+	*HazelcastErrorType
+}
+
 // HazelcastUnsupportedOperationError is returned to indicate that the requested operation is not supported.
 type HazelcastUnsupportedOperationError struct {
 	*HazelcastErrorType
@@ -206,4 +211,11 @@ func NewHazelcastConsistencyLostError(message string, cause error) *HazelcastCon
 // NewHazelcastCertificateError returns a HazelcastCertificateError.
 func NewHazelcastCertificateError(message string, cause error) *HazelcastCertificateError {
 	return &HazelcastCertificateError{&HazelcastErrorType{message: message, cause: cause}}
+}
+
+// NewHazelcastClientServiceNotFoundError returns a HazelcastClientServiceNotFoundError.
+func NewHazelcastClientServiceNotFoundError(message string, cause error) *HazelcastClientServiceNotFoundError {
+	return &HazelcastClientServiceNotFoundError{&HazelcastErrorType{
+		message: message, cause: cause,
+	}}
 }

--- a/internal/client.go
+++ b/internal/client.go
@@ -130,11 +130,7 @@ func (c *HazelcastClient) GetPNCounter(name string) (core.PNCounter, error) {
 }
 
 func (c *HazelcastClient) GetDistributedObject(serviceName string, name string) (core.DistributedObject, error) {
-	var clientProxy, err = c.ProxyManager.getOrCreateProxy(serviceName, name)
-	if err != nil {
-		return nil, err
-	}
-	return clientProxy, nil
+	return c.ProxyManager.getOrCreateProxy(serviceName, name)
 }
 
 func (c *HazelcastClient) GetCluster() core.Cluster {

--- a/internal/proxy_manager.go
+++ b/internal/proxy_manager.go
@@ -18,6 +18,8 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"fmt"
+
 	"github.com/hazelcast/hazelcast-go-client/core"
 	"github.com/hazelcast/hazelcast-go-client/internal/proto"
 	"github.com/hazelcast/hazelcast-go-client/internal/proto/bufutil"
@@ -114,5 +116,6 @@ func (pm *proxyManager) getProxyByNameSpace(serviceName string, name string) (co
 	} else if bufutil.ServiceNameIDGenerator == serviceName {
 		return newFlakeIDGenerator(pm.client, serviceName, name)
 	}
-	return nil, nil
+	return nil, core.NewHazelcastClientServiceNotFoundError(fmt.Sprintf("no factory registered for service: %s",
+		serviceName), nil)
 }


### PR DESCRIPTION
When there is no service found with the given name, the client was returning nil, nil which is misleading.

Currently we can only used the built in services in golang client, we should enhance this to support registering user defined factories.


