### PR TITLE
Remove missing linters from gometalinter

### DIFF
--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -32,14 +32,12 @@
     "gofmt",
     "goimports",
     "golint",
-    "gosimple",
     "ineffassign",
     "interfacer",
     "lll",
     "misspell",
     "unconvert",
     "unparam",
-    "unused",
     "vet"
   ],
   "LineLength": 130

--- a/test/testutil/util.go
+++ b/test/testutil/util.go
@@ -28,7 +28,10 @@ import (
 )
 
 const (
-	Timeout      = 1 * time.Minute
+	// Timeout is timeout for tests with waitgroup.
+	Timeout = 1 * time.Minute
+
+	// TimeoutShort is the timeout for tests with waitgroup that should timeout.
 	TimeoutShort = Timeout / 20
 )
 


### PR DESCRIPTION
`gosimple` and `unused` are not supported. We probably need to lock the gometalinter version to prevent changes that are not backward compatible. 