### PR TITLE
Collect RLimit for only linux and darwin

### DIFF
--- a/internal/statistics.go
+++ b/internal/statistics.go
@@ -26,8 +26,6 @@ import (
 
 	"time"
 
-	"syscall"
-
 	"github.com/hazelcast/hazelcast-go-client/config/property"
 	"github.com/hazelcast/hazelcast-go-client/internal/proto"
 	"github.com/hazelcast/hazelcast-go-client/internal/util/timeutil"
@@ -148,14 +146,6 @@ func (s *statistics) collectRuntimeMetrics(stats *bytes.Buffer) {
 	s.addStat(stats, "runtime.freeMemory", strconv.Itoa(int(m.HeapIdle)))
 	s.addStat(stats, "runtime.totalMemory", strconv.Itoa(int(m.HeapSys)))
 	s.addStat(stats, "runtime.usedMemory", strconv.Itoa(int(m.HeapInuse)))
-}
-
-func (s *statistics) collectOSMetrics(stats *bytes.Buffer) {
-	var limit syscall.Rlimit
-	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &limit); err == nil {
-		s.addStat(stats, "os.maxFileDescriptorCount", strconv.Itoa(int(limit.Max)))
-		s.addStat(stats, "os.openFileDescriptorCount", strconv.Itoa(int(limit.Cur)))
-	}
 }
 
 func (s *statistics) addStat(stats *bytes.Buffer, name string, value interface{}) {

--- a/internal/statistics_osmetric.go
+++ b/internal/statistics_osmetric.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux darwin
+
+package internal
+
+import (
+	"bytes"
+	"strconv"
+	"syscall"
+)
+
+func (s *statistics) collectOSMetrics(stats *bytes.Buffer) {
+	var limit syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &limit); err == nil {
+		s.addStat(stats, "os.maxFileDescriptorCount", strconv.Itoa(int(limit.Max)))
+		s.addStat(stats, "os.openFileDescriptorCount", strconv.Itoa(int(limit.Cur)))
+	}
+}

--- a/internal/statistics_other.go
+++ b/internal/statistics_other.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !darwin
+// +build !linux
+
+package internal
+
+import (
+	"bytes"
+)
+
+func (s *statistics) collectOSMetrics(stats *bytes.Buffer) {
+}


### PR DESCRIPTION
RLimit metric was collected under all os. This causes compilation issues for os such as windows. This PR adds linux and darwin tags for RLimit so that the code will compile successfully for windows and other os. For os other than linux and darwin, RLimit is not sent to the server.

fixes #439.