### PR TITLE
use list lastIndexOf codec

### DIFF
--- a/internal/list.go
+++ b/internal/list.go
@@ -142,7 +142,7 @@ func (lp *listProxy) LastIndexOf(element interface{}) (index int32, err error) {
 	}
 	request := proto.ListLastIndexOfEncodeRequest(lp.name, elementData)
 	responseMessage, err := lp.invoke(request)
-	return lp.decodeToInt32AndError(responseMessage, err, proto.ListIndexOfDecodeResponse)
+	return lp.decodeToInt32AndError(responseMessage, err, proto.ListLastIndexOfDecodeResponse)
 }
 
 func (lp *listProxy) Remove(element interface{}) (changed bool, err error) {


### PR DESCRIPTION
List Proxy `lastIndexOf` method was using `indexOf` decode method to decode the response. As they are identical the functionality is the same but we should use `lastIndexOf` codec.  