### PR TITLE
decrease statistics period time in test

### DIFF
--- a/test/statistics/client_statistics_test.go
+++ b/test/statistics/client_statistics_test.go
@@ -159,7 +159,7 @@ func TestClientStatisticsNonDefaultPeriod(t *testing.T) {
 
 	config := hazelcast.NewConfig()
 	config.SetProperty(property.StatisticsEnabled.Name(), "true")
-	config.SetProperty(property.StatisticsPeriodSeconds.Name(), "6")
+	config.SetProperty(property.StatisticsPeriodSeconds.Name(), "3")
 	client, _ := hazelcast.NewClientWithConfig(config)
 	defer client.Shutdown()
 


### PR DESCRIPTION
In test `TestClientStatisticsNonDefaultPeriod ` the period was set as 6 seconds and the waiting time is around 6 seconds so sometimes it cant send the new statistics after 6 seconds. Therefore statistics period is set as 3 so that it will refresh statistics. 