### PR TITLE
Add `encoding/json` package functions to `serialization.JSON`

### DIFF
--- a/serialization/json_value.go
+++ b/serialization/json_value.go
@@ -24,9 +24,9 @@ func (j JSON) String() string {
 	return string(j)
 }
 
-// MarshalJSON is used by functions in the Go `json` package. This function
-// ensures that a `serialization.JSON` value is correctly serialized by this
-// package. This is mostly applicable when `serialization.JSON` is
+// MarshalJSON is used by functions in the Go `encoding/json` package. This
+// function ensures that a `serialization.JSON` value is correctly serialized
+// by this package. This is mostly applicable when `serialization.JSON` is
 // serialized as a field of a larger struct.
 func (j JSON) MarshalJSON() ([]byte, error) {
 	if j == nil {
@@ -35,9 +35,9 @@ func (j JSON) MarshalJSON() ([]byte, error) {
 	return j, nil
 }
 
-// UnmarshalJSON is used by functions in the Go `json` package. This function
-// ensures that a `serialization.JSON` value is correctly deserialized from
-// JSON objects that should contain a field of this type.
+// UnmarshalJSON is used by functions in the Go `encoding/json` package. This
+// function ensures that a `serialization.JSON` value is correctly deserialized
+// from JSON objects that contain a field of this type.
 func (j *JSON) UnmarshalJSON(data []byte) error {
 	if j == nil {
 		return errors.New("serialization.JSON: UnmarshalJSON on nil pointer")

--- a/serialization/json_value.go
+++ b/serialization/json_value.go
@@ -16,8 +16,32 @@
 
 package serialization
 
+import "errors"
+
 type JSON []byte
 
 func (j JSON) String() string {
 	return string(j)
+}
+
+// MarshalJSON is used by functions in the Go `json` package. This function
+// ensures that a `serialization.JSON` value is correctly serialized by this
+// package. This is mostly applicable when `serialization.JSON` is
+// serialized as a field of a larger struct.
+func (j JSON) MarshalJSON() ([]byte, error) {
+	if j == nil {
+		return []byte("null"), nil
+	}
+	return j, nil
+}
+
+// UnmarshalJSON is used by functions in the Go `json` package. This function
+// ensures that a `serialization.JSON` value is correctly deserialized from
+// JSON objects that should contain a field of this type.
+func (j *JSON) UnmarshalJSON(data []byte) error {
+	if j == nil {
+		return errors.New("serialization.JSON: UnmarshalJSON on nil pointer")
+	}
+	*j = append((*j)[0:0], data...)
+	return nil
 }

--- a/serialization/json_value.go
+++ b/serialization/json_value.go
@@ -16,7 +16,7 @@
 
 package serialization
 
-import "errors"
+import ihzerrors "github.com/hazelcast/hazelcast-go-client/internal/hzerrors"
 
 type JSON []byte
 
@@ -24,10 +24,10 @@ func (j JSON) String() string {
 	return string(j)
 }
 
-// MarshalJSON is used by functions in the Go `encoding/json` package. This
-// function ensures that a `serialization.JSON` value is correctly serialized
-// by this package. This is mostly applicable when `serialization.JSON` is
-// serialized as a field of a larger struct.
+// MarshalJSON is used by functions in the Go `encoding/json` package.
+// This function ensures that a `serialization.JSON` value is correctly
+// serialized by this package. This is mostly applicable when
+// `serialization.JSON` is serialized as a field of a larger struct.
 func (j JSON) MarshalJSON() ([]byte, error) {
 	if j == nil {
 		return []byte("null"), nil
@@ -35,12 +35,12 @@ func (j JSON) MarshalJSON() ([]byte, error) {
 	return j, nil
 }
 
-// UnmarshalJSON is used by functions in the Go `encoding/json` package. This
-// function ensures that a `serialization.JSON` value is correctly deserialized
-// from JSON objects that contain a field of this type.
+// UnmarshalJSON is used by functions in the Go `encoding/json` package.
+// This function ensures that a `serialization.JSON` value is correctly
+// deserialized from JSON objects that contain a field of this type.
 func (j *JSON) UnmarshalJSON(data []byte) error {
 	if j == nil {
-		return errors.New("serialization.JSON: UnmarshalJSON on nil pointer")
+		return ihzerrors.NewIllegalArgumentError("serialization.JSON: UnmarshalJSON on nil pointer", nil)
 	}
 	*j = append((*j)[0:0], data...)
 	return nil

--- a/serialization/serialization_test.go
+++ b/serialization/serialization_test.go
@@ -36,7 +36,6 @@ func TestJSON_String(t *testing.T) {
 
 // Test compatibility with `encoding/json` package
 func TestJSON_Marshal(t *testing.T) {
-
 	j := serialization.JSON(`{"foo":4}`)
 	b, err := json.Marshal(j)
 	assert.NoError(t, err)

--- a/serialization/serialization_test.go
+++ b/serialization/serialization_test.go
@@ -17,6 +17,7 @@
 package serialization_test
 
 import (
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -31,6 +32,24 @@ func TestJSON_String(t *testing.T) {
 	if !assert.Equal(t, `{"foo": 4}`, j.String()) {
 		t.FailNow()
 	}
+}
+
+// Test compatibility with `encoding/json` package
+func TestJSON_Marshal(t *testing.T) {
+
+	j := serialization.JSON(`{"foo":4}`)
+	b, err := json.Marshal(j)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte(j), b)
+}
+
+// Test compatibility with `encoding/json` package
+func TestJSON_Unmarshal(t *testing.T) {
+	b := []byte(`{"foo":4}`)
+	var j serialization.JSON
+	err := json.Unmarshal(b, &j)
+	assert.NoError(t, err)
+	assert.Equal(t, serialization.JSON(b), j)
 }
 
 func TestClassDefinitionAddDuplicateField(t *testing.T) {


### PR DESCRIPTION
This PR allows the `serialization.JSON` type to be included in the (de)serialization of larger structs using `encoding.json` package. 

It does this by adding `MarshalJSON` and `UnmarshalJSON` functions to prevent the default behaviour for `[]byte` types, since we assume the data is already serialized or has to remain serialized for this type. See [here](https://pkg.go.dev/encoding/json#Marshal) for details.

I ran into this while working on Turbine and writing an HTTP API that includes endpoints that return JSON values received from HZ as part of a larger struct. This change prevents the need to cast to `json.RawMessage` in this case and is (in my opinion) the expected behaviour for this data type.