### PR TITLE
Change port type from int32 to int

### DIFF
--- a/internal/discovery/hazelcast_cloud_discovery.go
+++ b/internal/discovery/hazelcast_cloud_discovery.go
@@ -118,7 +118,7 @@ func (hzC *HazelcastCloud) parseResponse(response *http.Response) (map[string]co
 		publicAddress := hzC.createAddress(addr.PublicAddr)
 		// TODO:: what if privateAddress is not okay ?
 		// TODO:: use addressProvider
-		privateAddress := proto.NewAddressWithParameters(addr.PrivAddr, int32(publicAddress.Port()))
+		privateAddress := proto.NewAddressWithParameters(addr.PrivAddr, publicAddress.Port())
 		privateToPublicAddrs[privateAddress.String()] = publicAddress
 	}
 

--- a/internal/proto/core.go
+++ b/internal/proto/core.go
@@ -29,10 +29,10 @@ import (
 
 type Address struct {
 	host string
-	port int32
+	port int
 }
 
-func NewAddressWithParameters(Host string, Port int32) *Address {
+func NewAddressWithParameters(Host string, Port int) *Address {
 	return &Address{Host, Port}
 }
 

--- a/internal/proto/custom_codec.go
+++ b/internal/proto/custom_codec.go
@@ -21,13 +21,13 @@ Address Codec
 */
 func AddressCodecEncode(msg *ClientMessage, address *Address) {
 	msg.AppendString(address.host)
-	msg.AppendInt32(address.port)
+	msg.AppendInt32(int32(address.port))
 }
 
 func AddressCodecDecode(msg *ClientMessage) *Address {
 	host := msg.ReadString()
 	port := msg.ReadInt32()
-	return &Address{host, port}
+	return &Address{host, int(port)}
 }
 
 /*

--- a/internal/proto/custom_codec_test.go
+++ b/internal/proto/custom_codec_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestAddressCodecEncodeDecode(t *testing.T) {
 	host := "test-host"
-	var port int32 = 8080
+	var port = 8080
 	address := Address{host, port}
 	msg := NewClientMessage(nil, addressCalculateSize(&address))
 	AddressCodecEncode(msg, &address)

--- a/internal/util/iputil/util.go
+++ b/internal/util/iputil/util.go
@@ -29,7 +29,7 @@ func IsValidIPAddress(addr string) bool {
 	return net.ParseIP(addr) != nil
 }
 
-func GetIPAndPort(addr string) (string, int32) {
+func GetIPAndPort(addr string) (string, int) {
 	var port int
 	var err error
 	parts := strings.Split(addr, ":")
@@ -42,7 +42,7 @@ func GetIPAndPort(addr string) (string, int32) {
 		port = -1
 	}
 	addr = parts[0]
-	return addr, int32(port)
+	return addr, port
 }
 
 // NewUUID generates a random uuid according to RFC 4122

--- a/internal/util/iputil/util_test.go
+++ b/internal/util/iputil/util_test.go
@@ -38,7 +38,7 @@ func TestGetIpAndPort(t *testing.T) {
 
 func TestGetIpAndInvalidPort(t *testing.T) {
 	testAddress := "121.1.23.3:aa"
-	if ip, port := GetIPAndPort(testAddress); ip != "121.1.23.3" || port != int32(defaultPort) {
+	if ip, port := GetIPAndPort(testAddress); ip != "121.1.23.3" || port != defaultPort {
 		t.Fatal("GetIPAndPort failed.")
 	}
 }

--- a/test/client/cluster_test.go
+++ b/test/client/cluster_test.go
@@ -179,7 +179,7 @@ func TestGetMember(t *testing.T) {
 	member1, _ := remoteController.StartMember(cluster.ID)
 	member2, _ := remoteController.StartMember(cluster.ID)
 	client, _ := hazelcast.NewClient()
-	address := proto.NewAddressWithParameters(member1.GetHost(), int32(member1.GetPort()))
+	address := proto.NewAddressWithParameters(member1.GetHost(), int(member1.GetPort()))
 	member := client.(*internal.HazelcastClient).ClusterService.GetMember(address)
 	assert.Equalf(t, member.UUID(), member1.GetUUID(), "GetMember returned wrong member")
 	client.Shutdown()


### PR DESCRIPTION
Port method of Address interface returns `int`. Internally it was `int32`, This PR changes it to `int`.