### PR TITLE
Add aws private link feature to cloud discovery

### DIFF
--- a/internal/discovery/hazelcast_cloud_discovery.go
+++ b/internal/discovery/hazelcast_cloud_discovery.go
@@ -118,7 +118,11 @@ func (hzC *HazelcastCloud) parseResponse(response *http.Response) (map[string]co
 		publicAddress := hzC.createAddress(addr.PublicAddr)
 		// TODO:: what if privateAddress is not okay ?
 		// TODO:: use addressProvider
-		privateAddress := proto.NewAddressWithParameters(addr.PrivAddr, publicAddress.Port())
+		privateAddress := hzC.createAddress(addr.PrivAddr)
+		if privateAddress.Port() == -1 {
+			privateAddress = proto.NewAddressWithParameters(addr.PrivAddr, publicAddress.Port())
+		}
+
 		privateToPublicAddrs[privateAddress.String()] = publicAddress
 	}
 

--- a/internal/discovery/hazelcast_cloud_discovery_test.go
+++ b/internal/discovery/hazelcast_cloud_discovery_test.go
@@ -44,7 +44,7 @@ const serverPrivateLinkResponse = "[" +
 	"{\"private-address\":\"" + privateAddr3 + ":" + privatePort + "\",\"public-address\":\"54.186.232.37:" + port + "\"}" +
 	"]"
 
-func CheckHazelcastResponse(t *testing.T, response string, port string) {
+func checkHazelcastResponse(t *testing.T, response string, port string) {
 	// Start a local HTTP server
 	server := httptest.NewTLSServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		// Send response to be tested
@@ -83,11 +83,11 @@ func CheckHazelcastResponse(t *testing.T, response string, port string) {
 }
 
 func TestHazelcastCloudDiscoverPrivateLinkNodes(t *testing.T) {
-	CheckHazelcastResponse(t, serverPrivateLinkResponse, privatePort)
+	checkHazelcastResponse(t, serverPrivateLinkResponse, privatePort)
 }
 
 func TestHazelcastCloudDiscoverNodes(t *testing.T) {
-	CheckHazelcastResponse(t, serverResponse, port)
+	checkHazelcastResponse(t, serverResponse, port)
 }
 
 func TestHazelcastCloudDiscoveryInvalidURL(t *testing.T) {

--- a/internal/discovery/hazelcast_cloud_discovery_test.go
+++ b/internal/discovery/hazelcast_cloud_discovery_test.go
@@ -62,7 +62,7 @@ func CheckHazelcastResponse(t *testing.T,response string,port string) {
 	certpool := x509.NewCertPool()
 	certpool.AddCert(cert)
 
-	hzC := NewHazelcastCloud(server.URL , 0, certpool)
+	hzC := NewHazelcastCloud(server.URL, 0, certpool)
 	addresses, err := hzC.discoverNodesInternal()
 	if err != nil {
 		t.Fatal(err)

--- a/internal/discovery/hazelcast_cloud_discovery_test.go
+++ b/internal/discovery/hazelcast_cloud_discovery_test.go
@@ -28,8 +28,8 @@ const (
 	privateAddr1 = "10.47.0.8"
 	privateAddr2 = "10.47.0.9"
 	privateAddr3 = "10.47.0.10"
+	privatePort  = "31115"
 	port         = "32298"
-	privatePort	 = "31115"
 )
 
 const serverResponse = "[" +
@@ -44,7 +44,7 @@ const serverPrivateLinkResponse = "[" +
 	"{\"private-address\":\"" + privateAddr3 + ":" + privatePort + "\",\"public-address\":\"54.186.232.37:" + port + "\"}" +
 	"]"
 
-func CheckHazelcastResponse(t *testing.T,response string,port string) {
+func CheckHazelcastResponse(t *testing.T, response string, port string) {
 	// Start a local HTTP server
 	server := httptest.NewTLSServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		// Send response to be tested
@@ -87,7 +87,7 @@ func TestHazelcastCloudDiscoverPrivateLinkNodes(t *testing.T) {
 }
 
 func TestHazelcastCloudDiscoverNodes(t *testing.T) {
-	CheckHazelcastResponse(t,serverResponse,port)
+	CheckHazelcastResponse(t, serverResponse, port)
 }
 
 func TestHazelcastCloudDiscoveryInvalidURL(t *testing.T) {


### PR DESCRIPTION
Implements this PRD: https://hazelcast.atlassian.net/wiki/spaces/PM/pages/1952022594/Go+Client+AWS+PrivateLink+compatibility