### PR TITLE
Json API update

### DIFF
--- a/README.md
+++ b/README.md
@@ -795,11 +795,13 @@ core.CreateHazelcastJSONValueFromString{yourObject}
 
 No JSON parsing is performed but it is your responsibility to provide correctly formatted JSON strings. The client will not validate the string, and it will send it to the cluster as it is. If you submit incorrectly formatted JSON strings and, later, if you query those objects, it is highly possible that you will get formatting errors since the server will fail to deserialize or find the query fields.
 
-Here is an example of how you can construct a `HazelcastJSON` and put to the map:
+Here is an example of how you can construct a `HazelcastJSONValue` and put to the map:
 
 ```go
-mp.Put("item1", core.CreateHazelcastJSONValueFromString("{ \"age\": 4 }"))
-mp.Put("item2", core.CreateHazelcastJSONValueFromString("{ \"age\": 20 }"))
+jsonValue1 , _ := core.CreateHazelcastJSONValueFromString("{ \"age\": 4 }")
+mp.Put("item1", jsonValue1)
+jsonValue2 , _ := core.CreateHazelcastJSONValueFromString("{ \"age\": 4 }")
+mp.Put("item2", jsonValue2)
 ```
 
 You can query JSON objects in the cluster using the `Predicate`s of your choice. An example JSON query for querying the values whose age is greater than 6 is shown below:
@@ -822,10 +824,10 @@ type person struct {
 }
 
 
-person1 := person{Age: 20, Name: "Walter"}
-person2 := person{Age: 5, Name: "Mike"}
-mp.Put("item1", core.CreateHazelcastJSONValue(person1))
-mp.Put("item2", core.CreateHazelcastJSONValue(person2))
+person1 , _ := core.CreateHazelcastJSONValue(person{Age: 20, Name: "Walter"})
+person2 , _ := core.CreateHazelcastJSONValue(person{Age: 5, Name: "Mike"})
+mp.Put("item1", person1)
+mp.Put("item2", person2)
 result, _ := mp.ValuesWithPredicate(predicate.GreaterThan("Age", 6))
 var person person
 value := result[0].(*core.HazelcastJSON)
@@ -1958,17 +1960,17 @@ In this example, the code creates a slice with the values greater than or equal 
 #### 7.7.1.4. Querying with JSON Strings
 
 You can query JSON strings stored inside your Hazelcast clusters. To query the JSON string,
-you first need to create a `HazelcastJSON` from the JSON string. You can use ``HazelcastJSON``s both as keys and values in the distributed data structures. Then, it is
+you first need to create a `HazelcastJSONValue` from the JSON string. You can use ``HazelcastJSONValue``s both as keys and values in the distributed data structures. Then, it is
 possible to query these objects using the Hazelcast query methods explained in this section.
 
 ```go
-person1 := "{ \"name\": \"John\", \"age\": 35 }"
-person2 := "{ \"name\": \"Jane\", \"age\": 24 }"
-person3 := "{ \"name\": \"Trey\", \"age\": 17 }"
+person1 , _ := core.CreateHazelcastJSONValueFromString{"{ \"name\": \"John\", \"age\": 35 }"}
+person2 , _ := core.CreateHazelcastJSONValueFromString{"{ \"name\": \"Jane\", \"age\": 24 }"}
+person3 , _ := core.CreateHazelcastJSONValueFromString{"{ \"name\": \"Trey\", \"age\": 17 }"}
 
-mp.Put(1, core.HazelcastJSON{JSONString: []byte(person1)})
-mp.Put(2, core.HazelcastJSON{JSONString: []byte(person2)})
-mp.Put(3, core.HazelcastJSON{JSONString: []byte(person3)})
+mp.Put(1, person1)
+mp.Put(2, person2)
+mp.Put(3, person3)
 
 peopleUnder21, _ := mp.ValuesWithPredicate(predicate.LessThan("age", 21))
 ```
@@ -2011,7 +2013,7 @@ departmentWithPeter, _  := departments.values(predicate.Equal("people[any].name"
 
 ```
 
-`HazelcastJSON` is a lightweight wrapper around your JSON strings. It is used merely as a way to indicate
+`HazelcastJSONValue` is a lightweight wrapper around your JSON strings. It is used merely as a way to indicate
 that the contained string should be treated as a valid JSON value. Hazelcast does not check the validity of JSON
 strings put into to the maps. Putting an invalid JSON string into a map is permissible. However, in that case
 whether such an entry is going to be returned or not from a query is not defined.

--- a/core/api.go
+++ b/core/api.go
@@ -16,6 +16,7 @@
 package core
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 )
@@ -294,7 +295,6 @@ type ItemRemovedListener interface {
 // only the operations that are not key based will be routed to the endpoint returned by the LoadBalancer.
 // If the client is not smart routing, LoadBalancer will not be used.
 type LoadBalancer interface {
-
 	// Init initializes LoadBalancer with the given cluster.
 	// The given cluster is used to select members.
 	Init(cluster Cluster)
@@ -304,10 +304,26 @@ type LoadBalancer interface {
 	Next() Member
 }
 
-// HazelcastJSON is a wrapper for json byte array.
+// HazelcastJSONValue is a wrapper for json byte array.
 // JsonString should be a valid json string.
-type HazelcastJSON struct {
-	JSONString []byte
+type HazelcastJSONValue struct {
+	jsonString []byte
+}
+
+func CreateHazelcastJSONValueFromString(jsonString string) *HazelcastJSONValue {
+	return &HazelcastJSONValue{[]byte(jsonString)}
+}
+func CreateHazelcastJSONValue(object interface{}) *HazelcastJSONValue {
+	byteArray, _ := json.Marshal(object)
+	return &HazelcastJSONValue{byteArray}
+}
+
+func (h *HazelcastJSONValue) Unmarshal(v interface{}) {
+	json.Unmarshal(h.jsonString, &v)
+}
+
+func (h HazelcastJSONValue) ToString() string {
+	return string(h.jsonString)
 }
 
 // StackTraceElement contains stacktrace information for server side exception.

--- a/internal/listener.go
+++ b/internal/listener.go
@@ -71,8 +71,11 @@ type listenerRegistrationKey struct {
 }
 
 func newListenerService(client *HazelcastClient) *listenerService {
-	service := &listenerService{client: client, register: make(chan *invocation, 1),
-
+	service := &listenerService{
+		client:                                     client,
+		register:                                   make(chan *invocation, 1),
+		cancel:                                     make(chan struct{}),
+		logger:                                     client.logger,
 		registrations:                              make(map[string]map[int64]*eventRegistration),
 		registrationIDToListenerRegistration:       make(map[string]*listenerRegistrationKey),
 		failedRegistrations:                        make(map[int64][]*listenerRegistrationKey),
@@ -85,8 +88,6 @@ func newListenerService(client *HazelcastClient) *listenerService {
 		registerListenerInternalHandleErrorChannel: make(chan registrationIDConnection, 1),
 		registerListenerInitChannel:                make(chan *listenerRegistrationKey),
 		connectToAllMembersChannel:                 make(chan struct{}, 1),
-		cancel: make(chan struct{}),
-		logger: client.logger,
 	}
 	service.client.ConnectionManager.addListener(service)
 	go service.process()

--- a/internal/proxy.go
+++ b/internal/proxy.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hazelcast/hazelcast-go-client/internal/proto"
 	"github.com/hazelcast/hazelcast-go-client/internal/proto/bufutil"
 	"github.com/hazelcast/hazelcast-go-client/internal/util/colutil"
+	"github.com/hazelcast/hazelcast-go-client/internal/util/nilutil"
 	"github.com/hazelcast/hazelcast-go-client/serialization"
 )
 
@@ -57,7 +58,7 @@ func (p *proxy) ServiceName() string {
 }
 
 func (p *proxy) validateAndSerialize(arg1 interface{}) (arg1Data serialization.Data, err error) {
-	if arg1 == nil {
+	if nilutil.IsNil(arg1) {
 		return nil, core.NewHazelcastNilPointerError(bufutil.NilArgIsNotAllowed, nil)
 	}
 	arg1Data, err = p.toData(arg1)
@@ -66,10 +67,7 @@ func (p *proxy) validateAndSerialize(arg1 interface{}) (arg1Data serialization.D
 
 func (p *proxy) validateAndSerialize2(arg1 interface{}, arg2 interface{}) (arg1Data serialization.Data,
 	arg2Data serialization.Data, err error) {
-	if arg1 == nil {
-		return nil, nil, core.NewHazelcastNilPointerError(bufutil.NilArgIsNotAllowed, nil)
-	}
-	if arg2 == nil {
+	if nilutil.IsNil(arg1) || nilutil.IsNil(arg2) {
 		return nil, nil, core.NewHazelcastNilPointerError(bufutil.NilArgIsNotAllowed, nil)
 	}
 	arg1Data, err = p.toData(arg1)
@@ -82,10 +80,7 @@ func (p *proxy) validateAndSerialize2(arg1 interface{}, arg2 interface{}) (arg1D
 
 func (p *proxy) validateAndSerialize3(arg1 interface{}, arg2 interface{}, arg3 interface{}) (arg1Data serialization.Data,
 	arg2Data serialization.Data, arg3Data serialization.Data, err error) {
-	if arg1 == nil {
-		return nil, nil, nil, core.NewHazelcastNilPointerError(bufutil.NilArgIsNotAllowed, nil)
-	}
-	if arg2 == nil || arg3 == nil {
+	if nilutil.IsNil(arg1) || nilutil.IsNil(arg2) || nilutil.IsNil(arg3) {
 		return nil, nil, nil, core.NewHazelcastNilPointerError(bufutil.NilArgIsNotAllowed, nil)
 	}
 	arg1Data, err = p.toData(arg1)
@@ -101,7 +96,7 @@ func (p *proxy) validateAndSerialize3(arg1 interface{}, arg2 interface{}, arg3 i
 }
 
 func (p *proxy) validateAndSerializePredicate(arg1 interface{}) (arg1Data serialization.Data, err error) {
-	if arg1 == nil {
+	if nilutil.IsNil(arg1) {
 		return nil, core.NewHazelcastSerializationError(bufutil.NilPredicateIsNotAllowed, nil)
 	}
 	arg1Data, err = p.toData(arg1)

--- a/internal/util/nilutil/nil_test.go
+++ b/internal/util/nilutil/nil_test.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nilutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsNil(t *testing.T) {
+	assert.True(t, IsNil(nil))
+
+}
+
+func TestIsNil_forValueNil_TypeKnown(t *testing.T) {
+	var pnt *int
+	var i interface{} = pnt
+	assert.True(t, i != nil)
+	assert.True(t, IsNil(i))
+}

--- a/internal/util/nilutil/util.go
+++ b/internal/util/nilutil/util.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under
+
+package nilutil
+
+import "reflect"
+
+// IsNil does proper nil check for interface{} values taken from users
+// "== nil" check for interfaces are not enough
+//when an nil pointer is assigned to interface, it returns false from "== nil" check
+// Example:
+//var pnt *int
+//var inf interface{}
+//inf = pnt
+//fmt.Println(inf == nil) // false
+//fmt.Println(isNil(inf)) // true
+func IsNil(arg interface{}) bool {
+	return arg == nil || (reflect.ValueOf(arg).Kind() == reflect.Ptr) && reflect.ValueOf(arg).IsNil()
+}

--- a/sample/hazelcastJSON/hazelcastJSON.go
+++ b/sample/hazelcastJSON/hazelcastJSON.go
@@ -15,8 +15,6 @@
 package main
 
 import (
-	"encoding/json"
-
 	"fmt"
 
 	"github.com/hazelcast/hazelcast-go-client"
@@ -44,16 +42,16 @@ func main() {
 	person2 := person{
 		Age: 40, Name: "Name2",
 	}
-	jsonStr1, _ := json.Marshal(person1)
-	jsonStr2, _ := json.Marshal(person2)
-	mp.Put("person1", core.HazelcastJSON{JSONString: jsonStr1})
-	mp.Put("person2", core.HazelcastJSON{JSONString: jsonStr2})
+	mp.Put("person1", core.CreateHazelcastJSONValue(person1))
+	mp.Put("person2", core.CreateHazelcastJSONValue(person2))
 
 	greaterEqual := predicate.GreaterThan("Age", int32(35))
 	result, _ := mp.ValuesWithPredicate(greaterEqual)
 
 	var resultPerson person
-	json.Unmarshal(result[0].(core.HazelcastJSON).JSONString, &resultPerson)
+	value := result[0].(*core.HazelcastJSONValue)
+	fmt.Println(value.ToString())
+	value.Unmarshal(&resultPerson)
 	fmt.Println(resultPerson.Age)  // 40
 	fmt.Println(resultPerson.Name) // Name2
 

--- a/sample/hazelcastJSON/hazelcastJSON.go
+++ b/sample/hazelcastJSON/hazelcastJSON.go
@@ -42,8 +42,10 @@ func main() {
 	person2 := person{
 		Age: 40, Name: "Name2",
 	}
-	mp.Put("person1", core.CreateHazelcastJSONValue(person1))
-	mp.Put("person2", core.CreateHazelcastJSONValue(person2))
+	jsonValue1, _ := core.CreateHazelcastJSONValue(person1)
+	mp.Put("person1", jsonValue1)
+	jsonValue2, _ := core.CreateHazelcastJSONValue(person2)
+	mp.Put("person2", jsonValue2)
 
 	greaterEqual := predicate.GreaterThan("Age", int32(35))
 	result, _ := mp.ValuesWithPredicate(greaterEqual)
@@ -56,5 +58,4 @@ func main() {
 	fmt.Println(resultPerson.Name) // Name2
 
 	client.Shutdown()
-
 }

--- a/serialization/internal/default_serializer.go
+++ b/serialization/internal/default_serializer.go
@@ -431,10 +431,11 @@ func (*HazelcastJSONSerializer) ID() (id int32) {
 
 func (*HazelcastJSONSerializer) Read(input serialization.DataInput) (object interface{}, err error) {
 	obj := input.ReadUTF()
-	return core.HazelcastJSON{JSONString: []byte(obj)}, input.Error()
+	return core.CreateHazelcastJSONValueFromString(obj), input.Error()
 }
 
 func (*HazelcastJSONSerializer) Write(output serialization.DataOutput, object interface{}) (err error) {
-	output.WriteUTF(string(object.(core.HazelcastJSON).JSONString))
+	value := object.(*core.HazelcastJSONValue)
+	output.WriteUTF(value.ToString())
 	return nil
 }

--- a/serialization/internal/serialization.go
+++ b/serialization/internal/serialization.go
@@ -186,7 +186,7 @@ func (s *Service) registerDefaultSerializers() error {
 	s.nameToID["[]string"] = ConstantTypeStringArray
 
 	s.registerSerializer(&HazelcastJSONSerializer{})
-	s.nameToID[reflect.TypeOf(core.HazelcastJSON{}).String()] = JSONSerializationType
+	s.nameToID[reflect.TypeOf(&core.HazelcastJSONValue{}).String()] = JSONSerializationType
 
 	s.registerSerializer(&GobSerializer{})
 	s.nameToID["!gob"] = GoGobSerializationType

--- a/test/client/json_test.go
+++ b/test/client/json_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"testing"
+
+	"github.com/hazelcast/hazelcast-go-client/core"
+	"github.com/stretchr/testify/assert"
+)
+
+type person struct {
+	Age  int
+	Name string
+}
+
+func TestHazelcastJsonValue_Nil(t *testing.T) {
+	_, err := core.CreateHazelcastJSONValue(nil)
+	assert.Error(t, err)
+}
+
+func TestHazelcastJsonValue_Chan(t *testing.T) {
+	_, err := core.CreateHazelcastJSONValue(make(chan int))
+	assert.Error(t, err)
+}
+
+func TestHazelcastJsonValue_UnMarshalBack(t *testing.T) {
+	expected := person{
+		Age: 30, Name: "Name1",
+	}
+
+	value, err := core.CreateHazelcastJSONValue(expected)
+	assert.NoError(t, err)
+	var actual person
+	err = value.Unmarshal(&actual)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, actual)
+}

--- a/test/proxy/map/map_test.go
+++ b/test/proxy/map/map_test.go
@@ -922,16 +922,26 @@ func TestHazelcastJsonPut(t *testing.T) {
 	}
 
 	for _, currentPerson := range testCases {
-		_, err := mp.Put("key", core.CreateHazelcastJSONValue(currentPerson))
+		value, _ := core.CreateHazelcastJSONValue(currentPerson)
+		_, err := mp.Put("key", value)
 		assert.NoError(t, err)
 		jsonValue, err := mp.Get("key")
 		assert.NoError(t, err)
 		var result person
-		jsonValue.(core.HazelcastJSONValue).Unmarshal(&result)
+		jsonValue.(*core.HazelcastJSONValue).Unmarshal(&result)
 		assert.Equal(t, currentPerson.Age, result.Age)
 		assert.Equal(t, currentPerson.Name, result.Name)
 	}
 
+}
+
+func TestHazelcastNilPut(t *testing.T) {
+	_, err := mp.Put("key", nil)
+	assert.Error(t, err)
+
+	var pnt *int
+	_, err = mp.Put("key", pnt)
+	assert.Error(t, err)
 }
 
 func TestMapProxy_AddEntryListenerAdded(t *testing.T) {

--- a/test/proxy/map/map_test.go
+++ b/test/proxy/map/map_test.go
@@ -32,8 +32,6 @@ import (
 	"github.com/hazelcast/hazelcast-go-client/test/testutil"
 	"github.com/stretchr/testify/assert"
 
-	"encoding/json"
-
 	"github.com/stretchr/testify/require"
 )
 
@@ -924,14 +922,12 @@ func TestHazelcastJsonPut(t *testing.T) {
 	}
 
 	for _, currentPerson := range testCases {
-		jsonStr, _ := json.Marshal(currentPerson)
-		_, err := mp.Put("key", core.HazelcastJSON{JSONString: jsonStr})
+		_, err := mp.Put("key", core.CreateHazelcastJSONValue(currentPerson))
 		assert.NoError(t, err)
 		jsonValue, err := mp.Get("key")
 		assert.NoError(t, err)
 		var result person
-		err = json.Unmarshal(jsonValue.(core.HazelcastJSON).JSONString, &result)
-		assert.NoError(t, err)
+		jsonValue.(core.HazelcastJSONValue).Unmarshal(&result)
 		assert.Equal(t, currentPerson.Age, result.Age)
 		assert.Equal(t, currentPerson.Name, result.Name)
 	}

--- a/test/proxy/map/predicates_test.go
+++ b/test/proxy/map/predicates_test.go
@@ -128,8 +128,8 @@ func TestGreaterThanWithHazelcastJson(t *testing.T) {
 	}
 	jsonStr1, _ := json.Marshal(person1)
 	jsonStr2, _ := json.Marshal(person2)
-	mp.Put("person1", core.HazelcastJSON{JSONString: jsonStr1})
-	mp.Put("person2", core.HazelcastJSON{JSONString: jsonStr2})
+	mp.Put("person1", core.HazelcastJSONValue{JSONString: jsonStr1})
+	mp.Put("person2", core.HazelcastJSONValue{JSONString: jsonStr2})
 
 	greaterEqual := predicate.GreaterThan("Age", int32(35))
 	result, err := mp.ValuesWithPredicate(greaterEqual)
@@ -137,7 +137,7 @@ func TestGreaterThanWithHazelcastJson(t *testing.T) {
 	assert.Len(t, result, 1)
 
 	var resultPerson person
-	err = json.Unmarshal(result[0].(core.HazelcastJSON).JSONString, &resultPerson)
+	err = json.Unmarshal(result[0].(core.HazelcastJSONValue).JSONString, &resultPerson)
 	assert.NoError(t, err)
 	assert.Equal(t, resultPerson.Age, 40)
 	assert.Equal(t, resultPerson.Name, "Name2")

--- a/test/proxy/map/predicates_test.go
+++ b/test/proxy/map/predicates_test.go
@@ -23,8 +23,6 @@ import (
 	"github.com/hazelcast/hazelcast-go-client/core/predicate"
 	prd "github.com/hazelcast/hazelcast-go-client/internal/predicate"
 
-	"encoding/json"
-
 	"github.com/hazelcast/hazelcast-go-client/core"
 	"github.com/hazelcast/hazelcast-go-client/internal/aggregation"
 	"github.com/hazelcast/hazelcast-go-client/internal/projection"
@@ -126,10 +124,10 @@ func TestGreaterThanWithHazelcastJson(t *testing.T) {
 	person2 := person{
 		Age: 40, Name: "Name2",
 	}
-	jsonStr1, _ := json.Marshal(person1)
-	jsonStr2, _ := json.Marshal(person2)
-	mp.Put("person1", core.HazelcastJSONValue{JSONString: jsonStr1})
-	mp.Put("person2", core.HazelcastJSONValue{JSONString: jsonStr2})
+	value, _ := core.CreateHazelcastJSONValue(person1)
+	mp.Put("person1", value)
+	value2, _ := core.CreateHazelcastJSONValue(person2)
+	mp.Put("person2", value2)
 
 	greaterEqual := predicate.GreaterThan("Age", int32(35))
 	result, err := mp.ValuesWithPredicate(greaterEqual)
@@ -137,7 +135,7 @@ func TestGreaterThanWithHazelcastJson(t *testing.T) {
 	assert.Len(t, result, 1)
 
 	var resultPerson person
-	err = json.Unmarshal(result[0].(core.HazelcastJSONValue).JSONString, &resultPerson)
+	result[0].(*core.HazelcastJSONValue).Unmarshal(&resultPerson)
 	assert.NoError(t, err)
 	assert.Equal(t, resultPerson.Age, 40)
 	assert.Equal(t, resultPerson.Name, "Name2")


### PR DESCRIPTION
class name is aligned with other clients.
Constructors to create json from string and object is added.
ToString method is added.

Added nil check for hazelcastJSONValue 
Create methods will return nil actual check will be done in
put,get, ... methods.

This is to simplify API. Otherwise, user needs to seperate API
calls to two line as follows:
``
value , _ := CreateHazelcastJSONValue(person)
map.put("key", value)
``
isNil method also implemented on proxy to correctly check nil type over
interface{}