### PR TITLE
explicitly close socket in shutdown

### DIFF
--- a/internal/connection.go
+++ b/internal/connection.go
@@ -232,6 +232,7 @@ func (c *Connection) close(err error) {
 	}
 	c.logger.Warn("Connection :", c, " closed, err: ", err)
 	close(c.closed)
+	c.socket.Close()
 	c.closedTime.Store(time.Now())
 	c.connectionManager.onConnectionClose(c, core.NewHazelcastTargetDisconnectedError(err.Error(), err))
 }


### PR DESCRIPTION
https://github.com/hazelcast/hazelcast-go-client/issues/242#issuecomment-456368219

This PR closes sockets properly in case of a close signal. Unclosed sockets could block ports or consume open file descriptor count, so this could be a problem.