### PR TITLE
Improve test stability

### DIFF
--- a/internal/it/list.go
+++ b/internal/it/list.go
@@ -56,6 +56,9 @@ func ListTesterWithConfigBuilderWithName(t *testing.T,
 		cb.Cluster().SetSmartRouting(smart)
 		client, l = getClientListWithConfig(listName(), cb)
 		defer func() {
+			if err := l.Destroy(); err != nil {
+				t.Logf("test warning, could not destroy list: %s", err.Error())
+			}
 			if err := client.Shutdown(); err != nil {
 				t.Logf("test warning, client not shutdown: %s", err.Error())
 			}

--- a/internal/it/map.go
+++ b/internal/it/map.go
@@ -35,7 +35,7 @@ func MapTester(t *testing.T, f func(t *testing.T, m *hz.Map)) {
 
 func MapTesterWithConfigBuilder(t *testing.T, cbCallback func(cb *hz.ConfigBuilder), f func(t *testing.T, m *hz.Map)) {
 	makeMapName := func() string {
-		return fmt.Sprintf("test-map-%d", rand.Int())
+		return fmt.Sprintf("test-map-%d-%d", idGen.NextID(), rand.Int())
 	}
 	MapTesterWithConfigBuilderWithName(t, makeMapName, cbCallback, f)
 }
@@ -58,7 +58,9 @@ func MapTesterWithConfigBuilderWithName(t *testing.T, makeMapName func() string,
 		cb.Cluster().SetSmartRouting(smart)
 		client, m = GetClientMapWithConfigBuilder(makeMapName(), cb)
 		defer func() {
-			m.EvictAll()
+			if err := m.Destroy(); err != nil {
+				t.Logf("test warning, could not destroy map: %s", err.Error())
+			}
 			if err := client.Shutdown(); err != nil {
 				t.Logf("Test warning, client not shutdown: %s", err.Error())
 			}

--- a/internal/it/queue.go
+++ b/internal/it/queue.go
@@ -52,6 +52,9 @@ func QueueTesterWithConfigBuilderWithName(t *testing.T, queueName func() string,
 		cb.Cluster().SetSmartRouting(smart)
 		client, q = getClientQueueWithConfig(queueName(), cb)
 		defer func() {
+			if err := q.Destroy(); err != nil {
+				t.Logf("test warning, could not destroy queue: %s", err.Error())
+			}
 			if err := client.Shutdown(); err != nil {
 				t.Logf("test warning, client not shutdown: %s", err.Error())
 			}

--- a/internal/it/replicated_map.go
+++ b/internal/it/replicated_map.go
@@ -56,8 +56,12 @@ func ReplicatedMapTesterWithConfigBuilderWithName(t *testing.T, makeMapName func
 		cb.Cluster().SetSmartRouting(smart)
 		client, m = getClientReplicatedMapWithConfig(makeMapName(), cb)
 		defer func() {
-			m.Clear()
-			client.Shutdown()
+			if err := m.Destroy(); err != nil {
+				t.Logf("test warning, could not destroy replicated map: %s", err.Error())
+			}
+			if err := client.Shutdown(); err != nil {
+				t.Logf("test warning, client not shutdown: %s", err.Error())
+			}
 		}()
 		f(t, m)
 	}

--- a/internal/it/topic.go
+++ b/internal/it/topic.go
@@ -51,6 +51,9 @@ func TopicTesterWithConfigBuilderWithName(t *testing.T, makeName func() string, 
 		cb.Cluster().SetSmartRouting(smart)
 		client, tp = getClientTopicWithConfig(makeName(), cb)
 		defer func() {
+			if err := tp.Destroy(); err != nil {
+				t.Logf("test warning, could not destroy topic: %s", err.Error())
+			}
 			if err := client.Shutdown(); err != nil {
 				t.Logf("test warning, client not shutdown: %s", err.Error())
 			}

--- a/internal/it/util.go
+++ b/internal/it/util.go
@@ -21,12 +21,14 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"os"
 	"reflect"
 	"runtime/debug"
 	"strconv"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/hazelcast/hazelcast-go-client/internal/proxy"
 
@@ -54,6 +56,10 @@ var rc *RemoteControllerClient
 var rcMu = &sync.RWMutex{}
 var defaultTestCluster *TestCluster
 var idGen = proxy.ReferenceIDGenerator{}
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
 
 func Tester(t *testing.T, f func(t *testing.T, client *hz.Client)) {
 	TesterWithConfigBuilder(t, nil, f)

--- a/map_it_test.go
+++ b/map_it_test.go
@@ -66,7 +66,7 @@ func TestMap_PutWithMaxIdle(t *testing.T) {
 		if _, err := m.PutWithMaxIdle("key", targetValue, 1*time.Second); err != nil {
 			t.Fatal(err)
 		}
-		time.Sleep(2 * time.Second)
+		time.Sleep(4 * time.Second)
 		assert.Equal(t, nil, it.MustValue(m.Get("key")))
 	})
 }
@@ -78,7 +78,7 @@ func TestMap_PutWithTTLAndMaxIdle(t *testing.T) {
 			t.Fatal(err)
 		}
 		assert.Equal(t, targetValue, it.MustValue(m.Get("key")))
-		time.Sleep(2 * time.Second)
+		time.Sleep(4 * time.Second)
 		assert.Equal(t, nil, it.MustValue(m.Get("key")))
 	})
 }
@@ -104,7 +104,7 @@ func TestMap_PutIfAbsentWithTTL(t *testing.T) {
 			t.Fatal(err)
 		}
 		assert.Equal(t, targetValue, it.MustValue(m.Get("key")))
-		time.Sleep(2 * time.Second)
+		time.Sleep(4 * time.Second)
 		assert.Equal(t, nil, it.MustValue(m.Get("key")))
 	})
 }
@@ -118,7 +118,7 @@ func TestMap_PutIfAbsentWithTTLAndMaxIdle(t *testing.T) {
 			t.Fatal(err)
 		}
 		assert.Equal(t, targetValue, it.MustValue(m.Get("key")))
-		time.Sleep(2 * time.Second)
+		time.Sleep(4 * time.Second)
 		assert.Equal(t, nil, it.MustValue(m.Get("key")))
 	})
 }
@@ -140,7 +140,7 @@ func TestMap_PutTransientWithTTL(t *testing.T) {
 			t.Fatal(err)
 		}
 		it.AssertEquals(t, targetValue, it.MustValue(m.Get("key")))
-		time.Sleep(2 * time.Second)
+		time.Sleep(4 * time.Second)
 		it.AssertEquals(t, nil, it.MustValue(m.Get("key")))
 	})
 }
@@ -152,7 +152,7 @@ func TestMap_PutTransientWithMaxIdle(t *testing.T) {
 			t.Fatal(err)
 		}
 		it.AssertEquals(t, targetValue, it.MustValue(m.Get("key")))
-		time.Sleep(2 * time.Second)
+		time.Sleep(4 * time.Second)
 		it.AssertEquals(t, nil, it.MustValue(m.Get("key")))
 	})
 }
@@ -165,7 +165,7 @@ func TestMap_PutTransientWithTTLAndMaxIdle(t *testing.T) {
 			t.Fatal(err)
 		}
 		it.AssertEquals(t, targetValue, it.MustValue(m.Get("key")))
-		time.Sleep(2 * time.Second)
+		time.Sleep(4 * time.Second)
 		it.AssertEquals(t, nil, it.MustValue(m.Get("key")))
 	})
 }


### PR DESCRIPTION
* Increases sleep time for TTL/idleTime tests. TTL/idleTime is handled with second granularity on cluster side, so previous timeouts weren't enough under certain conditions.
  - I've faced a test failure in one of those tests when running test locally.
* Adds rand seed initialization for tests, so that generated data structure names used in test runners have better entropy.
* Adds destroy step for data structures used in test runners in order to save some memory in remote controller's JVM.