### PR TITLE
Refactor connection manager

### DIFF
--- a/internal/connection_manager.go
+++ b/internal/connection_manager.go
@@ -226,8 +226,7 @@ func (cm *connectionManagerImpl) shouldAuthenticateConn(asOwner bool, conn *Conn
 }
 
 func (cm *connectionManagerImpl) NextConnectionID() int64 {
-	cm.nextConnectionID = cm.nextConnectionID + 1
-	return cm.nextConnectionID
+	return atomic.AddInt64(&cm.nextConnectionID, 1)
 }
 
 func (cm *connectionManagerImpl) encodeAuthenticationRequest(asOwner bool) *proto.ClientMessage {


### PR DESCRIPTION
This PR refactors connection manager for better readability and maintainability.

It also fixes a defect in `nextConnectionID`, which wouldnt increment the next connection ID atomically. 
