### PR TITLE
Add it.SkipIf to skip tests based on conditions

### DIFF
--- a/aggregate/aggregate_it_test.go
+++ b/aggregate/aggregate_it_test.go
@@ -49,7 +49,7 @@ func TestCountAll(t *testing.T) {
 		config.Serialization.SetPortableFactories(it.SamplePortableFactory{})
 	}
 	it.MapTesterWithConfig(t, cbCallback, func(t *testing.T, m *hz.Map) {
-		it.SkipIf(t, "hz <= 4.0.3")
+		it.SkipIf(t, "hz < 4.1")
 		ctx := context.Background()
 		it.MustValue(m.Put(ctx, "k1", &it.SamplePortable{A: "foo", B: 10}))
 		it.MustValue(m.Put(ctx, "k2", &it.SamplePortable{A: "bar", B: 30}))
@@ -86,7 +86,7 @@ func TestDistinctValuesAll(t *testing.T) {
 		config.Serialization.SetPortableFactories(it.SamplePortableFactory{})
 	}
 	it.MapTesterWithConfig(t, cbCallback, func(t *testing.T, m *hz.Map) {
-		it.SkipIf(t, "hz <= 4.0.3")
+		it.SkipIf(t, "hz < 4.1")
 		ctx := context.Background()
 		it.MustValue(m.Put(ctx, "k1", &it.SamplePortable{A: "foo", B: 10}))
 		it.MustValue(m.Put(ctx, "k2", &it.SamplePortable{A: "bar", B: 30}))

--- a/aggregate/aggregate_it_test.go
+++ b/aggregate/aggregate_it_test.go
@@ -49,6 +49,7 @@ func TestCountAll(t *testing.T) {
 		config.Serialization.SetPortableFactories(it.SamplePortableFactory{})
 	}
 	it.MapTesterWithConfig(t, cbCallback, func(t *testing.T, m *hz.Map) {
+		it.SkipIf(t, "hz <= 4.0.3")
 		ctx := context.Background()
 		it.MustValue(m.Put(ctx, "k1", &it.SamplePortable{A: "foo", B: 10}))
 		it.MustValue(m.Put(ctx, "k2", &it.SamplePortable{A: "bar", B: 30}))
@@ -85,6 +86,7 @@ func TestDistinctValuesAll(t *testing.T) {
 		config.Serialization.SetPortableFactories(it.SamplePortableFactory{})
 	}
 	it.MapTesterWithConfig(t, cbCallback, func(t *testing.T, m *hz.Map) {
+		it.SkipIf(t, "hz <= 4.0.3")
 		ctx := context.Background()
 		it.MustValue(m.Put(ctx, "k1", &it.SamplePortable{A: "foo", B: 10}))
 		it.MustValue(m.Put(ctx, "k2", &it.SamplePortable{A: "bar", B: 30}))

--- a/internal/it/export_test.go
+++ b/internal/it/export_test.go
@@ -1,3 +1,0 @@
-package it
-
-var InternalSkipIf = skipIf

--- a/internal/it/export_test.go
+++ b/internal/it/export_test.go
@@ -1,0 +1,3 @@
+package it
+
+var InternalSkipIf = skipIf

--- a/internal/it/test_skip.go
+++ b/internal/it/test_skip.go
@@ -68,13 +68,13 @@ func checkCondition(condition string) bool {
 		validateLength(parts, 1, condition, "!oss")
 		return enterprise()
 	default:
-		panic(fmt.Errorf("Unexpected test skip constant \"%s\" in %s", parts[0], condition))
+		panic(fmt.Errorf("unexpected test skip constant \"%s\" in %s", parts[0], condition))
 	}
 }
 
 func validateLength(parts []string, expected int, condition, example string) {
 	if len(parts) != expected {
-		panic(fmt.Errorf("Unexpected format for %s, example of expected condition: \"%s\" ", condition, example))
+		panic(fmt.Errorf("unexpected format for %s, example of expected condition: \"%s\" ", condition, example))
 	}
 }
 
@@ -94,7 +94,7 @@ func checkVersion(given, operator, actual string) bool {
 	case "<=":
 		return greater >= 0
 	default:
-		panic(fmt.Errorf("Unexpected test skip operator \"%s\" to compare versions", operator))
+		panic(fmt.Errorf("unexpected test skip operator \"%s\" to compare versions", operator))
 	}
 }
 
@@ -112,11 +112,11 @@ func compareVersions(given, actual string) int {
 	for i := 0; i < min; i++ {
 		givenNumber, err := strconv.Atoi(givenVersions[i])
 		if err != nil {
-			panic(fmt.Errorf("Could not parse version number (to integer): %d", givenNumber))
+			panic(fmt.Errorf("could not parse version number (to integer): %d", givenNumber))
 		}
 		actualNumber, err := strconv.Atoi(actualVersions[i])
 		if err != nil {
-			panic(fmt.Errorf("Could not parse version number (to integer): %d", actualNumber))
+			panic(fmt.Errorf("could not parse version number (to integer): %d", actualNumber))
 		}
 
 		if givenNumber > actualNumber {
@@ -136,7 +136,7 @@ func checkOS(operator, value string) bool {
 	case "!=":
 		return runtime.GOOS != value
 	default:
-		panic(fmt.Errorf("Unexpected test skip operator \"%s\" in \"%s\" condition", operator, skipOS))
+		panic(fmt.Errorf("unexpected test skip operator \"%s\" in \"%s\" condition", operator, skipOS))
 	}
 }
 

--- a/internal/it/test_skip.go
+++ b/internal/it/test_skip.go
@@ -20,6 +20,13 @@ const (
 	enterpriseKey     = "HAZELCAST_ENTERPRISE_KEY"
 )
 
+// SkipIf can be used to skip a test case based on comma-separated conditions.
+// The following conditions may be set:
+// "hz": Hazelcast version
+// "ver": go client version
+// "os": value of runtime.GOOS
+// "enterprise"/"oss": presence of enterprise key environment variable
+// Example: SkipIf(t, "ver > 1.1, hz = 5")
 func SkipIf(t *testing.T, conditionString string) {
 	skip, err := skipIf(conditionString)
 	if err != nil {

--- a/internal/it/test_skip.go
+++ b/internal/it/test_skip.go
@@ -33,7 +33,7 @@ func SkipIf(t *testing.T, conditionString string) {
 		t.Fatalf(err.Error())
 	}
 	if skip {
-		t.Skip()
+		t.Skip("Skipping test: SkipIf conditions met")
 	}
 }
 
@@ -97,7 +97,7 @@ func skipIf(conditionString string) (bool, error) {
 			}
 			skip := checkEnterprise(true)
 			if skip {
-				return skip, nil
+				return true, nil
 			}
 		case parts[0] == "!"+skipOSS:
 			if err := validateLength(parts, 1, condition, "!oss"); err != nil {
@@ -181,7 +181,7 @@ func compareVersions(given, actual string) (*bool, error) {
 		}
 		actualNumber, err := strconv.Atoi(actualVersions[i])
 		if err != nil {
-			return nil, fmt.Errorf("Could not parse version number (to integer): %d", givenNumber)
+			return nil, fmt.Errorf("Could not parse version number (to integer): %d", actualNumber)
 		}
 
 		if givenNumber > actualNumber {

--- a/internal/it/test_skip.go
+++ b/internal/it/test_skip.go
@@ -1,0 +1,214 @@
+package it
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/hazelcast/hazelcast-go-client/internal"
+)
+
+const (
+	skipHzVersion     = "hz"
+	skipClientVersion = "ver"
+	skipOS            = "os"
+	skipEnterprise    = "enterprise"
+	skipOSS           = "oss"
+	enterpriseKey     = "HAZELCAST_ENTERPRISE_KEY"
+)
+
+func SkipIf(t *testing.T, conditionString string) {
+	skip, err := skipIf(conditionString)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if skip {
+		t.Skip()
+	}
+}
+
+func skipIf(conditionString string) (bool, error) {
+	conditions := strings.Split(conditionString, ",")
+	for _, condition := range conditions {
+		condition = strings.Trim(condition, " ")
+		switch parts := strings.Split(condition, " "); {
+		case parts[0] == skipHzVersion:
+			if err := validateLength(parts, 3, condition, "hz = 4.0"); err != nil {
+				return true, err
+			}
+			skip, err := checkVersion(parts[2], parts[1], HzVersion())
+			if err != nil {
+				return true, err
+			}
+			if skip {
+				return true, nil
+			}
+		case parts[0] == skipClientVersion:
+			if err := validateLength(parts, 3, condition, "ver = 4.0"); err != nil {
+				return true, err
+			}
+			skip, err := checkVersion(parts[2], parts[1], internal.ClientVersion)
+			if err != nil {
+				return true, err
+			}
+			if skip {
+				return true, nil
+			}
+		case parts[0] == skipOS:
+			if err := validateLength(parts, 3, condition, "os = windows"); err != nil {
+				return true, err
+			}
+			skip, err := checkOS(parts[1], parts[2])
+			if err != nil {
+				return true, err
+			}
+			if skip {
+				return true, nil
+			}
+		case parts[0] == skipEnterprise:
+			if err := validateLength(parts, 1, condition, "enterprise"); err != nil {
+				return true, err
+			}
+			skip := checkEnterprise(false)
+			if skip {
+				return true, nil
+			}
+		case parts[0] == "!"+skipEnterprise:
+			if err := validateLength(parts, 1, condition, "!enterprise"); err != nil {
+				return true, err
+			}
+			skip := checkEnterprise(true)
+			if skip {
+				return true, nil
+			}
+		case parts[0] == skipOSS:
+			if err := validateLength(parts, 1, condition, "oss"); err != nil {
+				return true, err
+			}
+			skip := checkEnterprise(true)
+			if skip {
+				return skip, nil
+			}
+		case parts[0] == "!"+skipOSS:
+			if err := validateLength(parts, 1, condition, "!oss"); err != nil {
+				return true, err
+			}
+			skip := checkEnterprise(false)
+			if skip {
+				return true, nil
+			}
+		default:
+			return true, fmt.Errorf("Unexpected test skip constant \"%s\" in %s", parts[0], condition)
+		}
+	}
+	return false, nil
+}
+
+func validateLength(parts []string, expected int, condition, example string) error {
+	if len(parts) != expected {
+		return fmt.Errorf("Unexpected format for %s, example of expected condition: \"%s\" ", condition, example)
+	}
+	return nil
+}
+
+func checkVersion(given, operator, actual string) (bool, error) {
+	isGivenGreater, err := compareVersions(given, actual)
+	if err != nil {
+		return true, err
+	}
+
+	switch operator {
+	case "=":
+		if isGivenGreater == nil {
+			return true, nil
+		}
+		return false, nil
+	case "!=":
+		if isGivenGreater != nil {
+			return true, nil
+		}
+		return false, nil
+	case ">":
+		if isGivenGreater != nil && !*isGivenGreater {
+			return true, nil
+		}
+		return false, nil
+	case ">=":
+		if isGivenGreater != nil && *isGivenGreater {
+			return false, nil
+		}
+		return true, nil
+	case "<":
+		if isGivenGreater != nil && *isGivenGreater {
+			return true, nil
+		}
+		return false, nil
+	case "<=":
+		if isGivenGreater != nil && !*isGivenGreater {
+			return false, nil
+		}
+		return true, nil
+	default:
+		return true, fmt.Errorf("Unexpected test skip operator \"%s\" to compare versions", operator)
+	}
+}
+
+func compareVersions(given, actual string) (*bool, error) {
+	// versionNumbers describe the numbers of the present version
+	actualVersions := strings.Split(actual, ".")
+	// checkNumbers describe the numbers received to test for
+	givenVersions := strings.Split(given, ".")
+
+	min := len(givenVersions)
+	if min > len(actualVersions) {
+		min = len(actualVersions)
+	}
+
+	for i := 0; i < min; i++ {
+		givenNumber, err := strconv.Atoi(givenVersions[i])
+		if err != nil {
+			return nil, fmt.Errorf("Could not parse version number (to integer): %d", givenNumber)
+		}
+		actualNumber, err := strconv.Atoi(actualVersions[i])
+		if err != nil {
+			return nil, fmt.Errorf("Could not parse version number (to integer): %d", givenNumber)
+		}
+
+		if givenNumber > actualNumber {
+			res := true
+			return &res, nil
+		}
+		if actualNumber > givenNumber {
+			res := false
+			return &res, nil
+		}
+	}
+	return nil, nil
+}
+
+func checkOS(operator, value string) (bool, error) {
+	switch operator {
+	case "=":
+		if runtime.GOOS == value {
+			return true, nil
+		}
+	case "!=":
+		if runtime.GOOS != value {
+			return true, nil
+		}
+	default:
+		return true, fmt.Errorf("Unexpected test skip operator \"%s\" in \"%s\" condition", operator, skipOS)
+	}
+	return false, nil
+}
+
+func checkEnterprise(expected bool) bool {
+	_, actual := os.LookupEnv(enterpriseKey)
+	if actual == expected {
+		return true
+	}
+	return false
+}

--- a/internal/it/test_skip.go
+++ b/internal/it/test_skip.go
@@ -68,13 +68,13 @@ func checkCondition(condition string) bool {
 		validateLength(parts, 1, condition, "!oss")
 		return enterprise()
 	default:
-		panic(fmt.Errorf("unexpected test skip constant \"%s\" in %s", parts[0], condition))
+		panic(fmt.Errorf(`unexpected test skip constant "%s" in %s`, parts[0], condition))
 	}
 }
 
 func validateLength(parts []string, expected int, condition, example string) {
 	if len(parts) != expected {
-		panic(fmt.Errorf("unexpected format for %s, example of expected condition: \"%s\" ", condition, example))
+		panic(fmt.Errorf(`unexpected format for %s, example of expected condition: "%s"`, condition, example))
 	}
 }
 
@@ -94,7 +94,7 @@ func checkVersion(given, operator, actual string) bool {
 	case "<=":
 		return greater >= 0
 	default:
-		panic(fmt.Errorf("unexpected test skip operator \"%s\" to compare versions", operator))
+		panic(fmt.Errorf(`unexpected test skip operator "%s" to compare versions`, operator))
 	}
 }
 
@@ -136,7 +136,7 @@ func checkOS(operator, value string) bool {
 	case "!=":
 		return runtime.GOOS != value
 	default:
-		panic(fmt.Errorf("unexpected test skip operator \"%s\" in \"%s\" condition", operator, skipOS))
+		panic(fmt.Errorf(`unexpected test skip operator "%s" in "%s" condition`, operator, skipOS))
 	}
 }
 

--- a/internal/it/test_skip_test.go
+++ b/internal/it/test_skip_test.go
@@ -3,6 +3,7 @@ package it_test
 import (
 	"testing"
 
+	"github.com/hazelcast/hazelcast-go-client/internal"
 	"github.com/hazelcast/hazelcast-go-client/internal/it"
 	"github.com/stretchr/testify/assert"
 )
@@ -42,9 +43,21 @@ func TestSkipIf(t *testing.T) {
 		{name: "skip version = 100.0.0", conditions: "ver = 100.0.0", expectFatal: false, expectSkip: false},
 		{name: "skip version != 100.0.0", conditions: "ver != 100.0.0", expectFatal: false, expectSkip: true},
 
+		// Check version compared to actual version
+		{name: "skip version >= actual", conditions: "ver >= " + internal.ClientVersion, expectFatal: false, expectSkip: true},
+		{name: "skip version < actual", conditions: "ver > " + internal.ClientVersion, expectFatal: false, expectSkip: false},
+		{name: "skip version <= actual", conditions: "ver <= " + internal.ClientVersion, expectFatal: false, expectSkip: true},
+		{name: "skip version < actual", conditions: "ver > " + internal.ClientVersion, expectFatal: false, expectSkip: false},
+		{name: "skip version = actual", conditions: "ver = " + internal.ClientVersion, expectFatal: false, expectSkip: true},
+		{name: "skip version != actual", conditions: "ver != " + internal.ClientVersion, expectFatal: false, expectSkip: false},
+
 		// Check hz
 		{name: "skip hz != 100.0.0", conditions: "hz != 100.0.0", expectFatal: false, expectSkip: true},
 		{name: "skip hz = 100", conditions: "hz = 100", expectFatal: false, expectSkip: false},
+
+		// Multiple conditions
+		{name: "skip hz = 100 or version = 100", conditions: "hz = 100, ver = 100", expectFatal: false, expectSkip: false},
+		{name: "skip hz = 100 or version < 100", conditions: "hz = 100.0.0, ver < 100", expectFatal: false, expectSkip: true},
 	}
 
 	for _, tc := range testCases {

--- a/internal/it/test_skip_test.go
+++ b/internal/it/test_skip_test.go
@@ -1,0 +1,64 @@
+package it_test
+
+import (
+	"testing"
+
+	"github.com/hazelcast/hazelcast-go-client/internal/it"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSkipIf(t *testing.T) {
+	testCases := []struct {
+		name       string
+		conditions string
+
+		expectFatal bool
+		expectSkip  bool
+	}{
+		// Check parsing
+		{name: "incorrect version format", conditions: "version < 1.0.0", expectFatal: true, expectSkip: true},
+		{name: "incorrect os format", conditions: "os windows", expectFatal: true, expectSkip: true},
+		{name: "incorrect enterprise format", conditions: "enterprise = os", expectFatal: true, expectSkip: true},
+
+		// Check OS based on non-existing OS
+		{name: "skip if not non-existing OS", conditions: "os != non-existent", expectFatal: false, expectSkip: true},
+		{name: "skip if non-existing OS", conditions: "os = non-existent", expectFatal: false, expectSkip: false},
+
+		// Check version compared to 0
+		{name: "skip version > 0.0.0", conditions: "ver > 0.0.0", expectFatal: false, expectSkip: true},
+		{name: "skip version > 0", conditions: "ver > 0", expectFatal: false, expectSkip: true},
+		{name: "skip version >= 0.0.0", conditions: "ver >= 0.0.0", expectFatal: false, expectSkip: true},
+		{name: "skip version < 0.0.0", conditions: "ver < 0.0.0", expectFatal: false, expectSkip: false},
+		{name: "skip version <= 0.0.0", conditions: "ver <= 0.0.0", expectFatal: false, expectSkip: false},
+		{name: "skip version = 0.0.0", conditions: "ver = 0.0.0", expectFatal: false, expectSkip: false},
+		{name: "skip version != 0.0.0", conditions: "ver != 0.0.0", expectFatal: false, expectSkip: true},
+
+		// Check version compared to 100
+		{name: "skip version > 100.0.0", conditions: "ver > 100.0.0", expectFatal: false, expectSkip: false},
+		{name: "skip version > 100.10", conditions: "ver > 100.10", expectFatal: false, expectSkip: false},
+		{name: "skip version >= 100.0.0", conditions: "ver >= 100.0.0", expectFatal: false, expectSkip: false},
+		{name: "skip version < 100.0.0", conditions: "ver < 100.0.0", expectFatal: false, expectSkip: true},
+		{name: "skip version <= 100.0.0", conditions: "ver <= 100.0.0", expectFatal: false, expectSkip: true},
+		{name: "skip version = 100.0.0", conditions: "ver = 100.0.0", expectFatal: false, expectSkip: false},
+		{name: "skip version != 100.0.0", conditions: "ver != 100.0.0", expectFatal: false, expectSkip: true},
+
+		// Check hz
+		{name: "skip hz != 100.0.0", conditions: "hz != 100.0.0", expectFatal: false, expectSkip: true},
+		{name: "skip hz = 100", conditions: "hz = 100", expectFatal: false, expectSkip: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// When
+			skip, err := it.InternalSkipIf(tc.conditions)
+
+			// Then
+			assert.Equal(t, tc.expectSkip, skip)
+			if tc.expectFatal {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/it/test_skip_test.go
+++ b/internal/it/test_skip_test.go
@@ -1,10 +1,9 @@
-package it_test
+package it
 
 import (
 	"testing"
 
 	"github.com/hazelcast/hazelcast-go-client/internal"
-	"github.com/hazelcast/hazelcast-go-client/internal/it"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -13,64 +12,62 @@ func TestSkipIf(t *testing.T) {
 		name       string
 		conditions string
 
-		expectFatal bool
+		expectPanic bool
 		expectSkip  bool
 	}{
 		// Check parsing
-		{name: "incorrect version format", conditions: "version < 1.0.0", expectFatal: true, expectSkip: true},
-		{name: "incorrect os format", conditions: "os windows", expectFatal: true, expectSkip: true},
-		{name: "incorrect enterprise format", conditions: "enterprise = os", expectFatal: true, expectSkip: true},
+		{name: "incorrect version format", conditions: "version < 1.0.0", expectPanic: true},
+		{name: "incorrect os format", conditions: "os windows", expectPanic: true},
+		{name: "incorrect enterprise format", conditions: "enterprise = os", expectPanic: true},
+		{name: "empty condition #1", conditions: "enterprise = os, , ver > 0", expectPanic: true},
+		{name: "empty condition #2", conditions: "enterprise = os,, ver > 0", expectPanic: true},
 
 		// Check OS based on non-existing OS
-		{name: "skip if not non-existing OS", conditions: "os != non-existent", expectFatal: false, expectSkip: true},
-		{name: "skip if non-existing OS", conditions: "os = non-existent", expectFatal: false, expectSkip: false},
+		{name: "skip if not non-existing OS", conditions: "os != non-existent", expectSkip: true},
+		{name: "skip if non-existing OS", conditions: "os = non-existent"},
 
 		// Check version compared to 0
-		{name: "skip version > 0.0.0", conditions: "ver > 0.0.0", expectFatal: false, expectSkip: true},
-		{name: "skip version > 0", conditions: "ver > 0", expectFatal: false, expectSkip: true},
-		{name: "skip version >= 0.0.0", conditions: "ver >= 0.0.0", expectFatal: false, expectSkip: true},
-		{name: "skip version < 0.0.0", conditions: "ver < 0.0.0", expectFatal: false, expectSkip: false},
-		{name: "skip version <= 0.0.0", conditions: "ver <= 0.0.0", expectFatal: false, expectSkip: false},
-		{name: "skip version = 0.0.0", conditions: "ver = 0.0.0", expectFatal: false, expectSkip: false},
-		{name: "skip version != 0.0.0", conditions: "ver != 0.0.0", expectFatal: false, expectSkip: true},
+		{name: "skip version > 0.0.0", conditions: "ver > 0.0.0", expectSkip: true},
+		{name: "skip version > 0", conditions: "ver > 0", expectSkip: true},
+		{name: "skip version >= 0.0.0", conditions: "ver >= 0.0.0", expectSkip: true},
+		{name: "skip version < 0.0.0", conditions: "ver < 0.0.0"},
+		{name: "skip version <= 0.0.0", conditions: "ver <= 0.0.0"},
+		{name: "skip version = 0.0.0", conditions: "ver = 0.0.0"},
+		{name: "skip version != 0.0.0", conditions: "ver != 0.0.0", expectSkip: true},
 
 		// Check version compared to 100
-		{name: "skip version > 100.0.0", conditions: "ver > 100.0.0", expectFatal: false, expectSkip: false},
-		{name: "skip version > 100.10", conditions: "ver > 100.10", expectFatal: false, expectSkip: false},
-		{name: "skip version >= 100.0.0", conditions: "ver >= 100.0.0", expectFatal: false, expectSkip: false},
-		{name: "skip version < 100.0.0", conditions: "ver < 100.0.0", expectFatal: false, expectSkip: true},
-		{name: "skip version <= 100.0.0", conditions: "ver <= 100.0.0", expectFatal: false, expectSkip: true},
-		{name: "skip version = 100.0.0", conditions: "ver = 100.0.0", expectFatal: false, expectSkip: false},
-		{name: "skip version != 100.0.0", conditions: "ver != 100.0.0", expectFatal: false, expectSkip: true},
+		{name: "skip version > 100.0.0", conditions: "ver > 100.0.0"},
+		{name: "skip version > 100.10", conditions: "ver > 100.10"},
+		{name: "skip version >= 100.0.0", conditions: "ver >= 100.0.0"},
+		{name: "skip version < 100.0.0", conditions: "ver < 100.0.0", expectSkip: true},
+		{name: "skip version <= 100.0.0", conditions: "ver <= 100.0.0", expectSkip: true},
+		{name: "skip version = 100.0.0", conditions: "ver = 100.0.0"},
+		{name: "skip version != 100.0.0", conditions: "ver != 100.0.0", expectSkip: true},
 
-		// Check version compared to actual version
-		{name: "skip version >= actual", conditions: "ver >= " + internal.ClientVersion, expectFatal: false, expectSkip: true},
-		{name: "skip version < actual", conditions: "ver > " + internal.ClientVersion, expectFatal: false, expectSkip: false},
-		{name: "skip version <= actual", conditions: "ver <= " + internal.ClientVersion, expectFatal: false, expectSkip: true},
-		{name: "skip version < actual", conditions: "ver > " + internal.ClientVersion, expectFatal: false, expectSkip: false},
-		{name: "skip version = actual", conditions: "ver = " + internal.ClientVersion, expectFatal: false, expectSkip: true},
-		{name: "skip version != actual", conditions: "ver != " + internal.ClientVersion, expectFatal: false, expectSkip: false},
+		// Check version compared to actual versiojn
+		{name: "skip version >= actual", conditions: "ver >= " + internal.ClientVersion, expectSkip: true},
+		{name: "skip version < actual", conditions: "ver > " + internal.ClientVersion},
+		{name: "skip version <= actual", conditions: "ver <= " + internal.ClientVersion, expectSkip: true},
+		{name: "skip version < actual", conditions: "ver > " + internal.ClientVersion},
+		{name: "skip version = actual", conditions: "ver = " + internal.ClientVersion, expectSkip: true},
+		{name: "skip version != actual", conditions: "ver != " + internal.ClientVersion},
 
 		// Check hz
-		{name: "skip hz != 100.0.0", conditions: "hz != 100.0.0", expectFatal: false, expectSkip: true},
-		{name: "skip hz = 100", conditions: "hz = 100", expectFatal: false, expectSkip: false},
+		{name: "skip hz != 100.0.0", conditions: "hz != 100.0.0", expectSkip: true},
+		{name: "skip hz = 100", conditions: "hz = 100"},
 
 		// Multiple conditions
-		{name: "skip hz = 100 or version = 100", conditions: "hz = 100, ver = 100", expectFatal: false, expectSkip: false},
-		{name: "skip hz = 100 or version < 100", conditions: "hz = 100.0.0, ver < 100", expectFatal: false, expectSkip: true},
+		{name: "skip hz = 100 or version = 100", conditions: "hz = 100, ver = 100"},
+		{name: "skip hz = 100 or version < 100", conditions: "hz = 100.0.0, ver < 100", expectSkip: true},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// When
-			skip, err := it.InternalSkipIf(tc.conditions)
-
-			// Then
-			assert.Equal(t, tc.expectSkip, skip)
-			if tc.expectFatal {
-				assert.Error(t, err)
+			if tc.expectPanic {
+				assert.Panics(t, func() { canSkip(tc.conditions) })
 			} else {
-				assert.NoError(t, err)
+				skip := canSkip(tc.conditions)
+				assert.Equal(t, tc.expectSkip, skip)
 			}
 		})
 	}


### PR DESCRIPTION
Introduce `SkipIf` function to skip test cases based on conditions like versioning or the operating system.

The code to parse the conditions is not so clean. This could be more clean when using option pattern, however this comes at the cost of readability where the function is actually applied. 

I tried to test most cases to confirm the parsing is valid.