### PR TITLE
fix heartbeat test

### DIFF
--- a/internal/connection.go
+++ b/internal/connection.go
@@ -96,8 +96,9 @@ func (c *Connection) writePool() {
 			err := c.write(request)
 			if err != nil {
 				c.clientMessageBuilder.handleResponse(request.CorrelationID())
+			} else {
+				c.lastWrite.Store(time.Now())
 			}
-			c.lastWrite.Store(time.Now())
 		case <-c.closed:
 			return
 		}

--- a/test/client_test.go
+++ b/test/client_test.go
@@ -29,8 +29,6 @@ import (
 	"github.com/hazelcast/hazelcast-go-client/core"
 	"github.com/hazelcast/hazelcast-go-client/internal"
 
-	"strconv"
-
 	"github.com/stretchr/testify/assert"
 )
 
@@ -150,36 +148,42 @@ func TestClientNameDefault(t *testing.T) {
 	remoteController.StartMember(cluster.ID)
 	client, _ := hazelcast.NewClient()
 	defer client.Shutdown()
-	assert.Equal(t, client.Name(), "hz.client_1")
+	assert.Contains(t, client.Name(), "hz.client_")
 }
 
 func TestMultipleClientNameDefault(t *testing.T) {
 	cluster, _ := remoteController.CreateCluster("", DefaultServerConfig)
 	defer remoteController.ShutdownCluster(cluster.ID)
 	remoteController.StartMember(cluster.ID)
+	names := make(map[string]struct{})
 	for i := 1; i <= 10; i++ {
 		client, _ := hazelcast.NewClient()
 		defer client.Shutdown()
-		assert.Equal(t, client.Name(), "hz.client_"+strconv.Itoa(i))
+		names[client.Name()] = struct{}{}
 	}
+	assert.Len(t, names, 10)
 }
 
 func TestMultipleClientNameDefaultConcurrent(t *testing.T) {
 	cluster, _ := remoteController.CreateCluster("", DefaultServerConfig)
 	defer remoteController.ShutdownCluster(cluster.ID)
 	remoteController.StartMember(cluster.ID)
-
+	mu := sync.Mutex{}
+	names := make(map[string]struct{})
 	for i := 1; i <= 10; i++ {
 		go func() {
 			client, _ := hazelcast.NewClient()
 			defer client.Shutdown()
+			mu.Lock()
+			names[client.Name()] = struct{}{}
+			mu.Unlock()
 		}()
 	}
 	time.Sleep(time.Second)
-	client, _ := hazelcast.NewClient()
-	defer client.Shutdown()
-	// since 10 clients were opened the next id should be 11.
-	assert.Equal(t, client.Name(), "hz.client_11")
+	mu.Lock()
+	assert.Len(t, names, 10)
+	mu.Unlock()
+
 }
 
 func TestGetDistributedObjectWithNotRegisteredServiceName(t *testing.T) {


### PR DESCRIPTION
`TestHeartbeatStoppedForConnection` would fail sometimes because last write would be updated even though there was an error during socket write process. This behavior is changed so that `last write` for a connection will only be updated if the write was successful. Also connection is closed in case of a heartbeat timeout.

