### PR TITLE
remove unused isNoOtherProvider variable

### DIFF
--- a/internal/address_provider.go
+++ b/internal/address_provider.go
@@ -24,14 +24,12 @@ type AddressProvider interface {
 }
 
 type defaultAddressProvider struct {
-	networkConfig     *config.NetworkConfig
-	isNoOtherProvider bool
+	networkConfig *config.NetworkConfig
 }
 
-func newDefaultAddressProvider(networkConfig *config.NetworkConfig, isNoOtherProvider bool) *defaultAddressProvider {
+func newDefaultAddressProvider(networkConfig *config.NetworkConfig) *defaultAddressProvider {
 	return &defaultAddressProvider{
-		networkConfig:     networkConfig,
-		isNoOtherProvider: isNoOtherProvider,
+		networkConfig: networkConfig,
 	}
 }
 

--- a/internal/client.go
+++ b/internal/client.go
@@ -216,8 +216,7 @@ func (c *HazelcastClient) createAddressProviders() []AddressProvider {
 	if cloudAddressProvider != nil {
 		addressProviders = append(addressProviders, cloudAddressProvider)
 	}
-	addressProviders = append(addressProviders, newDefaultAddressProvider(c.ClientConfig.NetworkConfig(),
-		len(addressProviders) == 0))
+	addressProviders = append(addressProviders, newDefaultAddressProvider(c.ClientConfig.NetworkConfig()))
 
 	return addressProviders
 }

--- a/test/cluster_test.go
+++ b/test/cluster_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/hazelcast/hazelcast-go-client"
+	"github.com/hazelcast/hazelcast-go-client/config"
 	"github.com/hazelcast/hazelcast-go-client/core"
 	"github.com/hazelcast/hazelcast-go-client/internal"
 	"github.com/hazelcast/hazelcast-go-client/internal/proto"
@@ -264,6 +265,22 @@ func TestConnectToClusterWithSetAddress(t *testing.T) {
 	assert.Equalf(t, nil, len(members), 1, "connectToClusterWithoutPort returned a wrong member address")
 	client.Shutdown()
 	remoteController.ShutdownCluster(cluster.ID)
+}
+
+func TestAddressesWhenCloudConfigEnabled(t *testing.T) {
+	cluster, _ = remoteController.CreateCluster("", DefaultServerConfig)
+	remoteController.StartMember(cluster.ID)
+	defer remoteController.ShutdownCluster(cluster.ID)
+
+	cfg := hazelcast.NewConfig()
+	cloudConfig := config.NewClientCloud()
+	cloudConfig.SetEnabled(true)
+	cloudConfig.SetDiscoveryToken("test")
+	cfg.NetworkConfig().SetCloudConfig(cloudConfig)
+	_, err := hazelcast.NewClientWithConfig(cfg)
+	// Since cloudConfig is enabled and it does not have a valid url returning an error means
+	// default address is not used.
+	assert.ErrorNotNil(t, err, "")
 }
 
 type mapListener struct {


### PR DESCRIPTION
This pr removes unused variable. In `https://github.com/hazelcast/hazelcast-go-client/blob/master/internal/cluster.go#L122` the same functionality of what this variable is used for already exists. So it is redundant.

