### PR TITLE
fix trying to reconnect if client is shutting down

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -164,12 +164,12 @@ func (c *HazelcastClient) init() error {
 	if err != nil {
 		return err
 	}
+	c.PartitionService.start()
 	err = c.ClusterService.start()
 	if err != nil {
 		return err
 	}
 	c.HeartBeatService.start()
-	c.PartitionService.start()
 	c.LifecycleService.fireLifecycleEvent(LifecycleStateStarted)
 	return nil
 }

--- a/internal/connection.go
+++ b/internal/connection.go
@@ -62,6 +62,7 @@ func newConnection(client *HazelcastClient, address core.Address, handleResponse
 		readBuffer:           make([]byte, 0),
 		connectionID:         connectionID,
 		connectionManager:    connectionManager,
+		status:               0,
 	}
 	connectionTimeout := timeutil.GetPositiveDurationOrMax(client.ClientConfig.NetworkConfig().ConnectionTimeout())
 	socket, err := net.DialTimeout("tcp", address.String(), connectionTimeout)
@@ -176,6 +177,7 @@ func (c *Connection) close(err error) {
 	if !atomic.CompareAndSwapInt32(&c.status, 0, 1) {
 		return
 	}
+	//TODO log close message
 	close(c.closed)
 	c.closedTime.Store(time.Now())
 	c.connectionManager.onConnectionClose(c, err)

--- a/internal/connection_manager.go
+++ b/internal/connection_manager.go
@@ -54,6 +54,7 @@ type connectionManager interface {
 	addListener(listener connectionListener)
 	onConnectionClose(connection *Connection, cause error)
 	NextConnectionID() int64
+	IsAlive() bool
 	shutdown()
 }
 
@@ -136,6 +137,10 @@ func (cm *connectionManagerImpl) getOwnerConnection() *Connection {
 		return nil
 	}
 	return cm.getActiveConnection(ownerConnectionAddress)
+}
+
+func (cm *connectionManagerImpl) IsAlive() bool {
+	return cm.isAlive.Load().(bool)
 }
 
 func (cm *connectionManagerImpl) shutdown() {

--- a/internal/partition.go
+++ b/internal/partition.go
@@ -34,7 +34,7 @@ type partitionService struct {
 }
 
 func newPartitionService(client *HazelcastClient) *partitionService {
-	return &partitionService{client: client, cancel: make(chan struct{}), refresh: make(chan struct{}, 1)}
+	return &partitionService{client: client, cancel: make(chan struct{}), refresh: make(chan struct{}, 10)}
 }
 
 func (ps *partitionService) start() {

--- a/test/client_test.go
+++ b/test/client_test.go
@@ -86,7 +86,8 @@ func TestConnectionTimeout(t *testing.T) {
 	remoteController.StartMember(cluster.ID)
 	cfg := hazelcast.NewConfig()
 	cfg.NetworkConfig().SetConnectionTimeout(0)
-	_, err := hazelcast.NewClient()
+	client, err := hazelcast.NewClient()
+	defer client.Shutdown()
 	assert.ErrorNil(t, err)
 }
 
@@ -128,14 +129,11 @@ func TestOpenedClientConnectionCount_WhenMultipleMembers(t *testing.T) {
 	client.Shutdown()
 	remoteController.ShutdownCluster(cluster.ID)
 }
-
 func TestGetDistributedObjectWithNotRegisteredServiceName(t *testing.T) {
 	cluster, _ = remoteController.CreateCluster("", DefaultServerConfig)
 	defer remoteController.ShutdownCluster(cluster.ID)
 	remoteController.StartMember(cluster.ID)
-	clientConfig := hazelcast.NewConfig()
-	clientConfig.NetworkConfig().AddAddress("127.0.0.1:5701")
-	client, err := hazelcast.NewClientWithConfig(clientConfig)
+	client, err := hazelcast.NewClient()
 	defer client.Shutdown()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
There was a race condition in cluster service. It was possible that client would try to access `reconnectChan` when client is shutdown. `shutdown` and `onConnectionClosed` methods should be synced. 

Fixes #333.

Another issue was that client was hanging and getting a `EOF` in socket read. It would happen in 5 minutes because server closes the connection after 5 minutes of not reaching a ping from client. Client was hanging because clusterService was using a global waitgroup. The waitgroup should be unique per cluster service. Initial fetch for partition table is added to partition service like Java Client.



I have tested it 5-6 times so it seems that the issue is resolved.

Fixes #332.
 