### PR TITLE
Purge proxies from local cache on Destroy()

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -31,7 +31,7 @@ func TestClient_NewConfigBuilder(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if "my-cluster" != config.ClusterConfig.Name {
+	if config.ClusterConfig.Name != "my-cluster" {
 		t.Errorf("target: %v != %v", "my-cluster", config.ClusterConfig.Name)
 	}
 }

--- a/config.go
+++ b/config.go
@@ -457,7 +457,6 @@ func (b *SerializationConfigBuilder) buildConfig() (*serialization.Config, error
 
 type LoggerConfigBuilder struct {
 	config *logger.Config
-	err    error
 }
 
 func newLoggerConfigBuilder() *LoggerConfigBuilder {

--- a/config_test.go
+++ b/config_test.go
@@ -46,7 +46,7 @@ func TestConfigNewConfigBuilder(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	if "my-cluster" != config.ClusterConfig.Name {
+	if config.ClusterConfig.Name != "my-cluster" {
 		t.Errorf("target: my-cluster != %v", config.ClusterConfig.Name)
 	}
 	targetAddrs := []string{"192.168.1.2"}

--- a/proxy.go
+++ b/proxy.go
@@ -93,9 +93,15 @@ type proxy struct {
 	name                 string
 	logger               ilogger.Logger
 	circuitBreaker       *cb.CircuitBreaker
+	removeFromCacheFn    func() bool
 }
 
-func newProxy(bundle creationBundle, serviceName string, objectName string, subscriptionIDGen *iproxy.ReferenceIDGenerator) (*proxy, error) {
+func newProxy(bundle creationBundle,
+	serviceName string,
+	objectName string,
+	subscriptionIDGen *iproxy.ReferenceIDGenerator,
+	removeFromCacheFn func() bool) (*proxy, error) {
+
 	bundle.Check()
 	// TODO: make circuit breaker configurable
 	circuitBreaker := cb.NewCircuitBreaker(
@@ -116,6 +122,7 @@ func newProxy(bundle creationBundle, serviceName string, objectName string, subs
 		config:               bundle.Config,
 		logger:               bundle.Logger,
 		circuitBreaker:       circuitBreaker,
+		removeFromCacheFn:    removeFromCacheFn,
 	}
 	if err := p.create(); err != nil {
 		return nil, err
@@ -133,7 +140,15 @@ func (p *proxy) create() error {
 	return nil
 }
 
+// Destroys this object cluster-wide.
+// Clears and releases all resources for this object.
 func (p *proxy) Destroy() error {
+	// wipe from proxy manager cache
+	if !p.removeFromCacheFn() {
+		// no need to destroy on cluster, since the proxy is stale and was already destroyed
+		return nil
+	}
+	// destroy on cluster
 	request := codec.EncodeClientDestroyProxyRequest(p.name, p.serviceName)
 	inv := p.invocationFactory.NewInvocationOnRandomTarget(request, nil)
 	p.requestCh <- inv

--- a/proxy_it_test.go
+++ b/proxy_it_test.go
@@ -36,6 +36,10 @@ func TestProxy_Destroy(t *testing.T) {
 		if err := m.Destroy(); err != nil {
 			t.Fatal(err)
 		}
+		// the next call should do nothing and return no error
+		if err := m.Destroy(); err != nil {
+			t.Fatal(err)
+		}
 	})
 }
 


### PR DESCRIPTION
* Fixes the issue with proxies not being purged from the local proxy manager cache on Destroy() which led to a memory leak
* Also fixes some code issues, like unused consts, reported by [staticcheck](https://staticcheck.io/) linter