### PR TITLE
try to connect cluster even if the error is authentication error

### DIFF
--- a/internal/cluster.go
+++ b/internal/cluster.go
@@ -165,9 +165,6 @@ func (cs *clusterService) connectToCluster() error {
 			if err != nil {
 				log.Println("The following error occurred while trying to connect to:", address, "in cluster. attempt ",
 					currentAttempt, " of ", attempLimit, " error: ", err)
-				if _, ok := err.(*core.HazelcastAuthenticationError); ok {
-					return err
-				}
 				continue
 			}
 			return nil

--- a/test/config_test.go
+++ b/test/config_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/hazelcast/hazelcast-go-client"
 	"github.com/hazelcast/hazelcast-go-client/config"
-	"github.com/hazelcast/hazelcast-go-client/core"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -32,9 +31,7 @@ func TestSetGroupConfig(t *testing.T) {
 	groupCfg.SetPassword("wrongPassword")
 	cfg.SetGroupConfig(groupCfg)
 	client, err := hazelcast.NewClientWithConfig(cfg)
-	if _, ok := err.(*core.HazelcastAuthenticationError); !ok {
-		t.Fatal("client should have returned an authentication error")
-	}
+	assert.Error(t, err)
 	client.Shutdown()
 	remoteController.ShutdownCluster(cluster.ID)
 }


### PR DESCRIPTION
When client gets an authentication error while trying to connect to cluster
it stops trying connecting. This behavior does not exist in Java and it should
keep trying connecting.