### PR TITLE
Add List support

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ func main() {
 ## Features
 
 * Distributed, partitioned and queryable in-memory key-value store implementation, called Map.
-* Additional data structures and simple messaging constructs such as Replicated Map, Queue and Topic.
+* Additional data structures and simple messaging constructs such as Replicated Map, Queue, List, and Topic.
 * Support for serverless and traditional web service architectures with Unisocket and Smart operation modes.
 * Ability to listen to client lifecycle, cluster state, and distributed data structure events.
 

--- a/client.go
+++ b/client.go
@@ -172,6 +172,7 @@ func (c *Client) GetReplicatedMap(name string) (*ReplicatedMap, error) {
 	return c.proxyManager.getReplicatedMap(name)
 }
 
+// GetQueue returns a queue instance.
 func (c *Client) GetQueue(name string) (*Queue, error) {
 	if atomic.LoadInt32(&c.state) != ready {
 		return nil, ErrClientNotReady
@@ -179,11 +180,20 @@ func (c *Client) GetQueue(name string) (*Queue, error) {
 	return c.proxyManager.getQueue(name)
 }
 
+// GetTopic returns a topic instance.
 func (c *Client) GetTopic(name string) (*Topic, error) {
 	if atomic.LoadInt32(&c.state) != ready {
 		return nil, ErrClientNotReady
 	}
 	return c.proxyManager.getTopic(name)
+}
+
+// GetList returns a list instance.
+func (c *Client) GetList(name string) (*List, error) {
+	if atomic.LoadInt32(&c.state) != ready {
+		return nil, ErrClientNotReady
+	}
+	return c.proxyManager.getList(name)
 }
 
 // Start connects the client to the cluster.

--- a/events.go
+++ b/events.go
@@ -45,11 +45,6 @@ const (
 	NotifyEntryLoaded = int32(1 << 9)
 )
 
-const (
-	NotifyItemAdded   int32 = 1
-	NotifyItemRemoved int32 = 2
-)
-
 type EntryNotifiedHandler func(event *EntryNotified)
 
 const (
@@ -57,6 +52,7 @@ const (
 	eventLifecycleEventStateChanged = "lifecyclestatechanged"
 	eventMessagePublished           = "messagepublished"
 	eventQueueItemNotified          = "queue.itemnotified"
+	eventListItemNotified           = "list.itemnotified"
 )
 
 type EntryNotified struct {
@@ -145,13 +141,23 @@ func newMessagePublished(name string, value interface{}, publishTime time.Time, 
 	}
 }
 
+// ItemEventType describes event types for item related events.
+type ItemEventType int32
+
+const (
+	// NotifyItemAdded stands for item added event.
+	NotifyItemAdded ItemEventType = 1
+	// NotifyItemRemoved stands for item removed event.
+	NotifyItemRemoved ItemEventType = 2
+)
+
 type QueueItemNotifiedHandler func(event *QueueItemNotified)
 
 type QueueItemNotified struct {
 	QueueName string
 	Value     interface{}
 	Member    cluster.Member
-	EventType int32
+	EventType ItemEventType
 }
 
 func (q QueueItemNotified) EventName() string {
@@ -163,6 +169,28 @@ func newQueueItemNotified(name string, value interface{}, member cluster.Member,
 		QueueName: name,
 		Value:     value,
 		Member:    member,
-		EventType: eventType,
+		EventType: ItemEventType(eventType),
+	}
+}
+
+type ListItemNotifiedHandler func(event *ListItemNotified)
+
+type ListItemNotified struct {
+	ListName  string
+	Value     interface{}
+	Member    cluster.Member
+	EventType ItemEventType
+}
+
+func (q ListItemNotified) EventName() string {
+	return eventListItemNotified
+}
+
+func newListItemNotified(name string, value interface{}, member cluster.Member, eventType int32) *ListItemNotified {
+	return &ListItemNotified{
+		ListName:  name,
+		Value:     value,
+		Member:    member,
+		EventType: ItemEventType(eventType),
 	}
 }

--- a/events.go
+++ b/events.go
@@ -173,8 +173,10 @@ func newQueueItemNotified(name string, value interface{}, member cluster.Member,
 	}
 }
 
+// ListItemNotifiedHandler is a handler function for the List item listener.
 type ListItemNotifiedHandler func(event *ListItemNotified)
 
+// ListItemNotified describes the List item event.
 type ListItemNotified struct {
 	ListName  string
 	Value     interface{}
@@ -182,6 +184,7 @@ type ListItemNotified struct {
 	EventType ItemEventType
 }
 
+// EventName returns generic event name, common for all List item listeners.
 func (q ListItemNotified) EventName() string {
 	return eventListItemNotified
 }

--- a/internal/it/list.go
+++ b/internal/it/list.go
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package it
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"go.uber.org/goleak"
+
+	hz "github.com/hazelcast/hazelcast-go-client"
+	"github.com/hazelcast/hazelcast-go-client/logger"
+)
+
+func ListTester(t *testing.T, f func(t *testing.T, l *hz.List)) {
+	makeListName := func() string {
+		return fmt.Sprintf("test-list-%d-%d", idGen.NextID(), rand.Int())
+	}
+	ListTesterWithConfigBuilderWithName(t, makeListName, nil, f)
+}
+
+func ListTesterWithConfigBuilderWithName(t *testing.T,
+	listName func() string,
+	cbCallback func(*hz.ConfigBuilder),
+	f func(*testing.T, *hz.List)) {
+
+	var (
+		client *hz.Client
+		l      *hz.List
+	)
+	ensureRemoteController(true)
+	runner := func(t *testing.T, smart bool) {
+		if LeakCheckEnabled() {
+			t.Logf("enabled leak check")
+			defer goleak.VerifyNone(t)
+		}
+		cb := defaultTestCluster.DefaultConfigBuilder()
+		if cbCallback != nil {
+			cbCallback(cb)
+		}
+		cb.Cluster().SetSmartRouting(smart)
+		client, l = getClientListWithConfig(listName(), cb)
+		defer func() {
+			if err := client.Shutdown(); err != nil {
+				t.Logf("test warning, client not shutdown: %s", err.Error())
+			}
+		}()
+		f(t, l)
+	}
+	if SmartEnabled() {
+		t.Run("Smart Client", func(t *testing.T) {
+			runner(t, true)
+		})
+	}
+	if NonSmartEnabled() {
+		t.Run("Non-Smart Client", func(t *testing.T) {
+			runner(t, false)
+		})
+	}
+}
+
+func getClientListWithConfig(name string, cb *hz.ConfigBuilder) (*hz.Client, *hz.List) {
+	if TraceLoggingEnabled() {
+		cb.Logger().SetLevel(logger.TraceLevel)
+	} else {
+		cb.Logger().SetLevel(logger.WarnLevel)
+	}
+	client, err := hz.StartNewClientWithConfig(cb)
+	if err != nil {
+		panic(err)
+	}
+	if l, err := client.GetList(name); err != nil {
+		panic(err)
+	} else {
+		return client, l
+	}
+}

--- a/internal/proto/codec/list_add_all_codec.go
+++ b/internal/proto/codec/list_add_all_codec.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package codec
+
+import (
+	"github.com/hazelcast/hazelcast-go-client/internal/proto"
+	"github.com/hazelcast/hazelcast-go-client/serialization"
+)
+
+const (
+	// hex: 0x050600
+	ListAddAllCodecRequestMessageType = int32(329216)
+	// hex: 0x050601
+	ListAddAllCodecResponseMessageType = int32(329217)
+
+	ListAddAllCodecRequestInitialFrameSize = proto.PartitionIDOffset + proto.IntSizeInBytes
+
+	ListAddAllResponseResponseOffset = proto.ResponseBackupAcksOffset + proto.ByteSizeInBytes
+)
+
+// Appends all of the elements in the specified collection to the end of this list, in the order that they are
+// returned by the specified collection's iterator (optional operation).
+// The behavior of this operation is undefined if the specified collection is modified while the operation is in progress.
+// (Note that this will occur if the specified collection is this list, and it's nonempty.)
+
+func EncodeListAddAllRequest(name string, valueList []serialization.Data) *proto.ClientMessage {
+	clientMessage := proto.NewClientMessageForEncode()
+	clientMessage.SetRetryable(false)
+
+	initialFrame := proto.NewFrameWith(make([]byte, ListAddAllCodecRequestInitialFrameSize), proto.UnfragmentedMessage)
+	clientMessage.AddFrame(initialFrame)
+	clientMessage.SetMessageType(ListAddAllCodecRequestMessageType)
+	clientMessage.SetPartitionId(-1)
+
+	EncodeString(clientMessage, name)
+	EncodeListMultiFrameForData(clientMessage, valueList)
+
+	return clientMessage
+}
+
+func DecodeListAddAllResponse(clientMessage *proto.ClientMessage) bool {
+	frameIterator := clientMessage.FrameIterator()
+	initialFrame := frameIterator.Next()
+
+	return FixSizedTypesCodec.DecodeBoolean(initialFrame.Content, ListAddAllResponseResponseOffset)
+}

--- a/internal/proto/codec/list_add_all_with_index_codec.go
+++ b/internal/proto/codec/list_add_all_with_index_codec.go
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package codec
+
+import (
+	"github.com/hazelcast/hazelcast-go-client/internal/proto"
+	"github.com/hazelcast/hazelcast-go-client/serialization"
+)
+
+const (
+	// hex: 0x050E00
+	ListAddAllWithIndexCodecRequestMessageType = int32(331264)
+	// hex: 0x050E01
+	ListAddAllWithIndexCodecResponseMessageType = int32(331265)
+
+	ListAddAllWithIndexCodecRequestIndexOffset      = proto.PartitionIDOffset + proto.IntSizeInBytes
+	ListAddAllWithIndexCodecRequestInitialFrameSize = ListAddAllWithIndexCodecRequestIndexOffset + proto.IntSizeInBytes
+
+	ListAddAllWithIndexResponseResponseOffset = proto.ResponseBackupAcksOffset + proto.ByteSizeInBytes
+)
+
+// Inserts all of the elements in the specified collection into this list at the specified position (optional operation).
+// Shifts the element currently at that position (if any) and any subsequent elements to the right (increases their indices).
+// The new elements will appear in this list in the order that they are returned by the specified collection's iterator.
+// The behavior of this operation is undefined if the specified collection is modified while the operation is in progress.
+// (Note that this will occur if the specified collection is this list, and it's nonempty.)
+
+func EncodeListAddAllWithIndexRequest(name string, index int32, valueList []serialization.Data) *proto.ClientMessage {
+	clientMessage := proto.NewClientMessageForEncode()
+	clientMessage.SetRetryable(false)
+
+	initialFrame := proto.NewFrameWith(make([]byte, ListAddAllWithIndexCodecRequestInitialFrameSize), proto.UnfragmentedMessage)
+	FixSizedTypesCodec.EncodeInt(initialFrame.Content, ListAddAllWithIndexCodecRequestIndexOffset, index)
+	clientMessage.AddFrame(initialFrame)
+	clientMessage.SetMessageType(ListAddAllWithIndexCodecRequestMessageType)
+	clientMessage.SetPartitionId(-1)
+
+	EncodeString(clientMessage, name)
+	EncodeListMultiFrameForData(clientMessage, valueList)
+
+	return clientMessage
+}
+
+func DecodeListAddAllWithIndexResponse(clientMessage *proto.ClientMessage) bool {
+	frameIterator := clientMessage.FrameIterator()
+	initialFrame := frameIterator.Next()
+
+	return FixSizedTypesCodec.DecodeBoolean(initialFrame.Content, ListAddAllWithIndexResponseResponseOffset)
+}

--- a/internal/proto/codec/list_add_codec.go
+++ b/internal/proto/codec/list_add_codec.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package codec
+
+import (
+	"github.com/hazelcast/hazelcast-go-client/internal/proto"
+	"github.com/hazelcast/hazelcast-go-client/serialization"
+)
+
+const (
+	// hex: 0x050400
+	ListAddCodecRequestMessageType = int32(328704)
+	// hex: 0x050401
+	ListAddCodecResponseMessageType = int32(328705)
+
+	ListAddCodecRequestInitialFrameSize = proto.PartitionIDOffset + proto.IntSizeInBytes
+
+	ListAddResponseResponseOffset = proto.ResponseBackupAcksOffset + proto.ByteSizeInBytes
+)
+
+// Appends the specified element to the end of this list (optional operation). Lists that support this operation may
+// place limitations on what elements may be added to this list.  In particular, some lists will refuse to add null
+// elements, and others will impose restrictions on the type of elements that may be added. List classes should
+// clearly specify in their documentation any restrictions on what elements may be added.
+
+func EncodeListAddRequest(name string, value serialization.Data) *proto.ClientMessage {
+	clientMessage := proto.NewClientMessageForEncode()
+	clientMessage.SetRetryable(false)
+
+	initialFrame := proto.NewFrameWith(make([]byte, ListAddCodecRequestInitialFrameSize), proto.UnfragmentedMessage)
+	clientMessage.AddFrame(initialFrame)
+	clientMessage.SetMessageType(ListAddCodecRequestMessageType)
+	clientMessage.SetPartitionId(-1)
+
+	EncodeString(clientMessage, name)
+	EncodeData(clientMessage, value)
+
+	return clientMessage
+}
+
+func DecodeListAddResponse(clientMessage *proto.ClientMessage) bool {
+	frameIterator := clientMessage.FrameIterator()
+	initialFrame := frameIterator.Next()
+
+	return FixSizedTypesCodec.DecodeBoolean(initialFrame.Content, ListAddResponseResponseOffset)
+}

--- a/internal/proto/codec/list_add_listener_codec.go
+++ b/internal/proto/codec/list_add_listener_codec.go
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package codec
+
+import (
+	"github.com/hazelcast/hazelcast-go-client/internal/proto"
+	"github.com/hazelcast/hazelcast-go-client/serialization"
+	"github.com/hazelcast/hazelcast-go-client/types"
+)
+
+const (
+	// hex: 0x050B00
+	ListAddListenerCodecRequestMessageType = int32(330496)
+	// hex: 0x050B01
+	ListAddListenerCodecResponseMessageType = int32(330497)
+
+	// hex: 0x050B02
+	ListAddListenerCodecEventItemMessageType = int32(330498)
+
+	ListAddListenerCodecRequestIncludeValueOffset = proto.PartitionIDOffset + proto.IntSizeInBytes
+	ListAddListenerCodecRequestLocalOnlyOffset    = ListAddListenerCodecRequestIncludeValueOffset + proto.BooleanSizeInBytes
+	ListAddListenerCodecRequestInitialFrameSize   = ListAddListenerCodecRequestLocalOnlyOffset + proto.BooleanSizeInBytes
+
+	ListAddListenerResponseResponseOffset   = proto.ResponseBackupAcksOffset + proto.ByteSizeInBytes
+	ListAddListenerEventItemUuidOffset      = proto.PartitionIDOffset + proto.IntSizeInBytes
+	ListAddListenerEventItemEventTypeOffset = ListAddListenerEventItemUuidOffset + proto.UuidSizeInBytes
+)
+
+// Adds an item listener for this collection. Listener will be notified for all collection add/remove events.
+
+func EncodeListAddListenerRequest(name string, includeValue bool, localOnly bool) *proto.ClientMessage {
+	clientMessage := proto.NewClientMessageForEncode()
+	clientMessage.SetRetryable(false)
+
+	initialFrame := proto.NewFrameWith(make([]byte, ListAddListenerCodecRequestInitialFrameSize), proto.UnfragmentedMessage)
+	FixSizedTypesCodec.EncodeBoolean(initialFrame.Content, ListAddListenerCodecRequestIncludeValueOffset, includeValue)
+	FixSizedTypesCodec.EncodeBoolean(initialFrame.Content, ListAddListenerCodecRequestLocalOnlyOffset, localOnly)
+	clientMessage.AddFrame(initialFrame)
+	clientMessage.SetMessageType(ListAddListenerCodecRequestMessageType)
+	clientMessage.SetPartitionId(-1)
+
+	EncodeString(clientMessage, name)
+
+	return clientMessage
+}
+
+func DecodeListAddListenerResponse(clientMessage *proto.ClientMessage) types.UUID {
+	frameIterator := clientMessage.FrameIterator()
+	initialFrame := frameIterator.Next()
+
+	return FixSizedTypesCodec.DecodeUUID(initialFrame.Content, ListAddListenerResponseResponseOffset)
+}
+
+func HandleListAddListener(clientMessage *proto.ClientMessage, handleItemEvent func(item serialization.Data, uuid types.UUID, eventType int32)) {
+	messageType := clientMessage.Type()
+	frameIterator := clientMessage.FrameIterator()
+	if messageType == ListAddListenerCodecEventItemMessageType {
+		initialFrame := frameIterator.Next()
+		uuid := FixSizedTypesCodec.DecodeUUID(initialFrame.Content, ListAddListenerEventItemUuidOffset)
+		eventType := FixSizedTypesCodec.DecodeInt(initialFrame.Content, ListAddListenerEventItemEventTypeOffset)
+		item := CodecUtil.DecodeNullableForData(frameIterator)
+		handleItemEvent(item, uuid, eventType)
+		return
+	}
+}

--- a/internal/proto/codec/list_add_with_index_codec.go
+++ b/internal/proto/codec/list_add_with_index_codec.go
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package codec
+
+import (
+	"github.com/hazelcast/hazelcast-go-client/internal/proto"
+	"github.com/hazelcast/hazelcast-go-client/serialization"
+)
+
+const (
+	// hex: 0x051100
+	ListAddWithIndexCodecRequestMessageType = int32(332032)
+	// hex: 0x051101
+	ListAddWithIndexCodecResponseMessageType = int32(332033)
+
+	ListAddWithIndexCodecRequestIndexOffset      = proto.PartitionIDOffset + proto.IntSizeInBytes
+	ListAddWithIndexCodecRequestInitialFrameSize = ListAddWithIndexCodecRequestIndexOffset + proto.IntSizeInBytes
+)
+
+// Inserts the specified element at the specified position in this list (optional operation). Shifts the element
+// currently at that position (if any) and any subsequent elements to the right (adds one to their indices).
+
+func EncodeListAddWithIndexRequest(name string, index int32, value serialization.Data) *proto.ClientMessage {
+	clientMessage := proto.NewClientMessageForEncode()
+	clientMessage.SetRetryable(false)
+
+	initialFrame := proto.NewFrameWith(make([]byte, ListAddWithIndexCodecRequestInitialFrameSize), proto.UnfragmentedMessage)
+	FixSizedTypesCodec.EncodeInt(initialFrame.Content, ListAddWithIndexCodecRequestIndexOffset, index)
+	clientMessage.AddFrame(initialFrame)
+	clientMessage.SetMessageType(ListAddWithIndexCodecRequestMessageType)
+	clientMessage.SetPartitionId(-1)
+
+	EncodeString(clientMessage, name)
+	EncodeData(clientMessage, value)
+
+	return clientMessage
+}

--- a/internal/proto/codec/list_clear_codec.go
+++ b/internal/proto/codec/list_clear_codec.go
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package codec
+
+import (
+	"github.com/hazelcast/hazelcast-go-client/internal/proto"
+)
+
+const (
+	// hex: 0x050900
+	ListClearCodecRequestMessageType = int32(329984)
+	// hex: 0x050901
+	ListClearCodecResponseMessageType = int32(329985)
+
+	ListClearCodecRequestInitialFrameSize = proto.PartitionIDOffset + proto.IntSizeInBytes
+)
+
+// Removes all of the elements from this list (optional operation). The list will be empty after this call returns.
+
+func EncodeListClearRequest(name string) *proto.ClientMessage {
+	clientMessage := proto.NewClientMessageForEncode()
+	clientMessage.SetRetryable(false)
+
+	initialFrame := proto.NewFrameWith(make([]byte, ListClearCodecRequestInitialFrameSize), proto.UnfragmentedMessage)
+	clientMessage.AddFrame(initialFrame)
+	clientMessage.SetMessageType(ListClearCodecRequestMessageType)
+	clientMessage.SetPartitionId(-1)
+
+	EncodeString(clientMessage, name)
+
+	return clientMessage
+}

--- a/internal/proto/codec/list_compare_and_remove_all_codec.go
+++ b/internal/proto/codec/list_compare_and_remove_all_codec.go
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package codec
+
+import (
+	"github.com/hazelcast/hazelcast-go-client/internal/proto"
+	"github.com/hazelcast/hazelcast-go-client/serialization"
+)
+
+const (
+	// hex: 0x050700
+	ListCompareAndRemoveAllCodecRequestMessageType = int32(329472)
+	// hex: 0x050701
+	ListCompareAndRemoveAllCodecResponseMessageType = int32(329473)
+
+	ListCompareAndRemoveAllCodecRequestInitialFrameSize = proto.PartitionIDOffset + proto.IntSizeInBytes
+
+	ListCompareAndRemoveAllResponseResponseOffset = proto.ResponseBackupAcksOffset + proto.ByteSizeInBytes
+)
+
+// Removes from this list all of its elements that are contained in the specified collection (optional operation).
+
+func EncodeListCompareAndRemoveAllRequest(name string, values []serialization.Data) *proto.ClientMessage {
+	clientMessage := proto.NewClientMessageForEncode()
+	clientMessage.SetRetryable(false)
+
+	initialFrame := proto.NewFrameWith(make([]byte, ListCompareAndRemoveAllCodecRequestInitialFrameSize), proto.UnfragmentedMessage)
+	clientMessage.AddFrame(initialFrame)
+	clientMessage.SetMessageType(ListCompareAndRemoveAllCodecRequestMessageType)
+	clientMessage.SetPartitionId(-1)
+
+	EncodeString(clientMessage, name)
+	EncodeListMultiFrameForData(clientMessage, values)
+
+	return clientMessage
+}
+
+func DecodeListCompareAndRemoveAllResponse(clientMessage *proto.ClientMessage) bool {
+	frameIterator := clientMessage.FrameIterator()
+	initialFrame := frameIterator.Next()
+
+	return FixSizedTypesCodec.DecodeBoolean(initialFrame.Content, ListCompareAndRemoveAllResponseResponseOffset)
+}

--- a/internal/proto/codec/list_compare_and_retain_all_codec.go
+++ b/internal/proto/codec/list_compare_and_retain_all_codec.go
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package codec
+
+import (
+	"github.com/hazelcast/hazelcast-go-client/internal/proto"
+	"github.com/hazelcast/hazelcast-go-client/serialization"
+)
+
+const (
+	// hex: 0x050800
+	ListCompareAndRetainAllCodecRequestMessageType = int32(329728)
+	// hex: 0x050801
+	ListCompareAndRetainAllCodecResponseMessageType = int32(329729)
+
+	ListCompareAndRetainAllCodecRequestInitialFrameSize = proto.PartitionIDOffset + proto.IntSizeInBytes
+
+	ListCompareAndRetainAllResponseResponseOffset = proto.ResponseBackupAcksOffset + proto.ByteSizeInBytes
+)
+
+// Retains only the elements in this list that are contained in the specified collection (optional operation).
+// In other words, removes from this list all of its elements that are not contained in the specified collection.
+
+func EncodeListCompareAndRetainAllRequest(name string, values []serialization.Data) *proto.ClientMessage {
+	clientMessage := proto.NewClientMessageForEncode()
+	clientMessage.SetRetryable(false)
+
+	initialFrame := proto.NewFrameWith(make([]byte, ListCompareAndRetainAllCodecRequestInitialFrameSize), proto.UnfragmentedMessage)
+	clientMessage.AddFrame(initialFrame)
+	clientMessage.SetMessageType(ListCompareAndRetainAllCodecRequestMessageType)
+	clientMessage.SetPartitionId(-1)
+
+	EncodeString(clientMessage, name)
+	EncodeListMultiFrameForData(clientMessage, values)
+
+	return clientMessage
+}
+
+func DecodeListCompareAndRetainAllResponse(clientMessage *proto.ClientMessage) bool {
+	frameIterator := clientMessage.FrameIterator()
+	initialFrame := frameIterator.Next()
+
+	return FixSizedTypesCodec.DecodeBoolean(initialFrame.Content, ListCompareAndRetainAllResponseResponseOffset)
+}

--- a/internal/proto/codec/list_contains_all_codec.go
+++ b/internal/proto/codec/list_contains_all_codec.go
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package codec
+
+import (
+	"github.com/hazelcast/hazelcast-go-client/internal/proto"
+	"github.com/hazelcast/hazelcast-go-client/serialization"
+)
+
+const (
+	// hex: 0x050300
+	ListContainsAllCodecRequestMessageType = int32(328448)
+	// hex: 0x050301
+	ListContainsAllCodecResponseMessageType = int32(328449)
+
+	ListContainsAllCodecRequestInitialFrameSize = proto.PartitionIDOffset + proto.IntSizeInBytes
+
+	ListContainsAllResponseResponseOffset = proto.ResponseBackupAcksOffset + proto.ByteSizeInBytes
+)
+
+// Returns true if this list contains all of the elements of the specified collection.
+
+func EncodeListContainsAllRequest(name string, values []serialization.Data) *proto.ClientMessage {
+	clientMessage := proto.NewClientMessageForEncode()
+	clientMessage.SetRetryable(true)
+
+	initialFrame := proto.NewFrameWith(make([]byte, ListContainsAllCodecRequestInitialFrameSize), proto.UnfragmentedMessage)
+	clientMessage.AddFrame(initialFrame)
+	clientMessage.SetMessageType(ListContainsAllCodecRequestMessageType)
+	clientMessage.SetPartitionId(-1)
+
+	EncodeString(clientMessage, name)
+	EncodeListMultiFrameForData(clientMessage, values)
+
+	return clientMessage
+}
+
+func DecodeListContainsAllResponse(clientMessage *proto.ClientMessage) bool {
+	frameIterator := clientMessage.FrameIterator()
+	initialFrame := frameIterator.Next()
+
+	return FixSizedTypesCodec.DecodeBoolean(initialFrame.Content, ListContainsAllResponseResponseOffset)
+}

--- a/internal/proto/codec/list_contains_codec.go
+++ b/internal/proto/codec/list_contains_codec.go
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package codec
+
+import (
+	"github.com/hazelcast/hazelcast-go-client/internal/proto"
+	"github.com/hazelcast/hazelcast-go-client/serialization"
+)
+
+const (
+	// hex: 0x050200
+	ListContainsCodecRequestMessageType = int32(328192)
+	// hex: 0x050201
+	ListContainsCodecResponseMessageType = int32(328193)
+
+	ListContainsCodecRequestInitialFrameSize = proto.PartitionIDOffset + proto.IntSizeInBytes
+
+	ListContainsResponseResponseOffset = proto.ResponseBackupAcksOffset + proto.ByteSizeInBytes
+)
+
+// Returns true if this list contains the specified element.
+
+func EncodeListContainsRequest(name string, value serialization.Data) *proto.ClientMessage {
+	clientMessage := proto.NewClientMessageForEncode()
+	clientMessage.SetRetryable(true)
+
+	initialFrame := proto.NewFrameWith(make([]byte, ListContainsCodecRequestInitialFrameSize), proto.UnfragmentedMessage)
+	clientMessage.AddFrame(initialFrame)
+	clientMessage.SetMessageType(ListContainsCodecRequestMessageType)
+	clientMessage.SetPartitionId(-1)
+
+	EncodeString(clientMessage, name)
+	EncodeData(clientMessage, value)
+
+	return clientMessage
+}
+
+func DecodeListContainsResponse(clientMessage *proto.ClientMessage) bool {
+	frameIterator := clientMessage.FrameIterator()
+	initialFrame := frameIterator.Next()
+
+	return FixSizedTypesCodec.DecodeBoolean(initialFrame.Content, ListContainsResponseResponseOffset)
+}

--- a/internal/proto/codec/list_get_all_codec.go
+++ b/internal/proto/codec/list_get_all_codec.go
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package codec
+
+import (
+	"github.com/hazelcast/hazelcast-go-client/internal/proto"
+	"github.com/hazelcast/hazelcast-go-client/serialization"
+)
+
+const (
+	// hex: 0x050A00
+	ListGetAllCodecRequestMessageType = int32(330240)
+	// hex: 0x050A01
+	ListGetAllCodecResponseMessageType = int32(330241)
+
+	ListGetAllCodecRequestInitialFrameSize = proto.PartitionIDOffset + proto.IntSizeInBytes
+)
+
+// Return the all elements of this collection
+
+func EncodeListGetAllRequest(name string) *proto.ClientMessage {
+	clientMessage := proto.NewClientMessageForEncode()
+	clientMessage.SetRetryable(true)
+
+	initialFrame := proto.NewFrameWith(make([]byte, ListGetAllCodecRequestInitialFrameSize), proto.UnfragmentedMessage)
+	clientMessage.AddFrame(initialFrame)
+	clientMessage.SetMessageType(ListGetAllCodecRequestMessageType)
+	clientMessage.SetPartitionId(-1)
+
+	EncodeString(clientMessage, name)
+
+	return clientMessage
+}
+
+func DecodeListGetAllResponse(clientMessage *proto.ClientMessage) []serialization.Data {
+	frameIterator := clientMessage.FrameIterator()
+	// empty initial frame
+	frameIterator.Next()
+
+	return DecodeListMultiFrameForData(frameIterator)
+}

--- a/internal/proto/codec/list_get_codec.go
+++ b/internal/proto/codec/list_get_codec.go
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package codec
+
+import (
+	"github.com/hazelcast/hazelcast-go-client/internal/proto"
+	"github.com/hazelcast/hazelcast-go-client/serialization"
+)
+
+const (
+	// hex: 0x050F00
+	ListGetCodecRequestMessageType = int32(331520)
+	// hex: 0x050F01
+	ListGetCodecResponseMessageType = int32(331521)
+
+	ListGetCodecRequestIndexOffset      = proto.PartitionIDOffset + proto.IntSizeInBytes
+	ListGetCodecRequestInitialFrameSize = ListGetCodecRequestIndexOffset + proto.IntSizeInBytes
+)
+
+// Returns the element at the specified position in this list
+
+func EncodeListGetRequest(name string, index int32) *proto.ClientMessage {
+	clientMessage := proto.NewClientMessageForEncode()
+	clientMessage.SetRetryable(true)
+
+	initialFrame := proto.NewFrameWith(make([]byte, ListGetCodecRequestInitialFrameSize), proto.UnfragmentedMessage)
+	FixSizedTypesCodec.EncodeInt(initialFrame.Content, ListGetCodecRequestIndexOffset, index)
+	clientMessage.AddFrame(initialFrame)
+	clientMessage.SetMessageType(ListGetCodecRequestMessageType)
+	clientMessage.SetPartitionId(-1)
+
+	EncodeString(clientMessage, name)
+
+	return clientMessage
+}
+
+func DecodeListGetResponse(clientMessage *proto.ClientMessage) serialization.Data {
+	frameIterator := clientMessage.FrameIterator()
+	// empty initial frame
+	frameIterator.Next()
+
+	return CodecUtil.DecodeNullableForData(frameIterator)
+}

--- a/internal/proto/codec/list_index_of_codec.go
+++ b/internal/proto/codec/list_index_of_codec.go
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package codec
+
+import (
+	"github.com/hazelcast/hazelcast-go-client/internal/proto"
+	"github.com/hazelcast/hazelcast-go-client/serialization"
+)
+
+const (
+	// hex: 0x051400
+	ListIndexOfCodecRequestMessageType = int32(332800)
+	// hex: 0x051401
+	ListIndexOfCodecResponseMessageType = int32(332801)
+
+	ListIndexOfCodecRequestInitialFrameSize = proto.PartitionIDOffset + proto.IntSizeInBytes
+
+	ListIndexOfResponseResponseOffset = proto.ResponseBackupAcksOffset + proto.ByteSizeInBytes
+)
+
+// Returns the index of the first occurrence of the specified element in this list, or -1 if this list does not
+// contain the element.
+
+func EncodeListIndexOfRequest(name string, value serialization.Data) *proto.ClientMessage {
+	clientMessage := proto.NewClientMessageForEncode()
+	clientMessage.SetRetryable(true)
+
+	initialFrame := proto.NewFrameWith(make([]byte, ListIndexOfCodecRequestInitialFrameSize), proto.UnfragmentedMessage)
+	clientMessage.AddFrame(initialFrame)
+	clientMessage.SetMessageType(ListIndexOfCodecRequestMessageType)
+	clientMessage.SetPartitionId(-1)
+
+	EncodeString(clientMessage, name)
+	EncodeData(clientMessage, value)
+
+	return clientMessage
+}
+
+func DecodeListIndexOfResponse(clientMessage *proto.ClientMessage) int32 {
+	frameIterator := clientMessage.FrameIterator()
+	initialFrame := frameIterator.Next()
+
+	return FixSizedTypesCodec.DecodeInt(initialFrame.Content, ListIndexOfResponseResponseOffset)
+}

--- a/internal/proto/codec/list_is_empty_codec.go
+++ b/internal/proto/codec/list_is_empty_codec.go
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package codec
+
+import (
+	"github.com/hazelcast/hazelcast-go-client/internal/proto"
+)
+
+const (
+	// hex: 0x050D00
+	ListIsEmptyCodecRequestMessageType = int32(331008)
+	// hex: 0x050D01
+	ListIsEmptyCodecResponseMessageType = int32(331009)
+
+	ListIsEmptyCodecRequestInitialFrameSize = proto.PartitionIDOffset + proto.IntSizeInBytes
+
+	ListIsEmptyResponseResponseOffset = proto.ResponseBackupAcksOffset + proto.ByteSizeInBytes
+)
+
+// Returns true if this list contains no elements
+
+func EncodeListIsEmptyRequest(name string) *proto.ClientMessage {
+	clientMessage := proto.NewClientMessageForEncode()
+	clientMessage.SetRetryable(true)
+
+	initialFrame := proto.NewFrameWith(make([]byte, ListIsEmptyCodecRequestInitialFrameSize), proto.UnfragmentedMessage)
+	clientMessage.AddFrame(initialFrame)
+	clientMessage.SetMessageType(ListIsEmptyCodecRequestMessageType)
+	clientMessage.SetPartitionId(-1)
+
+	EncodeString(clientMessage, name)
+
+	return clientMessage
+}
+
+func DecodeListIsEmptyResponse(clientMessage *proto.ClientMessage) bool {
+	frameIterator := clientMessage.FrameIterator()
+	initialFrame := frameIterator.Next()
+
+	return FixSizedTypesCodec.DecodeBoolean(initialFrame.Content, ListIsEmptyResponseResponseOffset)
+}

--- a/internal/proto/codec/list_iterator_codec.go
+++ b/internal/proto/codec/list_iterator_codec.go
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package codec
+
+import (
+	"github.com/hazelcast/hazelcast-go-client/internal/proto"
+	"github.com/hazelcast/hazelcast-go-client/serialization"
+)
+
+const (
+	// hex: 0x051600
+	ListIteratorCodecRequestMessageType = int32(333312)
+	// hex: 0x051601
+	ListIteratorCodecResponseMessageType = int32(333313)
+
+	ListIteratorCodecRequestInitialFrameSize = proto.PartitionIDOffset + proto.IntSizeInBytes
+)
+
+// Returns an iterator over the elements in this list in proper sequence.
+
+func EncodeListIteratorRequest(name string) *proto.ClientMessage {
+	clientMessage := proto.NewClientMessageForEncode()
+	clientMessage.SetRetryable(true)
+
+	initialFrame := proto.NewFrameWith(make([]byte, ListIteratorCodecRequestInitialFrameSize), proto.UnfragmentedMessage)
+	clientMessage.AddFrame(initialFrame)
+	clientMessage.SetMessageType(ListIteratorCodecRequestMessageType)
+	clientMessage.SetPartitionId(-1)
+
+	EncodeString(clientMessage, name)
+
+	return clientMessage
+}
+
+func DecodeListIteratorResponse(clientMessage *proto.ClientMessage) []serialization.Data {
+	frameIterator := clientMessage.FrameIterator()
+	// empty initial frame
+	frameIterator.Next()
+
+	return DecodeListMultiFrameForData(frameIterator)
+}

--- a/internal/proto/codec/list_last_index_of_codec.go
+++ b/internal/proto/codec/list_last_index_of_codec.go
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package codec
+
+import (
+	"github.com/hazelcast/hazelcast-go-client/internal/proto"
+	"github.com/hazelcast/hazelcast-go-client/serialization"
+)
+
+const (
+	// hex: 0x051300
+	ListLastIndexOfCodecRequestMessageType = int32(332544)
+	// hex: 0x051301
+	ListLastIndexOfCodecResponseMessageType = int32(332545)
+
+	ListLastIndexOfCodecRequestInitialFrameSize = proto.PartitionIDOffset + proto.IntSizeInBytes
+
+	ListLastIndexOfResponseResponseOffset = proto.ResponseBackupAcksOffset + proto.ByteSizeInBytes
+)
+
+// Returns the index of the last occurrence of the specified element in this list, or -1 if this list does not
+// contain the element.
+
+func EncodeListLastIndexOfRequest(name string, value serialization.Data) *proto.ClientMessage {
+	clientMessage := proto.NewClientMessageForEncode()
+	clientMessage.SetRetryable(true)
+
+	initialFrame := proto.NewFrameWith(make([]byte, ListLastIndexOfCodecRequestInitialFrameSize), proto.UnfragmentedMessage)
+	clientMessage.AddFrame(initialFrame)
+	clientMessage.SetMessageType(ListLastIndexOfCodecRequestMessageType)
+	clientMessage.SetPartitionId(-1)
+
+	EncodeString(clientMessage, name)
+	EncodeData(clientMessage, value)
+
+	return clientMessage
+}
+
+func DecodeListLastIndexOfResponse(clientMessage *proto.ClientMessage) int32 {
+	frameIterator := clientMessage.FrameIterator()
+	initialFrame := frameIterator.Next()
+
+	return FixSizedTypesCodec.DecodeInt(initialFrame.Content, ListLastIndexOfResponseResponseOffset)
+}

--- a/internal/proto/codec/list_list_iterator_codec.go
+++ b/internal/proto/codec/list_list_iterator_codec.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package codec
+
+import (
+	"github.com/hazelcast/hazelcast-go-client/internal/proto"
+	"github.com/hazelcast/hazelcast-go-client/serialization"
+)
+
+const (
+	// hex: 0x051700
+	ListListIteratorCodecRequestMessageType = int32(333568)
+	// hex: 0x051701
+	ListListIteratorCodecResponseMessageType = int32(333569)
+
+	ListListIteratorCodecRequestIndexOffset      = proto.PartitionIDOffset + proto.IntSizeInBytes
+	ListListIteratorCodecRequestInitialFrameSize = ListListIteratorCodecRequestIndexOffset + proto.IntSizeInBytes
+)
+
+// Returns a list iterator over the elements in this list (in proper sequence), starting at the specified position
+// in the list. The specified index indicates the first element that would be returned by an initial call to
+// ListIterator#next next. An initial call to ListIterator#previous previous would return the element with the
+// specified index minus one.
+
+func EncodeListListIteratorRequest(name string, index int32) *proto.ClientMessage {
+	clientMessage := proto.NewClientMessageForEncode()
+	clientMessage.SetRetryable(true)
+
+	initialFrame := proto.NewFrameWith(make([]byte, ListListIteratorCodecRequestInitialFrameSize), proto.UnfragmentedMessage)
+	FixSizedTypesCodec.EncodeInt(initialFrame.Content, ListListIteratorCodecRequestIndexOffset, index)
+	clientMessage.AddFrame(initialFrame)
+	clientMessage.SetMessageType(ListListIteratorCodecRequestMessageType)
+	clientMessage.SetPartitionId(-1)
+
+	EncodeString(clientMessage, name)
+
+	return clientMessage
+}
+
+func DecodeListListIteratorResponse(clientMessage *proto.ClientMessage) []serialization.Data {
+	frameIterator := clientMessage.FrameIterator()
+	// empty initial frame
+	frameIterator.Next()
+
+	return DecodeListMultiFrameForData(frameIterator)
+}

--- a/internal/proto/codec/list_remove_codec.go
+++ b/internal/proto/codec/list_remove_codec.go
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package codec
+
+import (
+	"github.com/hazelcast/hazelcast-go-client/internal/proto"
+	"github.com/hazelcast/hazelcast-go-client/serialization"
+)
+
+const (
+	// hex: 0x050500
+	ListRemoveCodecRequestMessageType = int32(328960)
+	// hex: 0x050501
+	ListRemoveCodecResponseMessageType = int32(328961)
+
+	ListRemoveCodecRequestInitialFrameSize = proto.PartitionIDOffset + proto.IntSizeInBytes
+
+	ListRemoveResponseResponseOffset = proto.ResponseBackupAcksOffset + proto.ByteSizeInBytes
+)
+
+// Removes the first occurrence of the specified element from this list, if it is present (optional operation).
+// If this list does not contain the element, it is unchanged.
+// Returns true if this list contained the specified element (or equivalently, if this list changed as a result of the call).
+
+func EncodeListRemoveRequest(name string, value serialization.Data) *proto.ClientMessage {
+	clientMessage := proto.NewClientMessageForEncode()
+	clientMessage.SetRetryable(false)
+
+	initialFrame := proto.NewFrameWith(make([]byte, ListRemoveCodecRequestInitialFrameSize), proto.UnfragmentedMessage)
+	clientMessage.AddFrame(initialFrame)
+	clientMessage.SetMessageType(ListRemoveCodecRequestMessageType)
+	clientMessage.SetPartitionId(-1)
+
+	EncodeString(clientMessage, name)
+	EncodeData(clientMessage, value)
+
+	return clientMessage
+}
+
+func DecodeListRemoveResponse(clientMessage *proto.ClientMessage) bool {
+	frameIterator := clientMessage.FrameIterator()
+	initialFrame := frameIterator.Next()
+
+	return FixSizedTypesCodec.DecodeBoolean(initialFrame.Content, ListRemoveResponseResponseOffset)
+}

--- a/internal/proto/codec/list_remove_listener_codec.go
+++ b/internal/proto/codec/list_remove_listener_codec.go
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package codec
+
+import (
+	"github.com/hazelcast/hazelcast-go-client/internal/proto"
+	"github.com/hazelcast/hazelcast-go-client/types"
+)
+
+const (
+	// hex: 0x050C00
+	ListRemoveListenerCodecRequestMessageType = int32(330752)
+	// hex: 0x050C01
+	ListRemoveListenerCodecResponseMessageType = int32(330753)
+
+	ListRemoveListenerCodecRequestRegistrationIdOffset = proto.PartitionIDOffset + proto.IntSizeInBytes
+	ListRemoveListenerCodecRequestInitialFrameSize     = ListRemoveListenerCodecRequestRegistrationIdOffset + proto.UuidSizeInBytes
+
+	ListRemoveListenerResponseResponseOffset = proto.ResponseBackupAcksOffset + proto.ByteSizeInBytes
+)
+
+// Removes the specified item listener. If there is no such listener added before, this call does no change in the
+// cluster and returns false.
+
+func EncodeListRemoveListenerRequest(name string, registrationId types.UUID) *proto.ClientMessage {
+	clientMessage := proto.NewClientMessageForEncode()
+	clientMessage.SetRetryable(true)
+
+	initialFrame := proto.NewFrameWith(make([]byte, ListRemoveListenerCodecRequestInitialFrameSize), proto.UnfragmentedMessage)
+	FixSizedTypesCodec.EncodeUUID(initialFrame.Content, ListRemoveListenerCodecRequestRegistrationIdOffset, registrationId)
+	clientMessage.AddFrame(initialFrame)
+	clientMessage.SetMessageType(ListRemoveListenerCodecRequestMessageType)
+	clientMessage.SetPartitionId(-1)
+
+	EncodeString(clientMessage, name)
+
+	return clientMessage
+}
+
+func DecodeListRemoveListenerResponse(clientMessage *proto.ClientMessage) bool {
+	frameIterator := clientMessage.FrameIterator()
+	initialFrame := frameIterator.Next()
+
+	return FixSizedTypesCodec.DecodeBoolean(initialFrame.Content, ListRemoveListenerResponseResponseOffset)
+}

--- a/internal/proto/codec/list_remove_with_index_codec.go
+++ b/internal/proto/codec/list_remove_with_index_codec.go
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package codec
+
+import (
+	"github.com/hazelcast/hazelcast-go-client/internal/proto"
+	"github.com/hazelcast/hazelcast-go-client/serialization"
+)
+
+const (
+	// hex: 0x051200
+	ListRemoveWithIndexCodecRequestMessageType = int32(332288)
+	// hex: 0x051201
+	ListRemoveWithIndexCodecResponseMessageType = int32(332289)
+
+	ListRemoveWithIndexCodecRequestIndexOffset      = proto.PartitionIDOffset + proto.IntSizeInBytes
+	ListRemoveWithIndexCodecRequestInitialFrameSize = ListRemoveWithIndexCodecRequestIndexOffset + proto.IntSizeInBytes
+)
+
+// Removes the element at the specified position in this list (optional operation). Shifts any subsequent elements
+// to the left (subtracts one from their indices). Returns the element that was removed from the list.
+
+func EncodeListRemoveWithIndexRequest(name string, index int32) *proto.ClientMessage {
+	clientMessage := proto.NewClientMessageForEncode()
+	clientMessage.SetRetryable(false)
+
+	initialFrame := proto.NewFrameWith(make([]byte, ListRemoveWithIndexCodecRequestInitialFrameSize), proto.UnfragmentedMessage)
+	FixSizedTypesCodec.EncodeInt(initialFrame.Content, ListRemoveWithIndexCodecRequestIndexOffset, index)
+	clientMessage.AddFrame(initialFrame)
+	clientMessage.SetMessageType(ListRemoveWithIndexCodecRequestMessageType)
+	clientMessage.SetPartitionId(-1)
+
+	EncodeString(clientMessage, name)
+
+	return clientMessage
+}
+
+func DecodeListRemoveWithIndexResponse(clientMessage *proto.ClientMessage) serialization.Data {
+	frameIterator := clientMessage.FrameIterator()
+	// empty initial frame
+	frameIterator.Next()
+
+	return CodecUtil.DecodeNullableForData(frameIterator)
+}

--- a/internal/proto/codec/list_set_codec.go
+++ b/internal/proto/codec/list_set_codec.go
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package codec
+
+import (
+	"github.com/hazelcast/hazelcast-go-client/internal/proto"
+	"github.com/hazelcast/hazelcast-go-client/serialization"
+)
+
+const (
+	// hex: 0x051000
+	ListSetCodecRequestMessageType = int32(331776)
+	// hex: 0x051001
+	ListSetCodecResponseMessageType = int32(331777)
+
+	ListSetCodecRequestIndexOffset      = proto.PartitionIDOffset + proto.IntSizeInBytes
+	ListSetCodecRequestInitialFrameSize = ListSetCodecRequestIndexOffset + proto.IntSizeInBytes
+)
+
+// The element previously at the specified position
+
+func EncodeListSetRequest(name string, index int32, value serialization.Data) *proto.ClientMessage {
+	clientMessage := proto.NewClientMessageForEncode()
+	clientMessage.SetRetryable(false)
+
+	initialFrame := proto.NewFrameWith(make([]byte, ListSetCodecRequestInitialFrameSize), proto.UnfragmentedMessage)
+	FixSizedTypesCodec.EncodeInt(initialFrame.Content, ListSetCodecRequestIndexOffset, index)
+	clientMessage.AddFrame(initialFrame)
+	clientMessage.SetMessageType(ListSetCodecRequestMessageType)
+	clientMessage.SetPartitionId(-1)
+
+	EncodeString(clientMessage, name)
+	EncodeData(clientMessage, value)
+
+	return clientMessage
+}
+
+func DecodeListSetResponse(clientMessage *proto.ClientMessage) serialization.Data {
+	frameIterator := clientMessage.FrameIterator()
+	// empty initial frame
+	frameIterator.Next()
+
+	return CodecUtil.DecodeNullableForData(frameIterator)
+}

--- a/internal/proto/codec/list_size_codec.go
+++ b/internal/proto/codec/list_size_codec.go
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package codec
+
+import (
+	"github.com/hazelcast/hazelcast-go-client/internal/proto"
+)
+
+const (
+	// hex: 0x050100
+	ListSizeCodecRequestMessageType = int32(327936)
+	// hex: 0x050101
+	ListSizeCodecResponseMessageType = int32(327937)
+
+	ListSizeCodecRequestInitialFrameSize = proto.PartitionIDOffset + proto.IntSizeInBytes
+
+	ListSizeResponseResponseOffset = proto.ResponseBackupAcksOffset + proto.ByteSizeInBytes
+)
+
+// Returns the number of elements in this list.  If this list contains more than Integer.MAX_VALUE elements, returns
+// Integer.MAX_VALUE.
+
+func EncodeListSizeRequest(name string) *proto.ClientMessage {
+	clientMessage := proto.NewClientMessageForEncode()
+	clientMessage.SetRetryable(true)
+
+	initialFrame := proto.NewFrameWith(make([]byte, ListSizeCodecRequestInitialFrameSize), proto.UnfragmentedMessage)
+	clientMessage.AddFrame(initialFrame)
+	clientMessage.SetMessageType(ListSizeCodecRequestMessageType)
+	clientMessage.SetPartitionId(-1)
+
+	EncodeString(clientMessage, name)
+
+	return clientMessage
+}
+
+func DecodeListSizeResponse(clientMessage *proto.ClientMessage) int32 {
+	frameIterator := clientMessage.FrameIterator()
+	initialFrame := frameIterator.Next()
+
+	return FixSizedTypesCodec.DecodeInt(initialFrame.Content, ListSizeResponseResponseOffset)
+}

--- a/internal/proto/codec/list_sub_codec.go
+++ b/internal/proto/codec/list_sub_codec.go
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package codec
+
+import (
+	"github.com/hazelcast/hazelcast-go-client/internal/proto"
+	"github.com/hazelcast/hazelcast-go-client/serialization"
+)
+
+const (
+	// hex: 0x051500
+	ListSubCodecRequestMessageType = int32(333056)
+	// hex: 0x051501
+	ListSubCodecResponseMessageType = int32(333057)
+
+	ListSubCodecRequestFromOffset       = proto.PartitionIDOffset + proto.IntSizeInBytes
+	ListSubCodecRequestToOffset         = ListSubCodecRequestFromOffset + proto.IntSizeInBytes
+	ListSubCodecRequestInitialFrameSize = ListSubCodecRequestToOffset + proto.IntSizeInBytes
+)
+
+// Returns a view of the portion of this list between the specified from, inclusive, and to, exclusive.(If from and
+// to are equal, the returned list is empty.) The returned list is backed by this list, so non-structural changes in
+// the returned list are reflected in this list, and vice-versa. The returned list supports all of the optional list
+// operations supported by this list.
+// This method eliminates the need for explicit range operations (of the sort that commonly exist for arrays).
+// Any operation that expects a list can be used as a range operation by passing a subList view instead of a whole list.
+// Similar idioms may be constructed for indexOf and lastIndexOf, and all of the algorithms in the Collections class
+// can be applied to a subList.
+// The semantics of the list returned by this method become undefined if the backing list (i.e., this list) is
+// structurally modified in any way other than via the returned list.(Structural modifications are those that change
+// the size of this list, or otherwise perturb it in such a fashion that iterations in progress may yield incorrect results.)
+
+func EncodeListSubRequest(name string, from int32, to int32) *proto.ClientMessage {
+	clientMessage := proto.NewClientMessageForEncode()
+	clientMessage.SetRetryable(true)
+
+	initialFrame := proto.NewFrameWith(make([]byte, ListSubCodecRequestInitialFrameSize), proto.UnfragmentedMessage)
+	FixSizedTypesCodec.EncodeInt(initialFrame.Content, ListSubCodecRequestFromOffset, from)
+	FixSizedTypesCodec.EncodeInt(initialFrame.Content, ListSubCodecRequestToOffset, to)
+	clientMessage.AddFrame(initialFrame)
+	clientMessage.SetMessageType(ListSubCodecRequestMessageType)
+	clientMessage.SetPartitionId(-1)
+
+	EncodeString(clientMessage, name)
+
+	return clientMessage
+}
+
+func DecodeListSubResponse(clientMessage *proto.ClientMessage) []serialization.Data {
+	frameIterator := clientMessage.FrameIterator()
+	// empty initial frame
+	frameIterator.Next()
+
+	return DecodeListMultiFrameForData(frameIterator)
+}

--- a/internal/util/validationutil/util.go
+++ b/internal/util/validationutil/util.go
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package validationutil
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/hazelcast/hazelcast-go-client/internal/hzerror"
+)
+
+const (
+	nonNegativeValueExpected = "non-negative integer number expected: %d"
+	int32ValueExpected       = "signed 32-bit integer number expected: %d"
+)
+
+func ValidateAsNonNegativeInt32(n int) (int32, error) {
+	if n < 0 {
+		return 0, hzerror.NewHazelcastIllegalArgumentError(fmt.Sprint(nonNegativeValueExpected, n), nil)
+	}
+	if n > math.MaxInt32 {
+		return 0, hzerror.NewHazelcastIllegalArgumentError(fmt.Sprint(int32ValueExpected, n), nil)
+	}
+	return int32(n), nil
+}

--- a/internal/util/validationutil/util_test.go
+++ b/internal/util/validationutil/util_test.go
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package validationutil
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateAsNonNegativeInt32(t *testing.T) {
+	testCases := []struct {
+		value         int
+		expectedValue int32
+	}{
+		{0, int32(0)},
+		{42, int32(42)},
+		{math.MaxInt32, int32(math.MaxInt32)},
+	}
+
+	for _, tc := range testCases {
+		t.Run("", func(t *testing.T) {
+			val, err := ValidateAsNonNegativeInt32(tc.value)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedValue, val)
+		})
+	}
+}
+
+func TestValidateAsNonNegativeInt32_Error(t *testing.T) {
+	testCases := []struct {
+		value          int
+		expectedErrMsg string
+	}{
+		{-1, "non-negative"},
+		{math.MaxInt32 + 1, "32-bit"},
+	}
+
+	for _, tc := range testCases {
+		t.Run("", func(t *testing.T) {
+			_, err := ValidateAsNonNegativeInt32(tc.value)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tc.expectedErrMsg)
+		})
+	}
+}

--- a/list_it_test.go
+++ b/list_it_test.go
@@ -217,15 +217,15 @@ func TestList_ContainsAllWithNilElement(t *testing.T) {
 	})
 }
 
-func TestList_Iterator(t *testing.T) {
+func TestList_ToSlice(t *testing.T) {
 	it.ListTester(t, func(t *testing.T, l *hz.List) {
-		res, err := l.Iterator()
+		res, err := l.ToSlice()
 		assert.NoError(t, err)
 		assert.Equal(t, 0, len(res))
 		all := []interface{}{"1", "2"}
 		_, err = l.AddAll(all...)
 		assert.NoError(t, err)
-		res, err = l.Iterator()
+		res, err = l.ToSlice()
 		assert.NoError(t, err)
 		assert.Equal(t, all[0], res[0])
 		assert.Equal(t, all[1], res[1])

--- a/list_it_test.go
+++ b/list_it_test.go
@@ -1,0 +1,384 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package hazelcast_test
+
+import (
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	hz "github.com/hazelcast/hazelcast-go-client"
+	"github.com/hazelcast/hazelcast-go-client/internal/it"
+)
+
+func TestList_AddListener(t *testing.T) {
+	it.ListTester(t, func(t *testing.T, l *hz.List) {
+		const targetCallCount = int32(10)
+		callCount := int32(0)
+		subscriptionID, err := l.AddListener(func(event *hz.ListItemNotified) {
+			if event.EventType == hz.NotifyItemAdded {
+				atomic.AddInt32(&callCount, 1)
+			}
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := 0; i < int(targetCallCount); i++ {
+			item := fmt.Sprintf("item-%d", i)
+			it.MustValue(l.Add(item))
+		}
+		time.Sleep(1 * time.Second)
+		if !assert.Equal(t, targetCallCount, atomic.LoadInt32(&callCount)) {
+			t.FailNow()
+		}
+		atomic.StoreInt32(&callCount, 0)
+		if err = l.RemoveListener(subscriptionID); err != nil {
+			t.Fatal(err)
+		}
+		it.MustValue(l.Add("item-42"))
+		time.Sleep(1 * time.Second)
+		if !assert.Equal(t, int32(0), atomic.LoadInt32(&callCount)) {
+			t.FailNow()
+		}
+	})
+}
+
+func TestList_AddListenerIncludeValue(t *testing.T) {
+	it.ListTester(t, func(t *testing.T, l *hz.List) {
+		const targetCallCount = int32(10)
+		callCount := int32(0)
+		subscriptionID, err := l.AddListenerIncludeValue(func(event *hz.ListItemNotified) {
+			if event.EventType == hz.NotifyItemRemoved {
+				atomic.AddInt32(&callCount, 1)
+			}
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := 0; i < int(targetCallCount); i++ {
+			item := fmt.Sprintf("item-%d", i)
+			it.MustValue(l.Add(item))
+			it.MustBool(l.Remove(item))
+		}
+		time.Sleep(1 * time.Second)
+		if !assert.Equal(t, targetCallCount, atomic.LoadInt32(&callCount)) {
+			t.FailNow()
+		}
+		atomic.StoreInt32(&callCount, 0)
+		if err = l.RemoveListener(subscriptionID); err != nil {
+			t.Fatal(err)
+		}
+		it.MustValue(l.Add("item-42"))
+		it.MustValue(l.Remove("item-42"))
+		time.Sleep(1 * time.Second)
+		if !assert.Equal(t, int32(0), atomic.LoadInt32(&callCount)) {
+			t.FailNow()
+		}
+	})
+}
+
+func TestList_Add(t *testing.T) {
+	it.ListTester(t, func(t *testing.T, l *hz.List) {
+		changed, err := l.Add("test1")
+		assert.NoError(t, err)
+		assert.True(t, changed)
+		result, err := l.Get(0)
+		assert.NoError(t, err)
+		assert.Equal(t, "test1", result)
+	})
+}
+
+func TestList_AddNilElement(t *testing.T) {
+	it.ListTester(t, func(t *testing.T, l *hz.List) {
+		_, err := l.Add(nil)
+		assert.Error(t, err)
+	})
+}
+
+func TestList_AddAt(t *testing.T) {
+	it.ListTester(t, func(t *testing.T, l *hz.List) {
+		assert.NoError(t, l.AddAt(0, "test1"))
+		assert.NoError(t, l.AddAt(1, "test2"))
+		result, err := l.Get(1)
+		assert.NoError(t, err)
+		assert.Equal(t, "test2", result)
+	})
+}
+
+func TestList_AddAtNilElement(t *testing.T) {
+	it.ListTester(t, func(t *testing.T, l *hz.List) {
+		assert.Error(t, l.AddAt(0, nil))
+	})
+}
+
+func TestList_AddAll(t *testing.T) {
+	it.ListTester(t, func(t *testing.T, l *hz.List) {
+		added, err := l.AddAll("1", "2")
+		assert.NoError(t, err)
+		assert.True(t, added)
+		res1, err := l.Get(0)
+		assert.NoError(t, err)
+		assert.Equal(t, "1", res1)
+		res2, err := l.Get(1)
+		assert.NoError(t, err)
+		assert.Equal(t, "2", res2)
+	})
+}
+
+func TestList_AddAllWithNilElement(t *testing.T) {
+	it.ListTester(t, func(t *testing.T, l *hz.List) {
+		_, err := l.AddAll("1", nil)
+		assert.Error(t, err)
+	})
+}
+
+func TestList_AddAllAt(t *testing.T) {
+	it.ListTester(t, func(t *testing.T, l *hz.List) {
+		assert.NoError(t, l.AddAt(0, "0"))
+		added, err := l.AddAllAt(1, "1", "2")
+		assert.NoError(t, err)
+		assert.True(t, added)
+		res1, err := l.Get(1)
+		assert.NoError(t, err)
+		assert.Equal(t, "1", res1)
+		res2, err := l.Get(2)
+		assert.NoError(t, err)
+		assert.Equal(t, "2", res2)
+	})
+}
+
+func TestList_AddAllAtWithNilElement(t *testing.T) {
+	it.ListTester(t, func(t *testing.T, l *hz.List) {
+		_, err := l.AddAllAt(1, "0", nil)
+		assert.Error(t, err)
+	})
+}
+
+func TestList_Clear(t *testing.T) {
+	it.ListTester(t, func(t *testing.T, l *hz.List) {
+		l.AddAll("1", "2")
+		l.Clear()
+		size, err := l.Size()
+		assert.NoError(t, err)
+		assert.Equal(t, int32(0), size)
+	})
+}
+
+func TestList_Contains(t *testing.T) {
+	it.ListTester(t, func(t *testing.T, l *hz.List) {
+		l.AddAll("1", "2")
+		found, err := l.Contains("1")
+		assert.NoError(t, err)
+		assert.True(t, found)
+	})
+}
+
+func TestList_ContainsWithNilElement(t *testing.T) {
+	it.ListTester(t, func(t *testing.T, l *hz.List) {
+		_, err := l.Contains(nil)
+		assert.Error(t, err)
+	})
+}
+
+func TestList_ContainsAll(t *testing.T) {
+	it.ListTester(t, func(t *testing.T, l *hz.List) {
+		all := []interface{}{"1", "2"}
+		l.AddAll(all...)
+		found, err := l.ContainsAll(all...)
+		assert.NoError(t, err)
+		assert.True(t, found)
+	})
+}
+
+func TestList_ContainsAllWithNilElement(t *testing.T) {
+	it.ListTester(t, func(t *testing.T, l *hz.List) {
+		_, err := l.ContainsAll(nil)
+		assert.Error(t, err)
+	})
+}
+
+func TestList_ToSlice(t *testing.T) {
+	it.ListTester(t, func(t *testing.T, l *hz.List) {
+		all := []interface{}{"1", "2"}
+		l.AddAll(all...)
+		res, err := l.ToSlice()
+		assert.NoError(t, err)
+		assert.Equal(t, all[0], res[0])
+		assert.Equal(t, all[1], res[1])
+	})
+}
+
+func TestList_IndexOf(t *testing.T) {
+	it.ListTester(t, func(t *testing.T, l *hz.List) {
+		l.AddAll("1", "2")
+		index, err := l.IndexOf("2")
+		assert.NoError(t, err)
+		assert.Equal(t, int32(1), index)
+	})
+}
+
+func TestList_IndexOfWithNilElement(t *testing.T) {
+	it.ListTester(t, func(t *testing.T, l *hz.List) {
+		_, err := l.IndexOf(nil)
+		assert.Error(t, err)
+	})
+}
+
+func TestList_IsEmpty(t *testing.T) {
+	it.ListTester(t, func(t *testing.T, l *hz.List) {
+		empty, err := l.IsEmpty()
+		assert.NoError(t, err)
+		assert.True(t, empty)
+	})
+}
+
+func TestList_LastIndexOf(t *testing.T) {
+	it.ListTester(t, func(t *testing.T, l *hz.List) {
+		l.AddAll("1", "2", "2")
+		index, err := l.LastIndexOf("2")
+		assert.NoError(t, err)
+		assert.Equal(t, int32(2), index)
+	})
+}
+
+func TestList_LastIndexOfWithNilElement(t *testing.T) {
+	it.ListTester(t, func(t *testing.T, l *hz.List) {
+		_, err := l.LastIndexOf(nil)
+		assert.Error(t, err)
+	})
+}
+
+func TestList_Remove(t *testing.T) {
+	it.ListTester(t, func(t *testing.T, l *hz.List) {
+		l.Add("1")
+		removed, err := l.Remove("1")
+		assert.NoError(t, err)
+		assert.True(t, removed)
+		removed, err = l.Remove("2")
+		assert.NoError(t, err)
+		assert.False(t, removed)
+	})
+}
+
+func TestList_RemoveWithNilElement(t *testing.T) {
+	it.ListTester(t, func(t *testing.T, l *hz.List) {
+		_, err := l.Remove(nil)
+		assert.Error(t, err)
+	})
+}
+
+func TestList_RemoveAt(t *testing.T) {
+	it.ListTester(t, func(t *testing.T, l *hz.List) {
+		l.Add("1")
+		previous, err := l.RemoveAt(0)
+		assert.NoError(t, err)
+		assert.Equal(t, "1", previous)
+	})
+}
+
+func TestList_RemoveAll(t *testing.T) {
+	it.ListTester(t, func(t *testing.T, l *hz.List) {
+		l.AddAll("1", "2", "3")
+		removedAll, err := l.RemoveAll("2", "3")
+		assert.NoError(t, err)
+		assert.True(t, removedAll)
+		found, err := l.Contains("1")
+		assert.NoError(t, err)
+		assert.True(t, found)
+	})
+}
+
+func TestList_RemoveAllWithNilElement(t *testing.T) {
+	it.ListTester(t, func(t *testing.T, l *hz.List) {
+		_, err := l.RemoveAll(nil, "1", "2")
+		assert.Error(t, err)
+	})
+}
+
+func TestList_RetainAll(t *testing.T) {
+	it.ListTester(t, func(t *testing.T, l *hz.List) {
+		l.AddAll("1", "2", "3")
+		changed, err := l.RetainAll("2", "3")
+		assert.NoError(t, err)
+		assert.True(t, changed)
+		found, err := l.Contains("1")
+		assert.NoError(t, err)
+		assert.False(t, found)
+	})
+}
+
+func TestList_RetainAllWithNilElement(t *testing.T) {
+	it.ListTester(t, func(t *testing.T, l *hz.List) {
+		_, err := l.RetainAll(nil, "1", "2")
+		assert.Error(t, err)
+	})
+}
+
+func TestList_Size(t *testing.T) {
+	it.ListTester(t, func(t *testing.T, l *hz.List) {
+		l.AddAll("1", "2", "3")
+		size, err := l.Size()
+		assert.NoError(t, err)
+		assert.Equal(t, int32(3), size)
+	})
+}
+
+func TestList_Get(t *testing.T) {
+	it.ListTester(t, func(t *testing.T, l *hz.List) {
+		l.Add("1")
+		res, err := l.Get(0)
+		assert.NoError(t, err)
+		assert.Equal(t, "1", res)
+	})
+}
+
+func TestList_Set(t *testing.T) {
+	it.ListTester(t, func(t *testing.T, l *hz.List) {
+		l.AddAll("1", "2", "3")
+		l.Set(1, "13")
+		res, err := l.Get(1)
+		assert.NoError(t, err)
+		assert.Equal(t, "13", res)
+	})
+}
+
+func TestList_SetWithNilElement(t *testing.T) {
+	it.ListTester(t, func(t *testing.T, l *hz.List) {
+		_, err := l.Set(0, nil)
+		assert.Error(t, err)
+	})
+}
+
+func TestList_SubList(t *testing.T) {
+	it.ListTester(t, func(t *testing.T, l *hz.List) {
+		l.AddAll("1", "2", "3")
+		res, err := l.SubList(1, 3)
+		assert.NoError(t, err)
+		assert.Equal(t, "2", res[0])
+		assert.Equal(t, "3", res[1])
+	})
+}
+
+func TestList_SetWithoutItem(t *testing.T) {
+	it.ListTester(t, func(t *testing.T, l *hz.List) {
+		_, err := l.Set(1, "a")
+		assert.Error(t, err)
+	})
+}

--- a/list_it_test.go
+++ b/list_it_test.go
@@ -18,6 +18,7 @@ package hazelcast_test
 
 import (
 	"fmt"
+	"math"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -122,6 +123,13 @@ func TestList_AddAt(t *testing.T) {
 	})
 }
 
+func TestList_AddAt_Error(t *testing.T) {
+	it.ListTester(t, func(t *testing.T, l *hz.List) {
+		assert.Error(t, l.AddAt(-1, "test-negative"))
+		assert.Error(t, l.AddAt(math.MaxInt32+1, "test-overflow"))
+	})
+}
+
 func TestList_AddAtNilElement(t *testing.T) {
 	it.ListTester(t, func(t *testing.T, l *hz.List) {
 		assert.Error(t, l.AddAt(0, nil))
@@ -164,6 +172,15 @@ func TestList_AddAllAt(t *testing.T) {
 	})
 }
 
+func TestList_AddAllAt_Error(t *testing.T) {
+	it.ListTester(t, func(t *testing.T, l *hz.List) {
+		_, err := l.AddAllAt(-1, "negative")
+		assert.Error(t, err)
+		_, err = l.AddAllAt(math.MaxInt32+1, "overflow")
+		assert.Error(t, err)
+	})
+}
+
 func TestList_AddAllAtWithNilElement(t *testing.T) {
 	it.ListTester(t, func(t *testing.T, l *hz.List) {
 		_, err := l.AddAllAt(1, "0", nil)
@@ -178,7 +195,7 @@ func TestList_Clear(t *testing.T) {
 		assert.NoError(t, l.Clear())
 		size, err := l.Size()
 		assert.NoError(t, err)
-		assert.Equal(t, int32(0), size)
+		assert.Equal(t, 0, size)
 	})
 }
 
@@ -238,7 +255,7 @@ func TestList_IndexOf(t *testing.T) {
 		assert.NoError(t, err)
 		index, err := l.IndexOf("2")
 		assert.NoError(t, err)
-		assert.Equal(t, int32(1), index)
+		assert.Equal(t, 1, index)
 	})
 }
 
@@ -263,7 +280,7 @@ func TestList_LastIndexOf(t *testing.T) {
 		assert.NoError(t, err)
 		index, err := l.LastIndexOf("2")
 		assert.NoError(t, err)
-		assert.Equal(t, int32(2), index)
+		assert.Equal(t, 2, index)
 	})
 }
 
@@ -301,6 +318,15 @@ func TestList_RemoveAt(t *testing.T) {
 		previous, err := l.RemoveAt(0)
 		assert.NoError(t, err)
 		assert.Equal(t, "1", previous)
+	})
+}
+
+func TestList_RemoveAt_Error(t *testing.T) {
+	it.ListTester(t, func(t *testing.T, l *hz.List) {
+		_, err := l.RemoveAt(-1)
+		assert.Error(t, err)
+		_, err = l.RemoveAt(math.MaxInt32 + 1)
+		assert.Error(t, err)
 	})
 }
 
@@ -350,7 +376,7 @@ func TestList_Size(t *testing.T) {
 		assert.NoError(t, err)
 		size, err := l.Size()
 		assert.NoError(t, err)
-		assert.Equal(t, int32(3), size)
+		assert.Equal(t, 3, size)
 	})
 }
 
@@ -364,6 +390,15 @@ func TestList_Get(t *testing.T) {
 	})
 }
 
+func TestList_Get_Error(t *testing.T) {
+	it.ListTester(t, func(t *testing.T, l *hz.List) {
+		_, err := l.Get(-1)
+		assert.Error(t, err)
+		_, err = l.Get(math.MaxInt32 + 1)
+		assert.Error(t, err)
+	})
+}
+
 func TestList_Set(t *testing.T) {
 	it.ListTester(t, func(t *testing.T, l *hz.List) {
 		_, err := l.AddAll("1", "2", "3")
@@ -373,6 +408,15 @@ func TestList_Set(t *testing.T) {
 		res, err := l.Get(1)
 		assert.NoError(t, err)
 		assert.Equal(t, "13", res)
+	})
+}
+
+func TestList_Set_Error(t *testing.T) {
+	it.ListTester(t, func(t *testing.T, l *hz.List) {
+		_, err := l.Set(-1, "negative")
+		assert.Error(t, err)
+		_, err = l.Set(math.MaxInt32+1, "overflow")
+		assert.Error(t, err)
 	})
 }
 
@@ -391,6 +435,19 @@ func TestList_SubList(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "2", res[0])
 		assert.Equal(t, "3", res[1])
+	})
+}
+
+func TestList_SubList_Error(t *testing.T) {
+	it.ListTester(t, func(t *testing.T, l *hz.List) {
+		_, err := l.SubList(-1, 3)
+		assert.Error(t, err)
+		_, err = l.SubList(1, -3)
+		assert.Error(t, err)
+		_, err = l.SubList(math.MaxInt32+1, 3)
+		assert.Error(t, err)
+		_, err = l.SubList(1, math.MaxInt32+1)
+		assert.Error(t, err)
 	})
 }
 

--- a/list_it_test.go
+++ b/list_it_test.go
@@ -217,12 +217,15 @@ func TestList_ContainsAllWithNilElement(t *testing.T) {
 	})
 }
 
-func TestList_ToSlice(t *testing.T) {
+func TestList_Iterator(t *testing.T) {
 	it.ListTester(t, func(t *testing.T, l *hz.List) {
-		all := []interface{}{"1", "2"}
-		_, err := l.AddAll(all...)
+		res, err := l.Iterator()
 		assert.NoError(t, err)
-		res, err := l.ToSlice()
+		assert.Equal(t, 0, len(res))
+		all := []interface{}{"1", "2"}
+		_, err = l.AddAll(all...)
+		assert.NoError(t, err)
+		res, err = l.Iterator()
 		assert.NoError(t, err)
 		assert.Equal(t, all[0], res[0])
 		assert.Equal(t, all[1], res[1])

--- a/list_it_test.go
+++ b/list_it_test.go
@@ -173,8 +173,9 @@ func TestList_AddAllAtWithNilElement(t *testing.T) {
 
 func TestList_Clear(t *testing.T) {
 	it.ListTester(t, func(t *testing.T, l *hz.List) {
-		l.AddAll("1", "2")
-		l.Clear()
+		_, err := l.AddAll("1", "2")
+		assert.NoError(t, err)
+		assert.NoError(t, l.Clear())
 		size, err := l.Size()
 		assert.NoError(t, err)
 		assert.Equal(t, int32(0), size)
@@ -183,7 +184,8 @@ func TestList_Clear(t *testing.T) {
 
 func TestList_Contains(t *testing.T) {
 	it.ListTester(t, func(t *testing.T, l *hz.List) {
-		l.AddAll("1", "2")
+		_, err := l.AddAll("1", "2")
+		assert.NoError(t, err)
 		found, err := l.Contains("1")
 		assert.NoError(t, err)
 		assert.True(t, found)
@@ -200,7 +202,8 @@ func TestList_ContainsWithNilElement(t *testing.T) {
 func TestList_ContainsAll(t *testing.T) {
 	it.ListTester(t, func(t *testing.T, l *hz.List) {
 		all := []interface{}{"1", "2"}
-		l.AddAll(all...)
+		_, err := l.AddAll(all...)
+		assert.NoError(t, err)
 		found, err := l.ContainsAll(all...)
 		assert.NoError(t, err)
 		assert.True(t, found)
@@ -217,7 +220,8 @@ func TestList_ContainsAllWithNilElement(t *testing.T) {
 func TestList_ToSlice(t *testing.T) {
 	it.ListTester(t, func(t *testing.T, l *hz.List) {
 		all := []interface{}{"1", "2"}
-		l.AddAll(all...)
+		_, err := l.AddAll(all...)
+		assert.NoError(t, err)
 		res, err := l.ToSlice()
 		assert.NoError(t, err)
 		assert.Equal(t, all[0], res[0])
@@ -227,7 +231,8 @@ func TestList_ToSlice(t *testing.T) {
 
 func TestList_IndexOf(t *testing.T) {
 	it.ListTester(t, func(t *testing.T, l *hz.List) {
-		l.AddAll("1", "2")
+		_, err := l.AddAll("1", "2")
+		assert.NoError(t, err)
 		index, err := l.IndexOf("2")
 		assert.NoError(t, err)
 		assert.Equal(t, int32(1), index)
@@ -251,7 +256,8 @@ func TestList_IsEmpty(t *testing.T) {
 
 func TestList_LastIndexOf(t *testing.T) {
 	it.ListTester(t, func(t *testing.T, l *hz.List) {
-		l.AddAll("1", "2", "2")
+		_, err := l.AddAll("1", "2", "2")
+		assert.NoError(t, err)
 		index, err := l.LastIndexOf("2")
 		assert.NoError(t, err)
 		assert.Equal(t, int32(2), index)
@@ -267,7 +273,8 @@ func TestList_LastIndexOfWithNilElement(t *testing.T) {
 
 func TestList_Remove(t *testing.T) {
 	it.ListTester(t, func(t *testing.T, l *hz.List) {
-		l.Add("1")
+		_, err := l.Add("1")
+		assert.NoError(t, err)
 		removed, err := l.Remove("1")
 		assert.NoError(t, err)
 		assert.True(t, removed)
@@ -286,7 +293,8 @@ func TestList_RemoveWithNilElement(t *testing.T) {
 
 func TestList_RemoveAt(t *testing.T) {
 	it.ListTester(t, func(t *testing.T, l *hz.List) {
-		l.Add("1")
+		_, err := l.Add("1")
+		assert.NoError(t, err)
 		previous, err := l.RemoveAt(0)
 		assert.NoError(t, err)
 		assert.Equal(t, "1", previous)
@@ -295,7 +303,8 @@ func TestList_RemoveAt(t *testing.T) {
 
 func TestList_RemoveAll(t *testing.T) {
 	it.ListTester(t, func(t *testing.T, l *hz.List) {
-		l.AddAll("1", "2", "3")
+		_, err := l.AddAll("1", "2", "3")
+		assert.NoError(t, err)
 		removedAll, err := l.RemoveAll("2", "3")
 		assert.NoError(t, err)
 		assert.True(t, removedAll)
@@ -314,7 +323,8 @@ func TestList_RemoveAllWithNilElement(t *testing.T) {
 
 func TestList_RetainAll(t *testing.T) {
 	it.ListTester(t, func(t *testing.T, l *hz.List) {
-		l.AddAll("1", "2", "3")
+		_, err := l.AddAll("1", "2", "3")
+		assert.NoError(t, err)
 		changed, err := l.RetainAll("2", "3")
 		assert.NoError(t, err)
 		assert.True(t, changed)
@@ -333,7 +343,8 @@ func TestList_RetainAllWithNilElement(t *testing.T) {
 
 func TestList_Size(t *testing.T) {
 	it.ListTester(t, func(t *testing.T, l *hz.List) {
-		l.AddAll("1", "2", "3")
+		_, err := l.AddAll("1", "2", "3")
+		assert.NoError(t, err)
 		size, err := l.Size()
 		assert.NoError(t, err)
 		assert.Equal(t, int32(3), size)
@@ -342,7 +353,8 @@ func TestList_Size(t *testing.T) {
 
 func TestList_Get(t *testing.T) {
 	it.ListTester(t, func(t *testing.T, l *hz.List) {
-		l.Add("1")
+		_, err := l.Add("1")
+		assert.NoError(t, err)
 		res, err := l.Get(0)
 		assert.NoError(t, err)
 		assert.Equal(t, "1", res)
@@ -351,8 +363,10 @@ func TestList_Get(t *testing.T) {
 
 func TestList_Set(t *testing.T) {
 	it.ListTester(t, func(t *testing.T, l *hz.List) {
-		l.AddAll("1", "2", "3")
-		l.Set(1, "13")
+		_, err := l.AddAll("1", "2", "3")
+		assert.NoError(t, err)
+		_, err = l.Set(1, "13")
+		assert.NoError(t, err)
 		res, err := l.Get(1)
 		assert.NoError(t, err)
 		assert.Equal(t, "13", res)
@@ -368,7 +382,8 @@ func TestList_SetWithNilElement(t *testing.T) {
 
 func TestList_SubList(t *testing.T) {
 	it.ListTester(t, func(t *testing.T, l *hz.List) {
-		l.AddAll("1", "2", "3")
+		_, err := l.AddAll("1", "2", "3")
+		assert.NoError(t, err)
 		res, err := l.SubList(1, 3)
 		assert.NoError(t, err)
 		assert.Equal(t, "2", res[0])

--- a/proxy.go
+++ b/proxy.go
@@ -240,6 +240,18 @@ func (p *proxy) convertToObject(data serialization.Data) (interface{}, error) {
 	return p.serializationService.ToObject(data)
 }
 
+func (p *proxy) convertToObjects(values []serialization.Data) ([]interface{}, error) {
+	decodedValues := make([]interface{}, len(values))
+	for i, value := range values {
+		if decodedValue, err := p.convertToObject(value); err != nil {
+			return nil, err
+		} else {
+			decodedValues[i] = decodedValue
+		}
+	}
+	return decodedValues, nil
+}
+
 func (p *proxy) convertToData(object interface{}) (serialization.Data, error) {
 	return p.serializationService.ToData(object)
 }

--- a/proxy_list.go
+++ b/proxy_list.go
@@ -323,10 +323,10 @@ func (l *List) SubList(start int32, end int32) ([]interface{}, error) {
 
 // Iterator returns all of the items in this list in proper sequence.
 func (l *List) Iterator() ([]interface{}, error) {
-	request := codec.EncodeListGetAllRequest(l.name)
+	request := codec.EncodeListIteratorRequest(l.name)
 	response, err := l.invokeOnPartition(context.TODO(), request, l.partitionID)
 	if err != nil {
 		return nil, err
 	}
-	return l.convertToObjects(codec.DecodeListGetAllResponse(response))
+	return l.convertToObjects(codec.DecodeListIteratorResponse(response))
 }

--- a/proxy_list.go
+++ b/proxy_list.go
@@ -1,0 +1,332 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package hazelcast
+
+import (
+	"context"
+
+	"github.com/hazelcast/hazelcast-go-client/internal/proto"
+	"github.com/hazelcast/hazelcast-go-client/internal/proto/codec"
+	"github.com/hazelcast/hazelcast-go-client/serialization"
+	"github.com/hazelcast/hazelcast-go-client/types"
+)
+
+/*
+List is a concurrent, distributed, ordered collection. The user of this
+data structure has precise control over where in the list each element is
+inserted. The user can access elements by their integer index (position in the list),
+and search for elements in the list.
+
+List is not a partitioned Hazelcast data structure. So all the contents of the List are stored in a single
+machine (and in the backup). So, a single List will not scale by adding more members in the cluster.
+*/
+type List struct {
+	*proxy
+	partitionID int32
+}
+
+func newList(p *proxy) (*List, error) {
+	if partitionID, err := p.stringToPartitionID(p.name); err != nil {
+		return nil, err
+	} else {
+		return &List{proxy: p, partitionID: partitionID}, nil
+	}
+}
+
+// AddListener adds an item listener for this list.
+// The listener will be invoked whenever an item is added to or removed from this list.
+// Returns subscription ID of the listener.
+func (l *List) AddListener(handler ListItemNotifiedHandler) (types.UUID, error) {
+	return l.addListener(false, handler)
+}
+
+// AddListener adds an item listener for this list.
+// The listener will be invoked whenever an item is added to or removed from this list.
+// Received events include the updated item.
+// Returns subscription ID of the listener.
+func (l *List) AddListenerIncludeValue(handler ListItemNotifiedHandler) (types.UUID, error) {
+	return l.addListener(true, handler)
+}
+
+func (l *List) addListener(includeValue bool, handler ListItemNotifiedHandler) (types.UUID, error) {
+	subscriptionID := types.NewUUID()
+	addRequest := codec.EncodeListAddListenerRequest(l.name, includeValue, l.config.ClusterConfig.SmartRouting)
+	removeRequest := codec.EncodeListRemoveListenerRequest(l.name, subscriptionID)
+	listenerHandler := func(msg *proto.ClientMessage) {
+		codec.HandleListAddListener(msg, func(itemData serialization.Data, uuid types.UUID, eventType int32) {
+			item, err := l.convertToObject(itemData)
+			if err != nil {
+				l.logger.Warnf("cannot convert data to Go value: %v", err)
+				return
+			}
+			member := l.clusterService.GetMemberByUUID(uuid.String())
+			handler(newListItemNotified(l.name, item, member, eventType))
+		})
+	}
+	err := l.listenerBinder.Add(subscriptionID, addRequest, removeRequest, listenerHandler)
+	return subscriptionID, err
+}
+
+// RemoveListener removes the item listener with the given subscription ID.
+func (l *List) RemoveListener(subscriptionID types.UUID) error {
+	return l.listenerBinder.Remove(subscriptionID)
+}
+
+// Add appends the specified element to the end of this list.
+// Returns true if the list has changed as a result of this operation, false otherwise.
+func (l *List) Add(element interface{}) (bool, error) {
+	elementData, err := l.validateAndSerialize(element)
+	if err != nil {
+		return false, err
+	}
+	request := codec.EncodeListAddRequest(l.name, elementData)
+	response, err := l.invokeOnPartition(context.TODO(), request, l.partitionID)
+	if err != nil {
+		return false, err
+	}
+	return codec.DecodeListAddResponse(response), nil
+}
+
+// AddAt inserts the specified element at the specified index.
+// Shifts the subsequent elements to the right.
+func (l *List) AddAt(index int32, element interface{}) error {
+	elementData, err := l.validateAndSerialize(element)
+	if err != nil {
+		return err
+	}
+	request := codec.EncodeListAddWithIndexRequest(l.name, index, elementData)
+	_, err = l.invokeOnPartition(context.TODO(), request, l.partitionID)
+	return err
+}
+
+// AddAll appends all elements in the specified slice to the end of this list.
+// Returns true if the list has changed as a result of this operation, false otherwise.
+func (l *List) AddAll(elements ...interface{}) (bool, error) {
+	elementsData, err := l.validateAndSerializeValues(elements...)
+	if err != nil {
+		return false, err
+	}
+	request := codec.EncodeListAddAllRequest(l.name, elementsData)
+	response, err := l.invokeOnPartition(context.TODO(), request, l.partitionID)
+	if err != nil {
+		return false, err
+	}
+	return codec.DecodeListAddAllResponse(response), nil
+}
+
+// AddAllAt inserts all elements in the specified slice at specified index, keeping the order of the slice.
+// Shifts the subsequent elements to the right.
+// Returns true if the list has changed as a result of this operation, false otherwise.
+func (l *List) AddAllAt(index int32, elements ...interface{}) (bool, error) {
+	elementsData, err := l.validateAndSerializeValues(elements...)
+	if err != nil {
+		return false, err
+	}
+	request := codec.EncodeListAddAllWithIndexRequest(l.name, index, elementsData)
+	response, err := l.invokeOnPartition(context.TODO(), request, l.partitionID)
+	if err != nil {
+		return false, err
+	}
+	return codec.DecodeListAddAllWithIndexResponse(response), nil
+}
+
+// Clear removes all elements from the list.
+func (l *List) Clear() error {
+	request := codec.EncodeListClearRequest(l.name)
+	_, err := l.invokeOnPartition(context.TODO(), request, l.partitionID)
+	return err
+}
+
+// Contains checks if the list contains the given element.
+// Returns true if the list contains the element, false otherwise.
+func (l *List) Contains(element interface{}) (bool, error) {
+	elementData, err := l.validateAndSerialize(element)
+	if err != nil {
+		return false, err
+	}
+	request := codec.EncodeListContainsRequest(l.name, elementData)
+	response, err := l.invokeOnPartition(context.TODO(), request, l.partitionID)
+	if err != nil {
+		return false, err
+	}
+	return codec.DecodeListContainsResponse(response), nil
+}
+
+// ContainsAll checks if the list contains all of the given elements.
+// Returns true if the list contains all of the elements, otherwise false.
+func (l *List) ContainsAll(elements ...interface{}) (bool, error) {
+	elementsData, err := l.validateAndSerializeValues(elements...)
+	if err != nil {
+		return false, err
+	}
+	request := codec.EncodeListContainsAllRequest(l.name, elementsData)
+	response, err := l.invokeOnPartition(context.TODO(), request, l.partitionID)
+	if err != nil {
+		return false, err
+	}
+	return codec.DecodeListContainsAllResponse(response), nil
+}
+
+// Get retrieves the element at given index.
+func (l *List) Get(index int32) (interface{}, error) {
+	request := codec.EncodeListGetRequest(l.name, index)
+	response, err := l.invokeOnPartition(context.TODO(), request, l.partitionID)
+	if err != nil {
+		return nil, err
+	}
+	return l.convertToObject(codec.DecodeListGetResponse(response))
+}
+
+// IndexOf returns the index of the first occurrence of the given element in this list.
+func (l *List) IndexOf(element interface{}) (int32, error) {
+	elementData, err := l.validateAndSerialize(element)
+	if err != nil {
+		return 0, err
+	}
+	request := codec.EncodeListIndexOfRequest(l.name, elementData)
+	response, err := l.invokeOnPartition(context.TODO(), request, l.partitionID)
+	if err != nil {
+		return 0, err
+	}
+	return codec.DecodeListIndexOfResponse(response), nil
+}
+
+// IsEmpty return true if the list is empty, false otherwise.
+func (l *List) IsEmpty() (bool, error) {
+	request := codec.EncodeListIsEmptyRequest(l.name)
+	response, err := l.invokeOnPartition(context.TODO(), request, l.partitionID)
+	if err != nil {
+		return false, err
+	}
+	return codec.DecodeListIsEmptyResponse(response), nil
+}
+
+// LastIndexOf returns the index of the last occurrence of the given element in this list.
+func (l *List) LastIndexOf(element interface{}) (int32, error) {
+	elementData, err := l.validateAndSerialize(element)
+	if err != nil {
+		return 0, err
+	}
+	request := codec.EncodeListLastIndexOfRequest(l.name, elementData)
+	response, err := l.invokeOnPartition(context.TODO(), request, l.partitionID)
+	if err != nil {
+		return 0, err
+	}
+	return codec.DecodeListLastIndexOfResponse(response), nil
+}
+
+// Remove removes the given element from this list.
+// Returns true if the list has changed as the result of this operation, false otherwise.
+func (l *List) Remove(element interface{}) (bool, error) {
+	elementData, err := l.validateAndSerialize(element)
+	if err != nil {
+		return false, err
+	}
+	request := codec.EncodeListRemoveRequest(l.name, elementData)
+	response, err := l.invokeOnPartition(context.TODO(), request, l.partitionID)
+	if err != nil {
+		return false, err
+	}
+	return codec.DecodeListRemoveResponse(response), nil
+}
+
+// RemoveAt removes the element at the given index.
+// Returns the removed element.
+func (l *List) RemoveAt(index int32) (interface{}, error) {
+	request := codec.EncodeListRemoveWithIndexRequest(l.name, index)
+	response, err := l.invokeOnPartition(context.TODO(), request, l.partitionID)
+	if err != nil {
+		return nil, err
+	}
+	return l.convertToObject(codec.DecodeListRemoveWithIndexResponse(response))
+}
+
+// RemoveAll removes the given elements from the list.
+// Returns true if the list has changed as the result of this operation, false otherwise.
+func (l *List) RemoveAll(elements ...interface{}) (bool, error) {
+	elementsData, err := l.validateAndSerializeValues(elements...)
+	if err != nil {
+		return false, err
+	}
+	request := codec.EncodeListCompareAndRemoveAllRequest(l.name, elementsData)
+	response, err := l.invokeOnPartition(context.TODO(), request, l.partitionID)
+	if err != nil {
+		return false, err
+	}
+	return codec.DecodeListCompareAndRemoveAllResponse(response), nil
+}
+
+// RetainAll removes all elements from this list except the ones contained in the given slice.
+// Returns true if the list has changed as a result of this operation, false otherwise.
+func (l *List) RetainAll(elements ...interface{}) (bool, error) {
+	elementsData, err := l.validateAndSerializeValues(elements...)
+	if err != nil {
+		return false, err
+	}
+	request := codec.EncodeListCompareAndRetainAllRequest(l.name, elementsData)
+	response, err := l.invokeOnPartition(context.TODO(), request, l.partitionID)
+	if err != nil {
+		return false, err
+	}
+	return codec.DecodeListCompareAndRetainAllResponse(response), nil
+}
+
+// Set replaces the element at the specified index in this list with the specified element.
+// Returns the previous element from the list.
+func (l *List) Set(index int32, element interface{}) (interface{}, error) {
+	elementData, err := l.validateAndSerialize(element)
+	if err != nil {
+		return nil, err
+	}
+	request := codec.EncodeListSetRequest(l.name, index, elementData)
+	response, err := l.invokeOnPartition(context.TODO(), request, l.partitionID)
+	if err != nil {
+		return nil, err
+	}
+	return l.convertToObject(codec.DecodeListSetResponse(response))
+}
+
+// Size returns the number of elements in this list.
+func (l *List) Size() (int32, error) {
+	request := codec.EncodeListSizeRequest(l.name)
+	response, err := l.invokeOnPartition(context.TODO(), request, l.partitionID)
+	if err != nil {
+		return 0, err
+	}
+	return codec.DecodeListSizeResponse(response), nil
+}
+
+// SubList returns a view of this list that contains elements between index numbers
+// from start (inclusive) to end (exclusive).
+func (l *List) SubList(start int32, end int32) ([]interface{}, error) {
+	request := codec.EncodeListSubRequest(l.name, start, end)
+	response, err := l.invokeOnPartition(context.TODO(), request, l.partitionID)
+	if err != nil {
+		return nil, err
+	}
+	return l.convertToObjects(codec.DecodeListSubResponse(response))
+}
+
+// ToSlice returns a slice that contains all elements of this list in proper sequence.
+func (l *List) ToSlice() ([]interface{}, error) {
+	request := codec.EncodeListGetAllRequest(l.name)
+	response, err := l.invokeOnPartition(context.TODO(), request, l.partitionID)
+	if err != nil {
+		return nil, err
+	}
+	return l.convertToObjects(codec.DecodeListGetAllResponse(response))
+}

--- a/proxy_list.go
+++ b/proxy_list.go
@@ -321,8 +321,8 @@ func (l *List) SubList(start int32, end int32) ([]interface{}, error) {
 	return l.convertToObjects(codec.DecodeListSubResponse(response))
 }
 
-// ToSlice returns a slice that contains all elements of this list in proper sequence.
-func (l *List) ToSlice() ([]interface{}, error) {
+// Iterator returns all of the items in this list in proper sequence.
+func (l *List) Iterator() ([]interface{}, error) {
 	request := codec.EncodeListGetAllRequest(l.name)
 	response, err := l.invokeOnPartition(context.TODO(), request, l.partitionID)
 	if err != nil {

--- a/proxy_list.go
+++ b/proxy_list.go
@@ -321,12 +321,12 @@ func (l *List) SubList(start int32, end int32) ([]interface{}, error) {
 	return l.convertToObjects(codec.DecodeListSubResponse(response))
 }
 
-// Iterator returns all of the items in this list in proper sequence.
-func (l *List) Iterator() ([]interface{}, error) {
-	request := codec.EncodeListIteratorRequest(l.name)
+// ToSlice returns a slice that contains all elements of this list in proper sequence.
+func (l *List) ToSlice() ([]interface{}, error) {
+	request := codec.EncodeListGetAllRequest(l.name)
 	response, err := l.invokeOnPartition(context.TODO(), request, l.partitionID)
 	if err != nil {
 		return nil, err
 	}
-	return l.convertToObjects(codec.DecodeListIteratorResponse(response))
+	return l.convertToObjects(codec.DecodeListGetAllResponse(response))
 }

--- a/proxy_manager.go
+++ b/proxy_manager.go
@@ -76,6 +76,14 @@ func (m *proxyManager) getTopic(objectName string) (*Topic, error) {
 	}
 }
 
+func (m *proxyManager) getList(objectName string) (*List, error) {
+	if p, err := m.proxyFor("hz:impl:listService", objectName); err != nil {
+		return nil, err
+	} else {
+		return newList(p)
+	}
+}
+
 func (m *proxyManager) remove(serviceName string, objectName string) error {
 	name := makeProxyName(serviceName, objectName)
 	m.mu.Lock()

--- a/proxy_map.go
+++ b/proxy_map.go
@@ -902,18 +902,6 @@ func (m *Map) tryRemove(key interface{}, timeout int64) (interface{}, error) {
 	}
 }
 
-func (m *Map) convertToObjects(valueDatas []pubser.Data) ([]interface{}, error) {
-	values := make([]interface{}, len(valueDatas))
-	for i, valueData := range valueDatas {
-		if value, err := m.convertToObject(valueData); err != nil {
-			return nil, err
-		} else {
-			values[i] = value
-		}
-	}
-	return values, nil
-}
-
 func (m *Map) makeListenerRequest(keyData, predicateData pubser.Data, flags int32, includeValue bool, smart bool) *proto.ClientMessage {
 	if keyData != nil {
 		if predicateData != nil {

--- a/proxy_queue.go
+++ b/proxy_queue.go
@@ -138,7 +138,6 @@ func (q *Queue) DrainWithMaxSize(maxSize int) ([]interface{}, error) {
 	} else {
 		return q.convertToObjects(codec.DecodeQueueDrainToMaxSizeResponse(response))
 	}
-
 }
 
 // Iterator returns all of the items in this queue.
@@ -309,16 +308,4 @@ func (q *Queue) poll(ctx context.Context, timeout int64) (interface{}, error) {
 	} else {
 		return q.convertToObject(codec.DecodeQueuePollResponse(response))
 	}
-}
-
-func (q *Queue) convertToObjects(data []serialization.Data) ([]interface{}, error) {
-	decodedValues := []interface{}{}
-	for _, datum := range data {
-		if obj, err := q.convertToObject(datum); err != nil {
-			return nil, err
-		} else {
-			decodedValues = append(decodedValues, obj)
-		}
-	}
-	return decodedValues, nil
 }

--- a/proxy_queue.go
+++ b/proxy_queue.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/hazelcast/hazelcast-go-client/internal/proto"
 	"github.com/hazelcast/hazelcast-go-client/internal/proto/codec"
+	"github.com/hazelcast/hazelcast-go-client/internal/util/validationutil"
 	"github.com/hazelcast/hazelcast-go-client/serialization"
 )
 
@@ -132,7 +133,11 @@ func (q *Queue) Drain() ([]interface{}, error) {
 
 // DrainWithMaxSize returns maximum maxSize items in tne queue and removes returned items from the queue.
 func (q *Queue) DrainWithMaxSize(maxSize int) ([]interface{}, error) {
-	request := codec.EncodeQueueDrainToMaxSizeRequest(q.name, int32(maxSize))
+	maxSizeAsInt32, err := validationutil.ValidateAsNonNegativeInt32(maxSize)
+	if err != nil {
+		return nil, err
+	}
+	request := codec.EncodeQueueDrainToMaxSizeRequest(q.name, maxSizeAsInt32)
 	if response, err := q.invokeOnPartition(context.TODO(), request, q.partitionID); err != nil {
 		return nil, err
 	} else {

--- a/proxy_queue.go
+++ b/proxy_queue.go
@@ -80,7 +80,7 @@ func (q *Queue) AddListener(handler QueueItemNotifiedHandler) (types.UUID, error
 }
 
 // AddListenerIncludeValue adds an item listener for this queue. Listener will be notified for all queue add/remove events.
-// Received events inclues the updated item.
+// Received events include the updated item.
 func (q *Queue) AddListenerIncludeValue(handler QueueItemNotifiedHandler) (types.UUID, error) {
 	return q.addListener(true, handler)
 }

--- a/proxy_queue.go
+++ b/proxy_queue.go
@@ -277,7 +277,7 @@ func (q *Queue) add(ctx context.Context, value interface{}, timeout int64) (bool
 	} else {
 		request := codec.EncodeQueueOfferRequest(q.name, valueData, timeout)
 		if response, err := q.invokeOnPartition(ctx, request, q.partitionID); err != nil {
-			return false, nil
+			return false, err
 		} else {
 			return codec.DecodeQueueOfferResponse(response), nil
 		}

--- a/queue_it_test.go
+++ b/queue_it_test.go
@@ -18,6 +18,7 @@ package hazelcast_test
 
 import (
 	"fmt"
+	"math"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -184,6 +185,15 @@ func TestQueue_DrainWithMaxSize(t *testing.T) {
 			targetValues := []interface{}{int64(1), int64(2)}
 			assert.Equal(t, targetValues, values)
 		}
+	})
+}
+
+func TestQueue_DrainWithMaxSize_Error(t *testing.T) {
+	it.QueueTester(t, func(t *testing.T, q *hz.Queue) {
+		_, err := q.DrainWithMaxSize(-1)
+		assert.Error(t, err)
+		_, err = q.DrainWithMaxSize(math.MaxInt32 + 1)
+		assert.Error(t, err)
 	})
 }
 


### PR DESCRIPTION
* Adds `List` support
* Introduces common `convertToObjects` method for proxies
* Fixes error handling in `Queue.Add`

Client protocol changes for the new codecs are ad-hoc for now. They will be added into the protocol repo with https://github.com/hazelcast/hazelcast-client-protocol/pull/375 or in a subsequent PR.