### PR TITLE
use connection error instead of swallowing it

### DIFF
--- a/internal/connection.go
+++ b/internal/connection.go
@@ -51,7 +51,7 @@ type Connection struct {
 }
 
 func newConnection(client *HazelcastClient, address core.Address, handleResponse func(interface{}),
-	connectionID int64, connectionManager connectionManager) *Connection {
+	connectionID int64, connectionManager connectionManager) (*Connection, error) {
 	builder := &clientMessageBuilder{handleResponse: handleResponse,
 		incompleteMessages: make(map[int64]*proto.ClientMessage)}
 	connection := Connection{pending: make(chan *proto.ClientMessage, 1),
@@ -67,7 +67,7 @@ func newConnection(client *HazelcastClient, address core.Address, handleResponse
 	connectionTimeout := timeutil.GetPositiveDurationOrMax(client.ClientConfig.NetworkConfig().ConnectionTimeout())
 	socket, err := net.DialTimeout("tcp", address.String(), connectionTimeout)
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	connection.socket = socket
 	connection.lastRead.Store(time.Now())
@@ -78,7 +78,7 @@ func newConnection(client *HazelcastClient, address core.Address, handleResponse
 	socket.Write([]byte("CB2"))
 	go connection.writePool()
 	go connection.read()
-	return &connection
+	return &connection, nil
 }
 
 func (c *Connection) isAlive() bool {

--- a/internal/connection_manager.go
+++ b/internal/connection_manager.go
@@ -339,11 +339,11 @@ func (cm *connectionManagerImpl) createConnection(address core.Address, asOwner 
 
 	invocationService := cm.client.InvocationService.(*invocationServiceImpl)
 	connectionID := cm.NextConnectionID()
-	con := newConnection(cm.client, address, invocationService.handleResponse, connectionID, cm)
-	if con == nil {
-		return nil, core.NewHazelcastTargetDisconnectedError("target is disconnected", nil)
+	con, err := newConnection(cm.client, address, invocationService.handleResponse, connectionID, cm)
+	if err != nil {
+		return nil, core.NewHazelcastTargetDisconnectedError(err.Error(), nil)
 	}
-	err := cm.authenticate(con, asOwner)
+	err = cm.authenticate(con, asOwner)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
When there is an error while creating a connection it was being swallowed. This pr uses the error.