### PR TITLE
Shutdown leftover clients in tests

### DIFF
--- a/test/client_authentication_test.go
+++ b/test/client_authentication_test.go
@@ -65,8 +65,9 @@ func TestCustomAuthenticationWithInvalidPassword(t *testing.T) {
 		),
 	})
 
-	_, err := hazelcast.NewClientWithConfig(cfg)
+	client, err := hazelcast.NewClientWithConfig(cfg)
 	assert.NoError(t, err)
+	client.Shutdown()
 }
 
 func TestCustomAuthenticationWithInvalidUsername(t *testing.T) {

--- a/test/client_test.go
+++ b/test/client_test.go
@@ -284,6 +284,7 @@ func TestHazelcastError_ServerError(t *testing.T) {
 	cfg := hazelcast.NewConfig()
 	cfg.SetProperty(property.InvocationTimeoutSeconds.Name(), "5")
 	client, _ := hazelcast.NewClientWithConfig(cfg)
+	defer client.Shutdown()
 	counter, _ := client.GetPNCounter("myPNCounter")
 	var delta int64 = 5
 	counter.GetAndAdd(delta)

--- a/test/proxy/pncounter/pn_counter_test.go
+++ b/test/proxy/pncounter/pn_counter_test.go
@@ -213,6 +213,7 @@ func TestPNCounter_HazelcastConsistencyLostError(t *testing.T) {
 	cfg := hazelcast.NewConfig()
 	cfg.SetProperty(property.InvocationTimeoutSeconds.Name(), "5")
 	client, _ = hazelcast.NewClientWithConfig(cfg)
+	defer client.Shutdown()
 	counter, _ = client.GetPNCounter(counterName)
 	var delta int64 = 5
 	counter.GetAndAdd(delta)
@@ -234,6 +235,7 @@ func TestPNCounter_Reset(t *testing.T) {
 	cfg := hazelcast.NewConfig()
 	cfg.SetProperty(property.InvocationTimeoutSeconds.Name(), "5")
 	client, _ = hazelcast.NewClientWithConfig(cfg)
+	defer client.Shutdown()
 	counter, _ = client.GetPNCounter(counterName)
 	var delta int64 = 5
 	counter.GetAndAdd(delta)

--- a/test/proxy/reliabletopic/reliable_topic_test.go
+++ b/test/proxy/reliabletopic/reliable_topic_test.go
@@ -371,6 +371,7 @@ func TestReliableTopicProxy_DistributedObjectDestroyed(t *testing.T) {
 	config.NetworkConfig().SetConnectionAttemptLimit(10)
 	config.SetProperty(property.InvocationTimeoutSeconds.Name(), "10")
 	client2, _ := hazelcast.NewClientWithConfig(config)
+	defer client2.Shutdown()
 	reliableTopic, _ := client2.GetReliableTopic("x")
 	var wg = new(sync.WaitGroup)
 	wg.Add(1)

--- a/test/ssl/client_ssl_authentication_test.go
+++ b/test/ssl/client_ssl_authentication_test.go
@@ -264,8 +264,9 @@ func TestSSL_OnlyServerName(t *testing.T) {
 	sslConfig := config.NetworkConfig().SSLConfig()
 	sslConfig.SetEnabled(true)
 	sslConfig.ServerName = "member1.hazelcast-test.download"
-	_, err = hazelcast.NewClientWithConfig(config)
+	client, err := hazelcast.NewClientWithConfig(config)
 	assert.NoError(t, err)
+	client.Shutdown()
 }
 
 func TestSSL_NoServerName(t *testing.T) {


### PR DESCRIPTION
This PR shutdowns leftover clients in tests. They might cause some failure in the future.