### PR TITLE
add cloud discovery tests

### DIFF
--- a/internal/discovery/hazelcast_cloud_discovery_test.go
+++ b/internal/discovery/hazelcast_cloud_discovery_test.go
@@ -1,0 +1,144 @@
+// Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package discovery
+
+import (
+	"crypto/x509"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hazelcast/hazelcast-go-client/test/assert"
+)
+
+const (
+	privateAddr1 = "10.47.0.8"
+	privateAddr2 = "10.47.0.9"
+	privateAddr3 = "10.47.0.10"
+	port         = "32298"
+)
+
+const serverResponse = "[" +
+	"{\"private-address\":\"" + privateAddr1 + "\",\"public-address\":\"54.213.63.142:" + port + "\"}," +
+	"{\"private-address\":\"" + privateAddr2 + "\",\"public-address\":\"54.245.77.185:" + port + "\"}," +
+	"{\"private-address\":\"" + privateAddr3 + "\",\"public-address\":\"54.186.232.37:" + port + "\"}" +
+	"]"
+
+func TestHazelcastCloudDiscoverNodes(t *testing.T) {
+	// Start a local HTTP server
+	server := httptest.NewTLSServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		// Send response to be tested
+		rw.Write([]byte(serverResponse))
+	}))
+
+	// Close the server when test finishes
+	defer server.Close()
+
+	cert, err := x509.ParseCertificate(server.TLS.Certificates[0].Certificate[0])
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	certpool := x509.NewCertPool()
+	certpool.AddCert(cert)
+
+	hzC := NewHazelcastCloud(server.URL, 0, certpool)
+	addresses, err := hzC.discoverNodesInternal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	expPrivAddr1 := privateAddr1 + ":" + port
+	expPrivAddr2 := privateAddr2 + ":" + port
+	expPrivAddr3 := privateAddr3 + ":" + port
+
+	if _, found := addresses[expPrivAddr1]; !found {
+		t.Errorf("Expected %s to be in addresses", expPrivAddr1)
+	}
+	if _, found := addresses[expPrivAddr2]; !found {
+		t.Errorf("Expected %s to be in addresses", expPrivAddr2)
+	}
+	if _, found := addresses[expPrivAddr3]; !found {
+		t.Errorf("Expected %s to be in addresses", expPrivAddr3)
+	}
+}
+
+func TestHazelcastCloudDiscoveryInvalidURL(t *testing.T) {
+	hzC := NewHazelcastCloud("invalid", 0, nil)
+	_, err := hzC.discoverNodesInternal()
+	assert.ErrorNotNil(t, err, "invalid url should return an error")
+
+}
+
+func TestHazelcastCloudDiscoveryWithoutCertPool(t *testing.T) {
+	// Start a local HTTP server
+	server := httptest.NewTLSServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		// Send response to be tested
+		rw.Write([]byte(serverResponse))
+	}))
+
+	// Close the server when test finishes
+	defer server.Close()
+
+	hzC := NewHazelcastCloud(server.URL, 0, nil)
+	_, err := hzC.discoverNodesInternal()
+	assert.ErrorNotNil(t, err, "Cloud Discovery without certPool should not connect")
+}
+
+func TestHazelcastCloudDiscoverNodesInvalidJSON(t *testing.T) {
+	// Start a local HTTP server
+	server := httptest.NewTLSServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		// Send response to be tested
+		rw.Write([]byte("invalidJSON"))
+	}))
+
+	// Close the server when test finishes
+	defer server.Close()
+
+	cert, err := x509.ParseCertificate(server.TLS.Certificates[0].Certificate[0])
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	certpool := x509.NewCertPool()
+	certpool.AddCert(cert)
+
+	hzC := NewHazelcastCloud(server.URL, 0, certpool)
+	_, err = hzC.discoverNodesInternal()
+	assert.ErrorNotNil(t, err, "non JSON response should return an error")
+}
+
+func TestHazelcastCloudDiscoverNodesWrongStatusCode(t *testing.T) {
+	// Start a local HTTP server
+	server := httptest.NewTLSServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		// Send response to be tested
+		http.Error(rw, "", http.StatusBadRequest)
+	}))
+
+	// Close the server when test finishes
+	defer server.Close()
+
+	cert, err := x509.ParseCertificate(server.TLS.Certificates[0].Certificate[0])
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	certpool := x509.NewCertPool()
+	certpool.AddCert(cert)
+
+	hzC := NewHazelcastCloud(server.URL, 0, certpool)
+	_, err = hzC.discoverNodesInternal()
+	assert.ErrorNotNil(t, err, "HTTP status other than 200 response should return an error")
+}

--- a/internal/discovery/hz_cloud_addr_provider.go
+++ b/internal/discovery/hz_cloud_addr_provider.go
@@ -35,6 +35,7 @@ func NewHzCloudAddrProvider(endpointURL string, connectionTimeout time.Duration)
 		NewHazelcastCloud(
 			endpointURL,
 			connectionTimeout,
+			nil,
 		),
 	)
 }

--- a/internal/discovery/hz_cloud_addr_provider_test.go
+++ b/internal/discovery/hz_cloud_addr_provider_test.go
@@ -37,7 +37,7 @@ func TestHzCloudAddrProvider(t *testing.T) {
 		return expectedAddresses, nil
 	}
 
-	hazelcastCloudDiscovery := NewHazelcastCloud("", 0)
+	hazelcastCloudDiscovery := NewHazelcastCloud("", 0, nil)
 	hazelcastCloudDiscovery.discoverNodes = mockProvider // mock the discoverNode function
 
 	provider = NewHzCloudAddrProvider("", 0)

--- a/internal/discovery/hz_cloud_addr_translator.go
+++ b/internal/discovery/hz_cloud_addr_translator.go
@@ -34,6 +34,7 @@ func NewHzCloudAddrTranslator(endpointURL string, connectionTimeout time.Duratio
 		NewHazelcastCloud(
 			endpointURL,
 			connectionTimeout,
+			nil,
 		),
 	)
 }

--- a/internal/discovery/hz_cloud_addr_translator_test.go
+++ b/internal/discovery/hz_cloud_addr_translator_test.go
@@ -37,7 +37,7 @@ func TestHzCloudAddrTranslator_Translate(t *testing.T) {
 		return lookup, nil
 	}
 
-	hazelcastCloudDiscovery := NewHazelcastCloud("", 0)
+	hazelcastCloudDiscovery := NewHazelcastCloud("", 0, nil)
 	hazelcastCloudDiscovery.discoverNodes = mockProvider // mock the discoverNode function
 
 	translator = NewHzCloudAddrTranslator("", 0)

--- a/test/client_test.go
+++ b/test/client_test.go
@@ -133,9 +133,7 @@ func TestGetDistributedObjectWithNotRegisteredServiceName(t *testing.T) {
 	cluster, _ = remoteController.CreateCluster("", DefaultServerConfig)
 	defer remoteController.ShutdownCluster(cluster.ID)
 	remoteController.StartMember(cluster.ID)
-	clientConfig := hazelcast.NewConfig()
-	clientConfig.NetworkConfig().AddAddress("127.0.0.1:5701")
-	client, err := hazelcast.NewClientWithConfig(clientConfig)
+	client, err := hazelcast.NewClient()
 	defer client.Shutdown()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This PR adds tests for cloud discovery.

When using hazelcast cloud discovery SSL/TLS should be used, it is also added in this PR however since TLS PR hasnt yet merged, that argument is set as nil. 

