### PR TITLE
give server error to users in ServerError interface

### DIFF
--- a/core/api.go
+++ b/core/api.go
@@ -274,3 +274,47 @@ type LoadBalancer interface {
 	// It returns nil if no member is available.
 	Next() Member
 }
+
+// StackTraceElement contains stacktrace information for server side exception.
+type StackTraceElement interface {
+	// DeclaringClass returns the fully qualified name of the class containing
+	// the execution point represented by the stack trace element.
+	DeclaringClass() string
+
+	// MethodName returns the name of the method containing the execution point
+	// represented by this stack trace element.
+	MethodName() string
+
+	// FileName returns the name of the file containing the execution point
+	// represented by the stack trace element, or nil if
+	// this information is unavailable.
+	FileName() string
+
+	// LineNumber returns the line number of the source line containing the
+	// execution point represented by this stack trace element, or
+	// a negative number if this information is unavailable. A value
+	// of -2 indicates that the method containing the execution point
+	// is a native method.
+	LineNumber() int32
+}
+
+// ServerError contains error information that occurred in the server.
+type ServerError interface {
+	// ErrorCode returns the error code.
+	ErrorCode() int32
+
+	// ClassName returns the class name where error occurred.
+	ClassName() string
+
+	// Message returns the error message.
+	Message() string
+
+	// StackTrace returns a slice of StackTraceElement.
+	StackTrace() []StackTraceElement
+
+	// CauseErrorCode returns the cause error code.
+	CauseErrorCode() int32
+
+	// CauseClassName returns the cause class name.
+	CauseClassName() string
+}

--- a/core/errors.go
+++ b/core/errors.go
@@ -21,6 +21,9 @@ type HazelcastError interface {
 
 	// Cause returns the cause of error.
 	Cause() error
+
+	// ServerError returns error info from server side.
+	ServerError() ServerError
 }
 
 // HazelcastErrorType is the general error struct.
@@ -40,6 +43,16 @@ func (e *HazelcastErrorType) Error() string {
 // Cause returns the cause error.
 func (e *HazelcastErrorType) Cause() error {
 	return e.cause
+}
+
+// ServerError returns error info from server side.
+// It checks if the cause implements ServerError and if it doesnt
+// it return nil.
+func (e *HazelcastErrorType) ServerError() ServerError {
+	if serverErr, ok := e.cause.(ServerError); ok {
+		return serverErr
+	}
+	return nil
 }
 
 // HazelcastEOFError is returned when an EOF error occurs.
@@ -160,22 +173,22 @@ func NewHazelcastTargetDisconnectedError(message string, cause error) *Hazelcast
 
 // NewHazelcastEOFError returns a HazelcastEOFError.
 func NewHazelcastEOFError(message string, cause error) *HazelcastEOFError {
-	return &HazelcastEOFError{&HazelcastErrorType{message, cause}}
+	return &HazelcastEOFError{&HazelcastErrorType{message: message, cause: cause}}
 }
 
 // NewHazelcastSerializationError returns a HazelcastSerializationError.
 func NewHazelcastSerializationError(message string, cause error) *HazelcastSerializationError {
-	return &HazelcastSerializationError{&HazelcastErrorType{message, cause}}
+	return &HazelcastSerializationError{&HazelcastErrorType{message: message, cause: cause}}
 }
 
 // NewHazelcastIllegalArgumentError returns a HazelcastIllegalArgumentError.
 func NewHazelcastIllegalArgumentError(message string, cause error) *HazelcastIllegalArgumentError {
-	return &HazelcastIllegalArgumentError{&HazelcastErrorType{message, cause}}
+	return &HazelcastIllegalArgumentError{&HazelcastErrorType{message: message, cause: cause}}
 }
 
 // NewHazelcastAuthenticationError returns a HazelcastAuthenticationError.
 func NewHazelcastAuthenticationError(message string, cause error) *HazelcastAuthenticationError {
-	return &HazelcastAuthenticationError{&HazelcastErrorType{message, cause}}
+	return &HazelcastAuthenticationError{&HazelcastErrorType{message: message, cause: cause}}
 }
 
 // NewHazelcastTimeoutError returns a HazelcastTimeoutError.

--- a/internal/error.go
+++ b/internal/error.go
@@ -22,7 +22,7 @@ import (
 	"github.com/hazelcast/hazelcast-go-client/internal/proto/bufutil"
 )
 
-func createHazelcastError(err *proto.Error) core.HazelcastError {
+func createHazelcastError(err *proto.ServerError) core.HazelcastError {
 	stackTrace := ""
 	for _, trace := range err.StackTrace() {
 		stackTrace += fmt.Sprintf("\n %s.%s(%s:%d)", trace.DeclaringClass(), trace.MethodName(), trace.FileName(),
@@ -31,20 +31,20 @@ func createHazelcastError(err *proto.Error) core.HazelcastError {
 	message := fmt.Sprintf("got exception from server:\n %s: %s\n %s", err.ClassName(), err.Message(), stackTrace)
 	switch bufutil.ErrorCode(err.ErrorCode()) {
 	case bufutil.ErrorCodeAuthentication:
-		return core.NewHazelcastAuthenticationError(message, nil)
+		return core.NewHazelcastAuthenticationError(message, err)
 	case bufutil.ErrorCodeHazelcastInstanceNotActive:
-		return core.NewHazelcastInstanceNotActiveError(message, nil)
+		return core.NewHazelcastInstanceNotActiveError(message, err)
 	case bufutil.ErrorCodeHazelcastSerialization:
-		return core.NewHazelcastSerializationError(message, nil)
+		return core.NewHazelcastSerializationError(message, err)
 	case bufutil.ErrorCodeTargetDisconnected:
-		return core.NewHazelcastTargetDisconnectedError(message, nil)
+		return core.NewHazelcastTargetDisconnectedError(message, err)
 	case bufutil.ErrorCodeTargetNotMember:
-		return core.NewHazelcastTargetNotMemberError(message, nil)
+		return core.NewHazelcastTargetNotMemberError(message, err)
 	case bufutil.ErrorCodeUnsupportedOperation:
-		return core.NewHazelcastUnsupportedOperationError(message, nil)
+		return core.NewHazelcastUnsupportedOperationError(message, err)
 	case bufutil.ErrorCodeConsistencyLostException:
-		return core.NewHazelcastConsistencyLostError(message, nil)
+		return core.NewHazelcastConsistencyLostError(message, err)
 	}
 
-	return core.NewHazelcastErrorType(message, nil)
+	return core.NewHazelcastErrorType(message, err)
 }

--- a/internal/invocation.go
+++ b/internal/invocation.go
@@ -404,7 +404,7 @@ func (is *invocationServiceImpl) handleClientMessage(response *proto.ClientMessa
 	}
 }
 
-func convertToError(clientMessage *proto.ClientMessage) *proto.Error {
+func convertToError(clientMessage *proto.ClientMessage) *proto.ServerError {
 	return proto.ErrorCodecDecode(clientMessage)
 }
 

--- a/internal/proto/core.go
+++ b/internal/proto/core.go
@@ -293,44 +293,44 @@ func (ev DataEntryView) Equal(ev2 DataEntryView) bool {
 	return true
 }
 
-type Error struct {
+type ServerError struct {
 	errorCode      int32
 	className      string
 	message        string
-	stackTrace     []*StackTraceElement
+	stackTrace     []core.StackTraceElement
 	causeErrorCode int32
 	causeClassName string
 }
 
-func (e *Error) Error() string {
+func (e *ServerError) Error() string {
 	return e.message
 }
 
-func (e *Error) ErrorCode() int32 {
+func (e *ServerError) ErrorCode() int32 {
 	return e.errorCode
 }
 
-func (e *Error) ClassName() string {
+func (e *ServerError) ClassName() string {
 	return e.className
 }
 
-func (e *Error) Message() string {
+func (e *ServerError) Message() string {
 	return e.message
 }
 
-func (e *Error) StackTrace() []*StackTraceElement {
-	stackTrace := make([]*StackTraceElement, len(e.stackTrace))
+func (e *ServerError) StackTrace() []core.StackTraceElement {
+	stackTrace := make([]core.StackTraceElement, len(e.stackTrace))
 	for i, v := range e.stackTrace {
 		stackTrace[i] = v
 	}
 	return stackTrace
 }
 
-func (e *Error) CauseErrorCode() int32 {
+func (e *ServerError) CauseErrorCode() int32 {
 	return e.causeErrorCode
 }
 
-func (e *Error) CauseClassName() string {
+func (e *ServerError) CauseClassName() string {
 	return e.causeClassName
 }
 

--- a/internal/proto/custom_codec.go
+++ b/internal/proto/custom_codec.go
@@ -14,6 +14,8 @@
 
 package proto
 
+import "github.com/hazelcast/hazelcast-go-client/core"
+
 /*
 Address Codec
 */
@@ -86,14 +88,14 @@ func UUIDCodecDecode(msg *ClientMessage) *uuid {
 	Error Codec
 */
 
-func ErrorCodecDecode(msg *ClientMessage) *Error {
-	response := Error{}
+func ErrorCodecDecode(msg *ClientMessage) *ServerError {
+	response := ServerError{}
 	response.errorCode = msg.ReadInt32()
 	response.className = msg.ReadString()
 	if !msg.ReadBool() {
 		response.message = msg.ReadString()
 	}
-	stackTrace := make([]*StackTraceElement, 0)
+	stackTrace := make([]core.StackTraceElement, 0)
 	stackTraceCount := msg.ReadInt32()
 	for i := 0; i < int(stackTraceCount); i++ {
 		stackTrace = append(stackTrace, DecodeStackTrace(msg))
@@ -107,7 +109,7 @@ func ErrorCodecDecode(msg *ClientMessage) *Error {
 
 }
 
-func DecodeStackTrace(msg *ClientMessage) *StackTraceElement {
+func DecodeStackTrace(msg *ClientMessage) core.StackTraceElement {
 	declaringClass := msg.ReadString()
 	methodName := msg.ReadString()
 	fileName := ""


### PR DESCRIPTION
When server returns an error client was returning it as a string. When they need to look up for a certain thing in the error message they needed to do string comparison. This pr adds `ServerError` interface, which has error `className`, `errorCode`, `stackTrace` etc.  

In order to get ServerError user will call `ServerError` Method which does the following:

```
func (e *HazelcastErrorType) ServerError() ServerError {
	if serverErr, ok := e.cause.(ServerError); ok {
		return serverErr
	}
	return nil
}
```


Fixes #349.
