### PR TITLE
Enhance tests in ringbuffer and remove unnecessary error from proxies

### DIFF
--- a/internal/list.go
+++ b/internal/list.go
@@ -23,12 +23,9 @@ type listProxy struct {
 	*partitionSpecificProxy
 }
 
-func newListProxy(client *HazelcastClient, serviceName string, name string) (*listProxy, error) {
-	parSpecProxy, err := newPartitionSpecificProxy(client, serviceName, name)
-	if err != nil {
-		return nil, err
-	}
-	return &listProxy{parSpecProxy}, nil
+func newListProxy(client *HazelcastClient, serviceName string, name string) *listProxy {
+	parSpecProxy := newPartitionSpecificProxy(client, serviceName, name)
+	return &listProxy{parSpecProxy}
 }
 
 func (lp *listProxy) Add(element interface{}) (changed bool, err error) {

--- a/internal/map.go
+++ b/internal/map.go
@@ -28,8 +28,8 @@ type mapProxy struct {
 	*proxy
 }
 
-func newMapProxy(client *HazelcastClient, serviceName string, name string) (*mapProxy, error) {
-	return &mapProxy{&proxy{client, serviceName, name}}, nil
+func newMapProxy(client *HazelcastClient, serviceName string, name string) *mapProxy {
+	return &mapProxy{&proxy{client, serviceName, name}}
 }
 
 func (mp *mapProxy) Put(key interface{}, value interface{}) (oldValue interface{}, err error) {

--- a/internal/multi_map.go
+++ b/internal/multi_map.go
@@ -28,8 +28,8 @@ type multiMapProxy struct {
 	*proxy
 }
 
-func newMultiMapProxy(client *HazelcastClient, serviceName string, name string) (*multiMapProxy, error) {
-	return &multiMapProxy{&proxy{client, serviceName, name}}, nil
+func newMultiMapProxy(client *HazelcastClient, serviceName string, name string) *multiMapProxy {
+	return &multiMapProxy{&proxy{client, serviceName, name}}
 }
 
 func (mmp *multiMapProxy) Put(key interface{}, value interface{}) (increased bool, err error) {

--- a/internal/pn_counter.go
+++ b/internal/pn_counter.go
@@ -36,14 +36,14 @@ type pnCounterProxy struct {
 	random                      *rand.Rand
 }
 
-func newPNCounterProxy(client *HazelcastClient, serviceName string, name string) (*pnCounterProxy, error) {
+func newPNCounterProxy(client *HazelcastClient, serviceName string, name string) *pnCounterProxy {
 	pn := &pnCounterProxy{
 		proxy:          &proxy{client, serviceName, name},
 		emptyAddresses: make(map[core.Address]struct{}),
 	}
 	atomic.StorePointer(&pn.observedClock, unsafe.Pointer(newVectorClock()))
 	pn.random = rand.New(rand.NewSource(time.Now().UnixNano()))
-	return pn, nil
+	return pn
 }
 
 func (pn *pnCounterProxy) Get() (currentValue int64, err error) {

--- a/internal/proxy.go
+++ b/internal/proxy.go
@@ -246,11 +246,10 @@ type partitionSpecificProxy struct {
 	partitionID int32
 }
 
-func newPartitionSpecificProxy(client *HazelcastClient, serviceName string, name string) (*partitionSpecificProxy, error) {
-	var err error
+func newPartitionSpecificProxy(client *HazelcastClient, serviceName string, name string) *partitionSpecificProxy {
 	parSpecProxy := &partitionSpecificProxy{proxy: &proxy{client, serviceName, name}}
-	parSpecProxy.partitionID, err = parSpecProxy.client.PartitionService.GetPartitionIDWithKey(parSpecProxy.PartitionKey())
-	return parSpecProxy, err
+	parSpecProxy.partitionID, _ = parSpecProxy.client.PartitionService.GetPartitionIDWithKey(parSpecProxy.PartitionKey())
+	return parSpecProxy
 
 }
 

--- a/internal/proxy_manager.go
+++ b/internal/proxy_manager.go
@@ -100,25 +100,25 @@ func (pm *proxyManager) findNextProxyAddress() core.Address {
 
 func (pm *proxyManager) getProxyByNameSpace(serviceName string, name string) (core.DistributedObject, error) {
 	if bufutil.ServiceNameMap == serviceName {
-		return newMapProxy(pm.client, serviceName, name)
+		return newMapProxy(pm.client, serviceName, name), nil
 	} else if bufutil.ServiceNameList == serviceName {
-		return newListProxy(pm.client, serviceName, name)
+		return newListProxy(pm.client, serviceName, name), nil
 	} else if bufutil.ServiceNameSet == serviceName {
-		return newSetProxy(pm.client, serviceName, name)
+		return newSetProxy(pm.client, serviceName, name), nil
 	} else if bufutil.ServiceNameTopic == serviceName {
-		return newTopicProxy(pm.client, serviceName, name)
+		return newTopicProxy(pm.client, serviceName, name), nil
 	} else if bufutil.ServiceNameMultiMap == serviceName {
-		return newMultiMapProxy(pm.client, serviceName, name)
+		return newMultiMapProxy(pm.client, serviceName, name), nil
 	} else if bufutil.ServiceNameReplicatedMap == serviceName {
-		return newReplicatedMapProxy(pm.client, serviceName, name)
+		return newReplicatedMapProxy(pm.client, serviceName, name), nil
 	} else if bufutil.ServiceNameQueue == serviceName {
-		return newQueueProxy(pm.client, serviceName, name)
+		return newQueueProxy(pm.client, serviceName, name), nil
 	} else if bufutil.ServiceNameRingbufferService == serviceName {
-		return newRingbufferProxy(pm.client, serviceName, name)
+		return newRingbufferProxy(pm.client, serviceName, name), nil
 	} else if bufutil.ServiceNamePNCounter == serviceName {
-		return newPNCounterProxy(pm.client, serviceName, name)
+		return newPNCounterProxy(pm.client, serviceName, name), nil
 	} else if bufutil.ServiceNameIDGenerator == serviceName {
-		return newFlakeIDGenerator(pm.client, serviceName, name)
+		return newFlakeIDGenerator(pm.client, serviceName, name), nil
 	} else if bufutil.ServiceNameReliableTopic == serviceName {
 		return newReliableTopicProxy(pm.client, serviceName, name)
 	}

--- a/internal/queue.go
+++ b/internal/queue.go
@@ -28,12 +28,9 @@ type queueProxy struct {
 	*partitionSpecificProxy
 }
 
-func newQueueProxy(client *HazelcastClient, serviceName string, name string) (*queueProxy, error) {
-	parSpecProxy, err := newPartitionSpecificProxy(client, serviceName, name)
-	if err != nil {
-		return nil, err
-	}
-	return &queueProxy{parSpecProxy}, nil
+func newQueueProxy(client *HazelcastClient, serviceName string, name string) *queueProxy {
+	parSpecProxy := newPartitionSpecificProxy(client, serviceName, name)
+	return &queueProxy{parSpecProxy}
 }
 
 func (qp *queueProxy) AddAll(items []interface{}) (changed bool, err error) {

--- a/internal/replicated_map.go
+++ b/internal/replicated_map.go
@@ -30,10 +30,10 @@ type replicatedMapProxy struct {
 	tarGetPartitionID int32
 }
 
-func newReplicatedMapProxy(client *HazelcastClient, serviceName string, name string) (*replicatedMapProxy, error) {
+func newReplicatedMapProxy(client *HazelcastClient, serviceName string, name string) *replicatedMapProxy {
 	partitionCount := client.PartitionService.getPartitionCount()
 	tarGetPartitionID := rand.Int31n(partitionCount)
-	return &replicatedMapProxy{proxy: &proxy{client, serviceName, name}, tarGetPartitionID: tarGetPartitionID}, nil
+	return &replicatedMapProxy{proxy: &proxy{client, serviceName, name}, tarGetPartitionID: tarGetPartitionID}
 }
 
 func (rmp *replicatedMapProxy) Put(key interface{}, value interface{}) (oldValue interface{}, err error) {

--- a/internal/ringbuffer.go
+++ b/internal/ringbuffer.go
@@ -28,12 +28,9 @@ type ringbufferProxy struct {
 	capacity int64
 }
 
-func newRingbufferProxy(client *HazelcastClient, serviceName string, name string) (*ringbufferProxy, error) {
-	parSpecProxy, err := newPartitionSpecificProxy(client, serviceName, name)
-	if err != nil {
-		return nil, err
-	}
-	return &ringbufferProxy{parSpecProxy, -1}, nil
+func newRingbufferProxy(client *HazelcastClient, serviceName string, name string) *ringbufferProxy {
+	parSpecProxy := newPartitionSpecificProxy(client, serviceName, name)
+	return &ringbufferProxy{parSpecProxy, -1}
 }
 
 func (rp *ringbufferProxy) Capacity() (capacity int64, err error) {
@@ -182,7 +179,7 @@ func (rs *LazyReadResultSet) Get(index int32) (result interface{}, err error) {
 
 func (rs *LazyReadResultSet) Sequence(index int32) (sequence int64, err error) {
 	if rs.itemSequences == nil {
-		return sequenceUnavailable, nil
+		return sequenceUnavailable, core.NewHazelcastIllegalStateError("sequence unavailable", nil)
 	}
 	if err = rs.rangeCheck(index); err != nil {
 		return

--- a/internal/ringbuffer_test.go
+++ b/internal/ringbuffer_test.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"testing"
+
+	"github.com/hazelcast/hazelcast-go-client/serialization"
+	"github.com/hazelcast/hazelcast-go-client/serialization/spi"
+	"github.com/hazelcast/hazelcast-go-client/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLazyReadResultSet_GetNonDeserializableDataSlice(t *testing.T) {
+	service, _ := spi.NewSerializationService(serialization.NewConfig())
+	lazyset := NewLazyReadResultSet(0, test.NewNonDeserializableDataSlice(), nil, service)
+	_, err := lazyset.Get(0)
+	assert.Error(t, err)
+}
+
+func TestLazyReadResultSet_SequenceWhenNotReady(t *testing.T) {
+	service, _ := spi.NewSerializationService(serialization.NewConfig())
+	lazyset := NewLazyReadResultSet(0, nil, nil, service)
+	_, err := lazyset.Sequence(0)
+	assert.Error(t, err)
+}

--- a/internal/set.go
+++ b/internal/set.go
@@ -23,12 +23,9 @@ type setProxy struct {
 	*partitionSpecificProxy
 }
 
-func newSetProxy(client *HazelcastClient, serviceName string, name string) (*setProxy, error) {
-	parSpecProxy, err := newPartitionSpecificProxy(client, serviceName, name)
-	if err != nil {
-		return nil, err
-	}
-	return &setProxy{parSpecProxy}, nil
+func newSetProxy(client *HazelcastClient, serviceName string, name string) *setProxy {
+	parSpecProxy := newPartitionSpecificProxy(client, serviceName, name)
+	return &setProxy{parSpecProxy}
 }
 
 func (sp *setProxy) Add(item interface{}) (added bool, err error) {

--- a/internal/topic.go
+++ b/internal/topic.go
@@ -24,12 +24,9 @@ type topicProxy struct {
 	*partitionSpecificProxy
 }
 
-func newTopicProxy(client *HazelcastClient, serviceName string, name string) (*topicProxy, error) {
-	parSpecProxy, err := newPartitionSpecificProxy(client, serviceName, name)
-	if err != nil {
-		return nil, err
-	}
-	return &topicProxy{parSpecProxy}, nil
+func newTopicProxy(client *HazelcastClient, serviceName string, name string) *topicProxy {
+	parSpecProxy := newPartitionSpecificProxy(client, serviceName, name)
+	return &topicProxy{parSpecProxy}
 }
 
 func (tp *topicProxy) AddMessageListener(messageListener core.MessageListener) (registrationID string, err error) {

--- a/test/proxy/ringbuffer/ringbuffer_test.go
+++ b/test/proxy/ringbuffer/ringbuffer_test.go
@@ -93,6 +93,12 @@ func TestRingbufferProxy_Add(t *testing.T) {
 	assert.Equalf(t, "value", item, "ringbuffer Add() failed")
 }
 
+func TestRingbufferProxy_AddNonSerializable(t *testing.T) {
+	defer destroyAndCreate()
+	_, err := ringbuffer.Add(test.NewNonSerializableObject(), core.OverflowPolicyOverwrite)
+	require.Error(t, err)
+}
+
 func TestRingbufferProxy_Size(t *testing.T) {
 	defer destroyAndCreate()
 	items := make([]interface{}, capacity)
@@ -152,6 +158,12 @@ func TestRingbufferProxy_AddAll(t *testing.T) {
 	assert.Equalf(t, capacity-1, lastSequence, "ringbuffer AddAll() failed")
 }
 
+func TestRingbufferProxy_AddAllNonSerializable(t *testing.T) {
+	defer destroyAndCreate()
+	_, err := ringbuffer.AddAll(test.NewNonSerializableObjectSlice(), core.OverflowPolicyFail)
+	require.Error(t, err)
+}
+
 func TestRingbufferProxy_AddAllWhenFull(t *testing.T) {
 	defer destroyAndCreate()
 	items := make([]interface{}, capacity*2)
@@ -205,6 +217,24 @@ func TestRingbufferProxy_ReadMany(t *testing.T) {
 	}
 }
 
+func TestRingbufferProxy_ReadMany_NonSerializableFilter(t *testing.T) {
+	defer destroyAndCreate()
+	_, err := ringbuffer.ReadMany(0, 0, 0, test.NewNonSerializableObject())
+	assert.Error(t, err)
+}
+
+func TestRingbufferProxy_ReadOne_NegativeSequence(t *testing.T) {
+	defer destroyAndCreate()
+	_, err := ringbuffer.ReadOne(-1)
+	assert.Error(t, err)
+}
+
+func TestRingbufferProxy_ReadMany_NegativeSequence(t *testing.T) {
+	defer destroyAndCreate()
+	_, err := ringbuffer.ReadMany(-1, 0, 0, nil)
+	assert.Error(t, err)
+}
+
 func TestRingbufferProxy_ReadMany_MinLargerThanMax(t *testing.T) {
 	_, err := ringbuffer.ReadMany(0, 2, 0, nil)
 	require.Errorf(t, err, "ringbuffer ReadMany() failed")
@@ -215,7 +245,7 @@ func TestRingbufferProxy_ReadMany_MinNegative(t *testing.T) {
 	require.Errorf(t, err, "ringbuffer ReadMany() failed")
 }
 
-func TestRingbufferProxy_ReadMany_ResulSetWithFilter(t *testing.T) {
+func TestRingbufferProxy_ReadMany_ResultSetWithFilter(t *testing.T) {
 	defer destroyAndCreate()
 	fillRingbuffer(capacity)
 	var expectedValue int64 = 2
@@ -226,7 +256,7 @@ func TestRingbufferProxy_ReadMany_ResulSetWithFilter(t *testing.T) {
 	assert.Equalf(t, retValue.(int64), expectedValue, "ringbuffer ReadMany() failed")
 }
 
-func TestRingbufferProxy_ReadMany_ResulSet_Get(t *testing.T) {
+func TestRingbufferProxy_ReadMany_ResultSet_Get(t *testing.T) {
 	defer destroyAndCreate()
 	fillRingbuffer(capacity)
 	var expectedValue int64 = 2
@@ -237,7 +267,7 @@ func TestRingbufferProxy_ReadMany_ResulSet_Get(t *testing.T) {
 	assert.Equalf(t, retValue.(int64), expectedValue, "ringbuffer ReadMany() failed")
 }
 
-func TestRingbufferProxy_ReadMany_ResulSet_GetWithIllegalIndex(t *testing.T) {
+func TestRingbufferProxy_ReadMany_ResultSet_GetWithIllegalIndex(t *testing.T) {
 	defer destroyAndCreate()
 	fillRingbuffer(capacity)
 	resultSet, err := ringbuffer.ReadMany(0, 3, 3, nil)
@@ -246,7 +276,7 @@ func TestRingbufferProxy_ReadMany_ResulSet_GetWithIllegalIndex(t *testing.T) {
 	require.Errorf(t, err, "ringbuffer ReadMany() failed")
 }
 
-func TestRingbufferProxy_ReadMany_ResulSet_Sequence(t *testing.T) {
+func TestRingbufferProxy_ReadMany_ResultSet_Sequence(t *testing.T) {
 	defer destroyAndCreate()
 	fillRingbuffer(capacity)
 	var expectedValue int64 = 4
@@ -257,7 +287,7 @@ func TestRingbufferProxy_ReadMany_ResulSet_Sequence(t *testing.T) {
 	assert.Equalf(t, retValue, expectedValue, "ringbuffer ReadMany() failed")
 }
 
-func TestRingbufferProxy_ReadMany_ResulSet_SequenceWithIllegalIndex(t *testing.T) {
+func TestRingbufferProxy_ReadMany_ResultSet_SequenceWithIllegalIndex(t *testing.T) {
 	defer destroyAndCreate()
 	fillRingbuffer(capacity)
 	resultSet, err := ringbuffer.ReadMany(0, 3, 3, nil)
@@ -266,7 +296,7 @@ func TestRingbufferProxy_ReadMany_ResulSet_SequenceWithIllegalIndex(t *testing.T
 	require.Errorf(t, err, "ringbuffer ReadMany() failed")
 }
 
-func TestRingbufferProxy_ReadMany_ResulSet_Size(t *testing.T) {
+func TestRingbufferProxy_ReadMany_ResultSet_Size(t *testing.T) {
 	defer destroyAndCreate()
 	fillRingbuffer(capacity)
 	var expectedValue int32 = 5
@@ -276,7 +306,7 @@ func TestRingbufferProxy_ReadMany_ResulSet_Size(t *testing.T) {
 	assert.Equalf(t, retValue, expectedValue, "ringbuffer ReadMany() failed")
 }
 
-func TestRingbufferProxy_ReadMany_ResulSet_ReadCount(t *testing.T) {
+func TestRingbufferProxy_ReadMany_ResultSet_ReadCount(t *testing.T) {
 	defer destroyAndCreate()
 	fillRingbuffer(capacity)
 	var expectedValue int32 = 5


### PR DESCRIPTION
This PR enhances ring buffer tests.

It also removes unnecessary error in partition specific proxies. Since the name of proxies is the `string` type, serialization wont return an error. So we can ignore the error.