### PR TITLE
Add GetDistributedObjectsInfo API.

### DIFF
--- a/client.go
+++ b/client.go
@@ -211,21 +211,7 @@ func (c *Client) GetDistributedObjectsInfo(ctx context.Context) ([]types.Distrib
 	if err != nil {
 		return nil, err
 	}
-	objects := codec.DecodeClientGetDistributedObjectsResponse(resp)
-	result := make([]types.DistributedObjectInfo, 0, len(objects))
-	cached := make(map[types.DistributedObjectInfo]struct{})
-	for _, o := range c.proxyManager.getCachedObjectsInfo() {
-		cached[o] = struct{}{}
-	}
-	for _, o := range objects {
-		result = append(result, o)
-		delete(cached, o)
-	}
-	for o := range cached {
-		// Purge the stale object from the manager's cache.
-		c.proxyManager.remove(o.ServiceName, o.Name)
-	}
-	return result, nil
+	return codec.DecodeClientGetDistributedObjectsResponse(resp), nil
 }
 
 func (c *Client) start(ctx context.Context) error {

--- a/client.go
+++ b/client.go
@@ -31,6 +31,7 @@ import (
 	"github.com/hazelcast/hazelcast-go-client/internal/invocation"
 	ilogger "github.com/hazelcast/hazelcast-go-client/internal/logger"
 	"github.com/hazelcast/hazelcast-go-client/internal/proto"
+	"github.com/hazelcast/hazelcast-go-client/internal/proto/codec"
 	iproxy "github.com/hazelcast/hazelcast-go-client/internal/proxy"
 	"github.com/hazelcast/hazelcast-go-client/internal/security"
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
@@ -198,6 +199,42 @@ func (c *Client) GetPNCounter(ctx context.Context, name string) (*PNCounter, err
 		return nil, hzerrors.ErrClientNotActive
 	}
 	return c.proxyManager.getPNCounter(ctx, name)
+}
+
+// GetDistributedObjectsInfo returns the information of all objects created cluster-wide.
+func (c *Client) GetDistributedObjectsInfo(ctx context.Context) ([]types.DistributedObjectInfo, error) {
+	if atomic.LoadInt32(&c.state) != ready {
+		return nil, hzerrors.ErrClientNotActive
+	}
+
+	request := codec.EncodeClientGetDistributedObjectsRequest()
+	resp, err := c.proxyManager.invokeOnRandomTarget(ctx, request, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	objects := codec.DecodeClientGetDistributedObjectsResponse(resp)
+	result := make([]types.DistributedObjectInfo, 0, len(objects))
+
+	cached := make(map[types.DistributedObjectInfo]struct{})
+	for _, o := range c.proxyManager.getCachedObjectsInfo() {
+		cached[o] = struct{}{}
+	}
+
+	for _, o := range objects {
+		if !serviceSupported(o.ServiceName()) {
+			continue
+		}
+		result = append(result, o)
+		delete(cached, o)
+	}
+
+	for o := range cached {
+		// Purge the stale object from the manager's cache.
+		c.proxyManager.remove(o.ServiceName(), o.Name())
+	}
+
+	return result, nil
 }
 
 func (c *Client) start(ctx context.Context) error {

--- a/client_it_test.go
+++ b/client_it_test.go
@@ -326,8 +326,8 @@ func TestClusterReconnection_ReconnectModeOff(t *testing.T) {
 func TestClient_GetDistributedObjects(t *testing.T) {
 	it.Tester(t, func(t *testing.T, client *hz.Client) {
 		var (
-			testMapName = it.NewUniqueServiceName("map")
-			testSetName = it.NewUniqueServiceName("set")
+			testMapName = it.NewUniqueObjectName("map")
+			testSetName = it.NewUniqueObjectName("set")
 			mapInfo     = types.NewDistributedObjectInfo(testMapName, hz.ServiceNameMap)
 			setInfo     = types.NewDistributedObjectInfo(testSetName, hz.ServiceNameSet)
 		)

--- a/client_it_test.go
+++ b/client_it_test.go
@@ -328,8 +328,8 @@ func TestClient_GetDistributedObjects(t *testing.T) {
 		var (
 			testMapName = it.NewUniqueObjectName("map")
 			testSetName = it.NewUniqueObjectName("set")
-			mapInfo     = types.NewDistributedObjectInfo(testMapName, hz.ServiceNameMap)
-			setInfo     = types.NewDistributedObjectInfo(testSetName, hz.ServiceNameSet)
+			mapInfo     = types.DistributedObjectInfo{Name: testMapName, ServiceName: hz.ServiceNameMap}
+			setInfo     = types.DistributedObjectInfo{Name: testSetName, ServiceName: hz.ServiceNameSet}
 		)
 
 		ctx, cancel := context.WithTimeout(context.Background(), 40*time.Second)

--- a/internal/it/list.go
+++ b/internal/it/list.go
@@ -18,8 +18,6 @@ package it
 
 import (
 	"context"
-	"fmt"
-	"math/rand"
 	"testing"
 
 	"go.uber.org/goleak"
@@ -29,7 +27,7 @@ import (
 
 func ListTester(t *testing.T, f func(t *testing.T, l *hz.List)) {
 	makeListName := func() string {
-		return fmt.Sprintf("test-list-%d-%d", idGen.NextID(), rand.Int())
+		return NewUniqueServiceName("list")
 	}
 	ListTesterWithConfigAndName(t, makeListName, nil, f)
 }

--- a/internal/it/list.go
+++ b/internal/it/list.go
@@ -27,7 +27,7 @@ import (
 
 func ListTester(t *testing.T, f func(t *testing.T, l *hz.List)) {
 	makeListName := func() string {
-		return NewUniqueServiceName("list")
+		return NewUniqueObjectName("list")
 	}
 	ListTesterWithConfigAndName(t, makeListName, nil, f)
 }

--- a/internal/it/map.go
+++ b/internal/it/map.go
@@ -30,7 +30,7 @@ func MapTester(t *testing.T, f func(t *testing.T, m *hz.Map)) {
 
 func MapTesterWithConfig(t *testing.T, configCallback func(*hz.Config), f func(t *testing.T, m *hz.Map)) {
 	makeMapName := func() string {
-		return NewUniqueServiceName("map")
+		return NewUniqueObjectName("map")
 	}
 	MapTesterWithConfigAndName(t, makeMapName, configCallback, f)
 }

--- a/internal/it/map.go
+++ b/internal/it/map.go
@@ -18,8 +18,6 @@ package it
 
 import (
 	"context"
-	"fmt"
-	"math/rand"
 	"testing"
 
 	hz "github.com/hazelcast/hazelcast-go-client"
@@ -32,7 +30,7 @@ func MapTester(t *testing.T, f func(t *testing.T, m *hz.Map)) {
 
 func MapTesterWithConfig(t *testing.T, configCallback func(*hz.Config), f func(t *testing.T, m *hz.Map)) {
 	makeMapName := func() string {
-		return fmt.Sprintf("test-map-%d-%d", idGen.NextID(), rand.Int())
+		return NewUniqueServiceName("map")
 	}
 	MapTesterWithConfigAndName(t, makeMapName, configCallback, f)
 }

--- a/internal/it/pn_counter.go
+++ b/internal/it/pn_counter.go
@@ -29,7 +29,7 @@ func PNCounterTester(t *testing.T, f func(t *testing.T, pn *hz.PNCounter)) {
 
 func PNCounterTesterWithConfig(t *testing.T, configCallback func(*hz.Config), f func(t *testing.T, pn *hz.PNCounter)) {
 	makeName := func() string {
-		return NewUniqueServiceName("pn-counter")
+		return NewUniqueObjectName("pn-counter")
 	}
 	PNCounterTesterWithConfigAndName(t, makeName, configCallback, f)
 }

--- a/internal/it/pn_counter.go
+++ b/internal/it/pn_counter.go
@@ -18,8 +18,6 @@ package it
 
 import (
 	"context"
-	"fmt"
-	"math/rand"
 	"testing"
 
 	hz "github.com/hazelcast/hazelcast-go-client"
@@ -31,7 +29,7 @@ func PNCounterTester(t *testing.T, f func(t *testing.T, pn *hz.PNCounter)) {
 
 func PNCounterTesterWithConfig(t *testing.T, configCallback func(*hz.Config), f func(t *testing.T, pn *hz.PNCounter)) {
 	makeName := func() string {
-		return fmt.Sprintf("test-pn-counter-%d-%d", idGen.NextID(), rand.Int())
+		return NewUniqueServiceName("pn-counter")
 	}
 	PNCounterTesterWithConfigAndName(t, makeName, configCallback, f)
 }

--- a/internal/it/queue.go
+++ b/internal/it/queue.go
@@ -18,8 +18,6 @@ package it
 
 import (
 	"context"
-	"fmt"
-	"math/rand"
 	"testing"
 
 	"go.uber.org/goleak"
@@ -29,7 +27,7 @@ import (
 
 func QueueTester(t *testing.T, f func(t *testing.T, q *hz.Queue)) {
 	makeQueueName := func() string {
-		return fmt.Sprintf("test-queue-%d-%d", idGen.NextID(), rand.Int())
+		return NewUniqueServiceName("queue")
 	}
 	QueueTesterWithConfigAndName(t, makeQueueName, nil, f)
 }

--- a/internal/it/queue.go
+++ b/internal/it/queue.go
@@ -27,7 +27,7 @@ import (
 
 func QueueTester(t *testing.T, f func(t *testing.T, q *hz.Queue)) {
 	makeQueueName := func() string {
-		return NewUniqueServiceName("queue")
+		return NewUniqueObjectName("queue")
 	}
 	QueueTesterWithConfigAndName(t, makeQueueName, nil, f)
 }

--- a/internal/it/replicated_map.go
+++ b/internal/it/replicated_map.go
@@ -31,7 +31,7 @@ func ReplicatedMapTester(t *testing.T, f func(t *testing.T, m *hz.ReplicatedMap)
 
 func ReplicatedMapTesterWithConfig(t *testing.T, configCallback func(*hz.Config), f func(t *testing.T, m *hz.ReplicatedMap)) {
 	makeMapName := func() string {
-		return NewUniqueServiceName("replicated-map")
+		return NewUniqueObjectName("replicated-map")
 	}
 	ReplicatedMapTesterWithConfigAndName(t, makeMapName, configCallback, f)
 }

--- a/internal/it/replicated_map.go
+++ b/internal/it/replicated_map.go
@@ -18,8 +18,6 @@ package it
 
 import (
 	"context"
-	"fmt"
-	"math/rand"
 	"testing"
 
 	"go.uber.org/goleak"
@@ -33,7 +31,7 @@ func ReplicatedMapTester(t *testing.T, f func(t *testing.T, m *hz.ReplicatedMap)
 
 func ReplicatedMapTesterWithConfig(t *testing.T, configCallback func(*hz.Config), f func(t *testing.T, m *hz.ReplicatedMap)) {
 	makeMapName := func() string {
-		return fmt.Sprintf("test-replicated-map-%d-%d", idGen.NextID(), rand.Int())
+		return NewUniqueServiceName("replicated-map")
 	}
 	ReplicatedMapTesterWithConfigAndName(t, makeMapName, configCallback, f)
 }

--- a/internal/it/set.go
+++ b/internal/it/set.go
@@ -18,8 +18,6 @@ package it
 
 import (
 	"context"
-	"fmt"
-	"math/rand"
 	"testing"
 
 	"go.uber.org/goleak"
@@ -33,7 +31,7 @@ func SetTester(t *testing.T, f func(t *testing.T, s *hz.Set)) {
 
 func SetTesterWithConfig(t *testing.T, configCallback func(*hz.Config), f func(t *testing.T, s *hz.Set)) {
 	makeName := func() string {
-		return fmt.Sprintf("test-set-%d-%d", idGen.NextID(), rand.Int())
+		return NewUniqueServiceName("set")
 	}
 	SetTesterWithConfigAndName(t, makeName, configCallback, f)
 }

--- a/internal/it/set.go
+++ b/internal/it/set.go
@@ -31,7 +31,7 @@ func SetTester(t *testing.T, f func(t *testing.T, s *hz.Set)) {
 
 func SetTesterWithConfig(t *testing.T, configCallback func(*hz.Config), f func(t *testing.T, s *hz.Set)) {
 	makeName := func() string {
-		return NewUniqueServiceName("set")
+		return NewUniqueObjectName("set")
 	}
 	SetTesterWithConfigAndName(t, makeName, configCallback, f)
 }

--- a/internal/it/topic.go
+++ b/internal/it/topic.go
@@ -18,8 +18,6 @@ package it
 
 import (
 	"context"
-	"fmt"
-	"math/rand"
 	"testing"
 
 	hz "github.com/hazelcast/hazelcast-go-client"
@@ -28,7 +26,7 @@ import (
 
 func TopicTester(t *testing.T, f func(t *testing.T, tp *hz.Topic)) {
 	makeName := func() string {
-		return fmt.Sprintf("test-topic-%d-%d", idGen.NextID(), rand.Int())
+		return NewUniqueServiceName("topic")
 	}
 	TopicTesterWithConfigAndName(t, makeName, nil, f)
 }

--- a/internal/it/topic.go
+++ b/internal/it/topic.go
@@ -26,7 +26,7 @@ import (
 
 func TopicTester(t *testing.T, f func(t *testing.T, tp *hz.Topic)) {
 	makeName := func() string {
-		return NewUniqueServiceName("topic")
+		return NewUniqueObjectName("topic")
 	}
 	TopicTesterWithConfigAndName(t, makeName, nil, f)
 }

--- a/internal/it/util.go
+++ b/internal/it/util.go
@@ -190,6 +190,10 @@ func MustClient(client *hz.Client, err error) *hz.Client {
 	return client
 }
 
+func NewUniqueServiceName(service string) string {
+	return fmt.Sprintf("test-%s-%d-%d", service, idGen.NextID(), rand.Int())
+}
+
 func TraceLoggingEnabled() bool {
 	return os.Getenv(EnvEnableTraceLogging) == "1"
 }

--- a/internal/it/util.go
+++ b/internal/it/util.go
@@ -190,7 +190,7 @@ func MustClient(client *hz.Client, err error) *hz.Client {
 	return client
 }
 
-func NewUniqueServiceName(service string) string {
+func NewUniqueObjectName(service string) string {
 	return fmt.Sprintf("test-%s-%d-%d", service, idGen.NextID(), rand.Int())
 }
 

--- a/internal/proto/codec/builtin.go
+++ b/internal/proto/codec/builtin.go
@@ -620,6 +620,24 @@ func DecodeListMultiFrameForDataContainsNullable(frameIterator *proto.ForwardFra
 	return result
 }
 
+func DecodeListMultiFrameForDistributedObjectInfo(frameIterator *proto.ForwardFrameIterator) []types.DistributedObjectInfo {
+	result := make([]types.DistributedObjectInfo, 0)
+	frameIterator.Next()
+	for !CodecUtil.NextFrameIsDataStructureEndFrame(frameIterator) {
+		result = append(result, DecodeDistributedObjectInfo(frameIterator))
+	}
+	frameIterator.Next()
+	return result
+}
+
+func DecodeDistributedObjectInfo(frameIterator *proto.ForwardFrameIterator) types.DistributedObjectInfo {
+	frameIterator.Next()
+	serviceName := DecodeString(frameIterator)
+	name := DecodeString(frameIterator)
+	CodecUtil.FastForwardToEndFrame(frameIterator)
+	return types.NewDistributedObjectInfo(name, serviceName)
+}
+
 func EncodeListData(message *proto.ClientMessage, entries []*iserialization.Data) {
 	EncodeListMultiFrameForData(message, entries)
 }
@@ -754,31 +772,6 @@ type DistributedObject interface {
 
 	// ServiceName returns the service name for this object.
 	ServiceName() string
-}
-
-type DistributedObjectInfo struct {
-	name        string
-	serviceName string
-}
-
-func (i *DistributedObjectInfo) Name() string {
-	return i.name
-}
-
-func (i *DistributedObjectInfo) ServiceName() string {
-	return i.serviceName
-}
-
-func (i *DistributedObjectInfo) GetName() string {
-	return i.name
-}
-
-func (i *DistributedObjectInfo) GetServiceName() string {
-	return i.serviceName
-}
-
-func NewDistributedObjectInfo(name string, serviceName string) DistributedObjectInfo {
-	return DistributedObjectInfo{name: name, serviceName: serviceName}
 }
 
 func NewMemberVersion(major, minor, patch byte) pubcluster.MemberVersion {

--- a/internal/proto/codec/builtin.go
+++ b/internal/proto/codec/builtin.go
@@ -621,7 +621,7 @@ func DecodeListMultiFrameForDataContainsNullable(frameIterator *proto.ForwardFra
 }
 
 func DecodeListMultiFrameForDistributedObjectInfo(frameIterator *proto.ForwardFrameIterator) []types.DistributedObjectInfo {
-	result := make([]types.DistributedObjectInfo, 0)
+	var result []types.DistributedObjectInfo
 	frameIterator.Next()
 	for !CodecUtil.NextFrameIsDataStructureEndFrame(frameIterator) {
 		result = append(result, DecodeDistributedObjectInfo(frameIterator))
@@ -635,7 +635,7 @@ func DecodeDistributedObjectInfo(frameIterator *proto.ForwardFrameIterator) type
 	serviceName := DecodeString(frameIterator)
 	name := DecodeString(frameIterator)
 	CodecUtil.FastForwardToEndFrame(frameIterator)
-	return types.NewDistributedObjectInfo(name, serviceName)
+	return types.DistributedObjectInfo{Name: name, ServiceName: serviceName}
 }
 
 func EncodeListData(message *proto.ClientMessage, entries []*iserialization.Data) {

--- a/internal/proto/codec/client_get_distributed_objects_codec.go
+++ b/internal/proto/codec/client_get_distributed_objects_codec.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package codec
+
+import (
+	"github.com/hazelcast/hazelcast-go-client/internal/proto"
+	"github.com/hazelcast/hazelcast-go-client/types"
+)
+
+const (
+	// hex: 0x000800
+	ClientGetDistributedObjectsCodecRequestMessageType = int32(2048)
+	// hex: 0x000801
+	ClientGetDistributedObjectsCodecResponseMessageType     = int32(2049)
+	ClientGetDistributedObjectsCodecRequestInitialFrameSize = proto.PartitionIDOffset + proto.IntSizeInBytes
+)
+
+// Gets the list of distributed objects in the cluster.
+func EncodeClientGetDistributedObjectsRequest() *proto.ClientMessage {
+	clientMessage := proto.NewClientMessageForEncode()
+	clientMessage.SetRetryable(false)
+	initialFrame := proto.NewFrameWith(make([]byte, ClientGetDistributedObjectsCodecRequestInitialFrameSize), proto.UnfragmentedMessage)
+	clientMessage.AddFrame(initialFrame)
+	clientMessage.SetMessageType(ClientGetDistributedObjectsCodecRequestMessageType)
+	clientMessage.SetPartitionId(-1)
+	return clientMessage
+}
+
+func DecodeClientGetDistributedObjectsResponse(clientMessage *proto.ClientMessage) []types.DistributedObjectInfo {
+	frameIterator := clientMessage.FrameIterator()
+	// empty initial frame
+	frameIterator.Next()
+	return DecodeListMultiFrameForDistributedObjectInfo(frameIterator)
+}

--- a/proxy.go
+++ b/proxy.go
@@ -53,6 +53,21 @@ const (
 	ttlUnlimited = 0
 )
 
+func serviceSupported(serviceName string) bool {
+	switch serviceName {
+	case ServiceNameMap,
+		ServiceNameReplicatedMap,
+		ServiceNameQueue,
+		ServiceNameTopic,
+		ServiceNameList,
+		ServiceNameSet,
+		ServiceNamePNCounter:
+		return true
+	default:
+		return false
+	}
+}
+
 type creationBundle struct {
 	RequestCh            chan<- invocation.Invocation
 	RemoveCh             chan<- int64
@@ -119,7 +134,8 @@ func newProxy(
 	serviceName string,
 	objectName string,
 	refIDGen *iproxy.ReferenceIDGenerator,
-	removeFromCacheFn func() bool) (*proxy, error) {
+	removeFromCacheFn func() bool,
+	remote bool) (*proxy, error) {
 
 	bundle.Check()
 	// TODO: make circuit breaker configurable
@@ -145,6 +161,9 @@ func newProxy(
 		removeFromCacheFn:    removeFromCacheFn,
 		refIDGen:             refIDGen,
 		smart:                !bundle.Config.Cluster.Unisocket,
+	}
+	if !remote {
+		return p, nil
 	}
 	if err := p.create(ctx); err != nil {
 		return nil, err

--- a/proxy.go
+++ b/proxy.go
@@ -53,21 +53,6 @@ const (
 	ttlUnlimited = 0
 )
 
-func serviceSupported(serviceName string) bool {
-	switch serviceName {
-	case ServiceNameMap,
-		ServiceNameReplicatedMap,
-		ServiceNameQueue,
-		ServiceNameTopic,
-		ServiceNameList,
-		ServiceNameSet,
-		ServiceNamePNCounter:
-		return true
-	default:
-		return false
-	}
-}
-
 type creationBundle struct {
 	RequestCh            chan<- invocation.Invocation
 	RemoveCh             chan<- int64

--- a/proxy_manager.go
+++ b/proxy_manager.go
@@ -117,7 +117,7 @@ func (m *proxyManager) getCachedObjectsInfo() []types.DistributedObjectInfo {
 	defer m.mu.RUnlock()
 	objects := make([]types.DistributedObjectInfo, 0, len(m.proxies))
 	for _, p := range m.proxies {
-		objects = append(objects, types.NewDistributedObjectInfo(p.name, p.serviceName))
+		objects = append(objects, types.DistributedObjectInfo{Name: p.name, ServiceName: p.serviceName})
 	}
 	return objects
 }

--- a/proxy_manager.go
+++ b/proxy_manager.go
@@ -112,16 +112,6 @@ func (m *proxyManager) invokeOnRandomTarget(ctx context.Context, request *proto.
 	return m.invocationProxy.invokeOnRandomTarget(ctx, request, handler)
 }
 
-func (m *proxyManager) getCachedObjectsInfo() []types.DistributedObjectInfo {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	objects := make([]types.DistributedObjectInfo, 0, len(m.proxies))
-	for _, p := range m.proxies {
-		objects = append(objects, types.DistributedObjectInfo{Name: p.name, ServiceName: p.serviceName})
-	}
-	return objects
-}
-
 func (m *proxyManager) addDistributedObjectEventListener(ctx context.Context, handler DistributedObjectNotifiedHandler) (types.UUID, error) {
 	request := codec.EncodeClientAddDistributedObjectListenerRequest(!m.serviceBundle.Config.Cluster.Unisocket)
 	subscriptionID := types.NewUUID()

--- a/types/distributed_objects_info.go
+++ b/types/distributed_objects_info.go
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package types
+
+type DistributedObjectInfo struct {
+	name        string
+	serviceName string
+}
+
+func (i *DistributedObjectInfo) Name() string {
+	return i.name
+}
+
+func (i *DistributedObjectInfo) ServiceName() string {
+	return i.serviceName
+}
+
+func NewDistributedObjectInfo(name string, serviceName string) DistributedObjectInfo {
+	return DistributedObjectInfo{name: name, serviceName: serviceName}
+}

--- a/types/distributed_objects_info.go
+++ b/types/distributed_objects_info.go
@@ -17,18 +17,6 @@
 package types
 
 type DistributedObjectInfo struct {
-	name        string
-	serviceName string
-}
-
-func (i *DistributedObjectInfo) Name() string {
-	return i.name
-}
-
-func (i *DistributedObjectInfo) ServiceName() string {
-	return i.serviceName
-}
-
-func NewDistributedObjectInfo(name string, serviceName string) DistributedObjectInfo {
-	return DistributedObjectInfo{name: name, serviceName: serviceName}
+	Name        string
+	ServiceName string
 }


### PR DESCRIPTION
Replaces #602 

- Moves DistributedObjectInfo from internal pkg to types. It's also the return type of the new API.
- Unlike #602, this does not create local proxies for fetched distributed objects until client makes `Get*` call.