### PR TITLE
increase coverage and reduce test time

### DIFF
--- a/config/flake_id_generator_config.go
+++ b/config/flake_id_generator_config.go
@@ -50,11 +50,12 @@ func NewFlakeIDGeneratorConfig(name string) *FlakeIDGeneratorConfig {
 // prefetchValidityMillis.
 func NewFlakeIDGeneratorConfigWithParameters(name string, prefetchCount int32,
 	prefetchValidityMillis int64) *FlakeIDGeneratorConfig {
-	return &FlakeIDGeneratorConfig{
-		name:                   name,
-		prefetchCount:          prefetchCount,
-		prefetchValidityMillis: prefetchValidityMillis,
+	flakeCfg := &FlakeIDGeneratorConfig{
+		name: name,
 	}
+	flakeCfg.SetPrefetchValidityMillis(prefetchValidityMillis)
+	flakeCfg.SetPrefetchCount(prefetchCount)
+	return flakeCfg
 }
 
 // SetPrefetchCount sets prefetchCount as the given value.
@@ -68,6 +69,7 @@ func (igc *FlakeIDGeneratorConfig) SetPrefetchCount(prefetchCount int32) {
 }
 
 // SetName sets the name as the given name.
+// Name must not be set after flake id config is added to config.
 func (igc *FlakeIDGeneratorConfig) SetName(name string) {
 	igc.name = name
 }

--- a/config/property/hazelcast_properties_test.go
+++ b/config/property/hazelcast_properties_test.go
@@ -160,3 +160,13 @@ func TestHazelcastProperties_GetPositiveDurationFromEnv(t *testing.T) {
 	}
 
 }
+
+func TestHazelcastProperty_SetNameAndString(t *testing.T) {
+	expected := "bar"
+	property := NewHazelcastProperty("foo")
+	property.SetName("bar")
+	actual := property.String()
+	if actual != expected {
+		t.Errorf("expected %s got %s", expected, actual)
+	}
+}

--- a/internal/vector_clock.go
+++ b/internal/vector_clock.go
@@ -18,12 +18,6 @@ import (
 	"sync"
 
 	"github.com/hazelcast/hazelcast-go-client/internal/proto"
-	"github.com/hazelcast/hazelcast-go-client/serialization"
-)
-
-const (
-	fID                = 0
-	vectorClockClassID = 43
 )
 
 type vectorClock struct {
@@ -33,44 +27,6 @@ type vectorClock struct {
 
 func newVectorClock() *vectorClock {
 	return &vectorClock{replicaTimestamps: make(map[string]int64)}
-}
-
-func (*vectorClock) FactoryID() int32 {
-	return fID
-}
-
-func (*vectorClock) ClassID() int32 {
-	return vectorClockClassID
-}
-
-func (v *vectorClock) WriteData(output serialization.DataOutput) (err error) {
-	v.mutex.RLock()
-	defer v.mutex.RUnlock()
-	output.WriteInt32(int32(len(v.replicaTimestamps)))
-	for key, value := range v.replicaTimestamps {
-		output.WriteUTF(key)
-		output.WriteInt64(value)
-	}
-	return
-}
-
-func (v *vectorClock) ReadData(input serialization.DataInput) error {
-	stateSize, err := input.ReadInt32()
-	if err != nil {
-		return err
-	}
-	for i := int32(0); i < stateSize; i++ {
-		replicaID, err := input.ReadUTF()
-		if err != nil {
-			return err
-		}
-		timestamp, err := input.ReadInt64()
-		if err != nil {
-			return err
-		}
-		v.replicaTimestamps[replicaID] = timestamp
-	}
-	return nil
 }
 
 func (v *vectorClock) EntrySet() (entrySet []*proto.Pair) {

--- a/test/client_test.go
+++ b/test/client_test.go
@@ -130,3 +130,42 @@ func TestGetDistributedObjectWithNotRegisteredServiceName(t *testing.T) {
 	}
 
 }
+
+func TestGetDistributedObjectsWhenClientNotActive(t *testing.T) {
+	cluster, _ = remoteController.CreateCluster("", DefaultServerConfig)
+	remoteController.StartMember(cluster.ID)
+	client, _ := hazelcast.NewClient()
+	remoteController.ShutdownCluster(cluster.ID)
+	name := "test"
+	message := "Distributed object should not be created when client is not active"
+	_, err := client.GetMap(name)
+	assert.ErrorNotNil(t, err, message)
+
+	_, err = client.GetTopic(name)
+	assert.ErrorNotNil(t, err, message)
+
+	_, err = client.GetReplicatedMap(name)
+	assert.ErrorNotNil(t, err, message)
+
+	_, err = client.GetSet(name)
+	assert.ErrorNotNil(t, err, message)
+
+	_, err = client.GetQueue(name)
+	assert.ErrorNotNil(t, err, message)
+
+	_, err = client.GetList(name)
+	assert.ErrorNotNil(t, err, message)
+
+	_, err = client.GetMultiMap(name)
+	assert.ErrorNotNil(t, err, message)
+
+	_, err = client.GetPNCounter(name)
+	assert.ErrorNotNil(t, err, message)
+
+	_, err = client.GetRingbuffer(name)
+	assert.ErrorNotNil(t, err, message)
+
+	_, err = client.GetFlakeIDGenerator(name)
+	assert.ErrorNotNil(t, err, message)
+
+}

--- a/test/cluster_test.go
+++ b/test/cluster_test.go
@@ -253,6 +253,19 @@ func TestConnectToClusterWithoutPort(t *testing.T) {
 	remoteController.ShutdownCluster(cluster.ID)
 }
 
+func TestConnectToClusterWithSetAddress(t *testing.T) {
+	cluster, _ = remoteController.CreateCluster("", DefaultServerConfig)
+	remoteController.StartMember(cluster.ID)
+	config := hazelcast.NewConfig()
+	config.NetworkConfig().SetAddresses([]string{"127.0.0.1"})
+	client, _ := hazelcast.NewClientWithConfig(config)
+	members := client.GetCluster().GetMembers()
+	assert.Equalf(t, nil, members[0].Address().Host(), "127.0.0.1", "connectToClusterWithoutPort returned a wrong member address")
+	assert.Equalf(t, nil, len(members), 1, "connectToClusterWithoutPort returned a wrong member address")
+	client.Shutdown()
+	remoteController.ShutdownCluster(cluster.ID)
+}
+
 type mapListener struct {
 	wg *sync.WaitGroup
 }

--- a/test/config_test.go
+++ b/test/config_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"testing"
+
+	"github.com/hazelcast/hazelcast-go-client"
+	"github.com/hazelcast/hazelcast-go-client/config"
+	"github.com/hazelcast/hazelcast-go-client/core"
+	"github.com/hazelcast/hazelcast-go-client/test/assert"
+)
+
+func TestSetGroupConfig(t *testing.T) {
+	cluster, _ = remoteController.CreateCluster("", DefaultServerConfig)
+	remoteController.StartMember(cluster.ID)
+	cfg := hazelcast.NewConfig()
+	groupCfg := config.NewGroupConfig()
+	groupCfg.SetName("wrongName")
+	groupCfg.SetPassword("wrongPassword")
+	cfg.SetGroupConfig(groupCfg)
+	client, err := hazelcast.NewClientWithConfig(cfg)
+	if _, ok := err.(*core.HazelcastAuthenticationError); !ok {
+		t.Fatal("client should have returned an authentication error")
+	}
+	client.Shutdown()
+	remoteController.ShutdownCluster(cluster.ID)
+}
+
+func TestSetNetworkConfig(t *testing.T) {
+	var expected int32 = 10
+	cfg := hazelcast.NewConfig()
+	nCfg := config.NewNetworkConfig()
+	nCfg.SetConnectionAttemptLimit(10)
+	cfg.SetNetworkConfig(nCfg)
+	actual := cfg.NetworkConfig().ConnectionAttemptLimit()
+	assert.Equal(t, nil, expected, actual)
+}

--- a/test/proxy/flakeidgen/flake_id_generator_test.go
+++ b/test/proxy/flakeidgen/flake_id_generator_test.go
@@ -60,12 +60,53 @@ func asssignOverFlowID(clusterID string, instanceNum int) (r *rc.Response, err e
 	return remoteController.ExecuteOnController(clusterID, script, 1)
 }
 
+func TestFlakeIDGeneratorProxy_ConfigPanicsWithInvalidPrefetchCount(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("Negative prefetch count should panic.")
+		}
+	}()
+	flakeIDCfg := config.NewFlakeIDGeneratorConfig("gen")
+	flakeIDCfg.SetPrefetchCount(-1)
+
+}
+
+func TestFlakeIDGeneratorProxy_ConfigPanicsWithInvalidPrefetchCount2(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("Negative prefetch count should panic.")
+		}
+	}()
+	config.NewFlakeIDGeneratorConfigWithParameters("gen", -1, 10)
+}
+
+func TestFlakeIDGeneratorProxy_ConfigPanicsWithInvalidPrefetchValidityMillis(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("Negative prefetchValidityMillis count should panic.")
+		}
+	}()
+	flakeIDCfg := config.NewFlakeIDGeneratorConfig("gen")
+	flakeIDCfg.SetPrefetchValidityMillis(-1)
+
+}
+
+func TestFlakeIDGeneratorProxy_ConfigPanicsWithInvalidPrefetchValidityMillis2(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("Negative prefetchValidityMillis count should panic.")
+		}
+	}()
+	config.NewFlakeIDGeneratorConfigWithParameters("gen", 10, -1)
+}
+
 func TestFlakeIDGeneratorProxy_ConfigTest(t *testing.T) {
 	cluster, _ := remoteController.CreateCluster("", test.DefaultServerConfig)
 	defer remoteController.ShutdownCluster(cluster.ID)
 	remoteController.StartMember(cluster.ID)
 	var myBatchSize int32 = shortTermBatchSize
 	flakeIDConf := config.NewFlakeIDGeneratorConfig("gen")
+	flakeIDConf.SetName("gen") // this is redundant, just to check if it doesnt mess anything.
 	flakeIDConf.SetPrefetchCount(myBatchSize)
 	flakeIDConf.SetPrefetchValidityMillis(shortTermValidityMillis)
 	config := hazelcast.NewConfig()

--- a/test/proxy/pncounter/pn_counter_test.go
+++ b/test/proxy/pncounter/pn_counter_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/hazelcast/hazelcast-go-client"
+	"github.com/hazelcast/hazelcast-go-client/config/property"
 	"github.com/hazelcast/hazelcast-go-client/core"
 	"github.com/hazelcast/hazelcast-go-client/internal"
 	"github.com/hazelcast/hazelcast-go-client/internal/proto/bufutil"
@@ -193,7 +194,9 @@ func TestPNCounter_HazelcastConsistencyLostError(t *testing.T) {
 	cluster, err = remoteController.CreateCluster("", crdtReplicationDelayedConfig)
 	remoteController.StartMember(cluster.ID)
 	remoteController.StartMember(cluster.ID)
-	client, _ = hazelcast.NewClient()
+	cfg := hazelcast.NewConfig()
+	cfg.SetProperty(property.InvocationTimeoutSeconds.Name(), "5")
+	client, _ = hazelcast.NewClientWithConfig(cfg)
 	counter, _ = client.GetPNCounter(counterName)
 	var delta int64 = 5
 	counter.GetAndAdd(delta)
@@ -212,7 +215,9 @@ func TestPNCounter_Reset(t *testing.T) {
 	cluster, err = remoteController.CreateCluster("", crdtReplicationDelayedConfig)
 	remoteController.StartMember(cluster.ID)
 	remoteController.StartMember(cluster.ID)
-	client, _ = hazelcast.NewClient()
+	cfg := hazelcast.NewConfig()
+	cfg.SetProperty(property.InvocationTimeoutSeconds.Name(), "5")
+	client, _ = hazelcast.NewClientWithConfig(cfg)
 	counter, _ = client.GetPNCounter(counterName)
 	var delta int64 = 5
 	counter.GetAndAdd(delta)


### PR DESCRIPTION
This PR increases test coverage.

It also reduces testing time approximately 4 minutes by setting invocation timeout in pn counter tests.

