### PR TITLE
rename ClientConfig as Config

### DIFF
--- a/internal/cluster.go
+++ b/internal/cluster.go
@@ -60,7 +60,7 @@ func newClusterService(client *HazelcastClient, config *config.Config, addressPr
 	service.ownerUUID.Store(ownerUUID) //Initialize
 	uuid := ""
 	service.uuid.Store(uuid) //Initialize
-	for _, membershipListener := range client.ClientConfig.MembershipListeners() {
+	for _, membershipListener := range client.Config.MembershipListeners() {
 		service.AddMembershipListener(membershipListener)
 	}
 	service.addressProviders = addressProviders

--- a/internal/connection_manager.go
+++ b/internal/connection_manager.go
@@ -339,7 +339,7 @@ func (cm *connectionManagerImpl) createConnection(address core.Address, asOwner 
 
 	invocationService := cm.client.InvocationService.(*invocationServiceImpl)
 	connectionID := cm.NextConnectionID()
-	con, err := newConnection(address, invocationService.handleResponse, connectionID, cm, cm.client.ClientConfig.NetworkConfig())
+	con, err := newConnection(address, invocationService.handleResponse, connectionID, cm, cm.client.Config.NetworkConfig())
 	if err != nil {
 		return nil, core.NewHazelcastTargetDisconnectedError(err.Error(), err)
 	}

--- a/internal/flake_id_generator.go
+++ b/internal/flake_id_generator.go
@@ -39,7 +39,7 @@ func (fp *flakeIDGeneratorProxy) NewIDBatch(batchSize int32) (*flakeid.IDBatch, 
 }
 
 func newFlakeIDGenerator(client *HazelcastClient, serviceName string, name string) (*flakeIDGeneratorProxy, error) {
-	config := client.ClientConfig.GetFlakeIDGeneratorConfig(name)
+	config := client.Config.GetFlakeIDGeneratorConfig(name)
 	flakeIDGenerator := &flakeIDGeneratorProxy{}
 	flakeIDGenerator.proxy = &proxy{client: client, serviceName: serviceName, name: name}
 	flakeIDGenerator.batcher = flakeid.NewAutoBatcher(config.PrefetchCount(), config.PrefetchValidityMillis(), flakeIDGenerator)

--- a/internal/invocation.go
+++ b/internal/invocation.go
@@ -229,7 +229,7 @@ func newInvocationService(client *HazelcastClient) *invocationServiceImpl {
 	service.initInvocationTimeout()
 	service.initRetryPause()
 	service.isShutdown.Store(false)
-	if client.ClientConfig.NetworkConfig().IsSmartRouting() {
+	if client.Config.NetworkConfig().IsSmartRouting() {
 		service.invoke = service.invokeSmart
 	} else {
 		service.invoke = service.invokeNonSmart
@@ -435,7 +435,7 @@ func (is *invocationServiceImpl) handleError(invocation *invocation, err error) 
 }
 
 func (is *invocationServiceImpl) isRedoOperation() bool {
-	return is.client.ClientConfig.NetworkConfig().IsRedoOperation()
+	return is.client.Config.NetworkConfig().IsRedoOperation()
 }
 
 func (is *invocationServiceImpl) shouldRetryInvocation(invocation *invocation, err error) bool {

--- a/internal/listener.go
+++ b/internal/listener.go
@@ -88,7 +88,7 @@ func newListenerService(client *HazelcastClient) *listenerService {
 	}
 	service.client.ConnectionManager.addListener(service)
 	go service.process()
-	if service.client.ClientConfig.NetworkConfig().IsSmartRouting() {
+	if service.client.Config.NetworkConfig().IsSmartRouting() {
 		go service.connectToAllMembersPeriodically()
 	}
 	return service
@@ -304,7 +304,7 @@ func (ls *listenerService) onConnectionOpenedInternal(connection *Connection) {
 }
 
 func (ls *listenerService) trySyncConnectToAllConnections() error {
-	if !ls.client.ClientConfig.NetworkConfig().IsSmartRouting() {
+	if !ls.client.Config.NetworkConfig().IsSmartRouting() {
 		return nil
 	}
 	remainingTime := ls.client.properties.GetPositiveDuration(property.InvocationTimeoutSeconds)

--- a/internal/proxy.go
+++ b/internal/proxy.go
@@ -41,7 +41,7 @@ func (p *proxy) Destroy() (bool, error) {
 }
 
 func (p *proxy) isSmart() bool {
-	return p.client.ClientConfig.NetworkConfig().IsSmartRouting()
+	return p.client.Config.NetworkConfig().IsSmartRouting()
 }
 
 func (p *proxy) Name() string {

--- a/internal/reliable_topic.go
+++ b/internal/reliable_topic.go
@@ -59,7 +59,7 @@ func newReliableTopicProxy(client *HazelcastClient, serviceName string, name str
 		},
 	}
 	proxy.serializationService = client.SerializationService
-	proxy.config = client.ClientConfig.GetReliableTopicConfig(name)
+	proxy.config = client.Config.GetReliableTopicConfig(name)
 	proxy.topicOverLoadPolicy = proxy.config.TopicOverloadPolicy()
 	var err error
 	proxy.ringBuffer, err = client.GetRingbuffer(topicRBPrefix + name)


### PR DESCRIPTION
In `HazelcastClient` struct the name of `config.Config` was ClientConfig but since it is inside `HazelcastClient` it is enough to name if `Config` which is interpreted as `Client Config` from its context.

