### PR TITLE
Add client.IsRunning() method

### DIFF
--- a/client.go
+++ b/client.go
@@ -219,8 +219,8 @@ func (c *Client) Shutdown() error {
 	return nil
 }
 
-// IsRunning checks whether or not the client is running.
-func (c *Client) IsRunning() bool {
+// Running checks whether or not the client is running.
+func (c *Client) Running() bool {
 	return atomic.LoadInt32(&c.state) == ready
 }
 

--- a/client.go
+++ b/client.go
@@ -219,6 +219,11 @@ func (c *Client) Shutdown() error {
 	return nil
 }
 
+// IsRunning checks whether or not the client is running.
+func (c *Client) IsRunning() bool {
+	return atomic.LoadInt32(&c.state) == ready
+}
+
 // AddLifecycleListener adds a lifecycle state change handler after the client starts.
 // The listener is attached to the client after the client starts, so lifecyle events after the client start can be received.
 // Use the returned subscription ID to remove the listener.

--- a/client_it_test.go
+++ b/client_it_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/hazelcast/hazelcast-go-client/cluster"
+	"github.com/stretchr/testify/assert"
 
 	hz "github.com/hazelcast/hazelcast-go-client"
 	"github.com/hazelcast/hazelcast-go-client/internal/it"
@@ -78,6 +79,16 @@ func TestClientLifecycleEvents(t *testing.T) {
 		if !reflect.DeepEqual(targetStates, receivedStates) {
 			t.Fatalf("target %v != %v", targetStates, receivedStates)
 		}
+	})
+}
+
+func TestClientIsRunning(t *testing.T) {
+	it.Tester(t, func(t *testing.T, client *hz.Client) {
+		assert.True(t, client.IsRunning())
+		if err := client.Shutdown(); err != nil {
+			t.Fatal(err)
+		}
+		assert.False(t, client.IsRunning())
 	})
 }
 

--- a/client_it_test.go
+++ b/client_it_test.go
@@ -82,13 +82,13 @@ func TestClientLifecycleEvents(t *testing.T) {
 	})
 }
 
-func TestClientIsRunning(t *testing.T) {
+func TestClientRunning(t *testing.T) {
 	it.Tester(t, func(t *testing.T, client *hz.Client) {
-		assert.True(t, client.IsRunning())
+		assert.True(t, client.Running())
 		if err := client.Shutdown(); err != nil {
 			t.Fatal(err)
 		}
-		assert.False(t, client.IsRunning())
+		assert.False(t, client.Running())
 	})
 }
 


### PR DESCRIPTION
* Adds `client.IsRunning()` method

v0.6.0 client had `client.LifecycleService().IsRunning()` method available to users. This method simplifies simple checks on the client lifecycle state and allows the user to avoid having to deal with a lifecycle listener, so it's convenient and deserves to be restored.