### PR TITLE
Add FlakeIDGenerator [API-482]

### DIFF
--- a/client.go
+++ b/client.go
@@ -201,6 +201,14 @@ func (c *Client) GetPNCounter(ctx context.Context, name string) (*PNCounter, err
 	return c.proxyManager.getPNCounter(ctx, name)
 }
 
+// GetPNCounter returns a PNCounter instance.
+func (c *Client) GetFlakeIDGenerator(ctx context.Context, name string) (*FlakeIdGenerator, error) {
+	if atomic.LoadInt32(&c.state) != ready {
+		return nil, hzerrors.ErrClientNotActive
+	}
+	return c.proxyManager.getFlakeIDGenerator(ctx, name)
+}
+
 // GetDistributedObjectsInfo returns the information of all objects created cluster-wide.
 func (c *Client) GetDistributedObjectsInfo(ctx context.Context) ([]types.DistributedObjectInfo, error) {
 	if atomic.LoadInt32(&c.state) != ready {

--- a/client.go
+++ b/client.go
@@ -201,8 +201,8 @@ func (c *Client) GetPNCounter(ctx context.Context, name string) (*PNCounter, err
 	return c.proxyManager.getPNCounter(ctx, name)
 }
 
-// GetPNCounter returns a PNCounter instance.
-func (c *Client) GetFlakeIDGenerator(ctx context.Context, name string) (*FlakeIdGenerator, error) {
+// GetFlakeIDGenerator returns a FlakeIDGenerator instance.
+func (c *Client) GetFlakeIDGenerator(ctx context.Context, name string) (*FlakeIDGenerator, error) {
 	if atomic.LoadInt32(&c.state) != ready {
 		return nil, hzerrors.ErrClientNotActive
 	}

--- a/config.go
+++ b/config.go
@@ -189,7 +189,7 @@ type FlakeIDGeneratorConfig struct {
 func (f *FlakeIDGeneratorConfig) Validate() error {
 	if f.PrefetchCount == 0 {
 		f.PrefetchCount = defaultFlakeIDPrefetchCount
-	} else if err := validate.IsWithinInclusiveRangeInt32(f.PrefetchCount, 1, maxFlakeIDPrefetchCount); err != nil {
+	} else if err := validate.WithinRangeInt32(f.PrefetchCount, 1, maxFlakeIDPrefetchCount); err != nil {
 		return err
 	}
 	if err := validate.NonNegativeDuration(&f.PrefetchExpiry, time.Duration(defaultFlakeIDPrefetchExpiry), "invalid duration"); err != nil {

--- a/export_test.go
+++ b/export_test.go
@@ -41,10 +41,6 @@ func NewFlakeIdGenerator(config FlakeIDGeneratorConfig, newBatchFn NewFlakeIDBat
 	})
 }
 
-func (c *Config) GetFlakeIDGeneratorConfig(name string) FlakeIDGeneratorConfig {
-	return c.getFlakeIDGeneratorConfig(name)
-}
-
 func NewFlakeIDBatch(base, increment int64, size int32, expiry time.Duration) flakeIDBatch {
 	return flakeIDBatch{
 		expiresAt: time.Now().Add(expiry),

--- a/export_test.go
+++ b/export_test.go
@@ -44,10 +44,10 @@ func NewFlakeIdGenerator(config FlakeIDGeneratorConfig, newBatchFn NewFlakeIDBat
 func NewFlakeIDBatch(base, increment int64, size int32, expiry time.Duration) flakeIDBatch {
 	return flakeIDBatch{
 		expiresAt: time.Now().Add(expiry),
-		index:     new(int32),
+		index:     -1,
 		base:      base,
 		increment: increment,
-		size:      size,
+		size:      int64(size),
 	}
 }
 

--- a/export_test.go
+++ b/export_test.go
@@ -1,12 +1,60 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package hazelcast
+
+import (
+	"context"
+	"time"
+)
 
 // Exports non-exported types and methods to hazelcast_test package.
 
 const (
 	DefaultFlakeIDPrefetchCount  = defaultFlakeIDPrefetchCount
 	DefaultFlakeIDPrefetchExpiry = defaultFlakeIDPrefetchExpiry
+	InvalidFlakeID               = invalidFlakeID
 )
+
+type (
+	FlakeIDBatch      flakeIDBatch
+	NewFlakeIDBatchFn func(ctx context.Context, f *FlakeIDGenerator) (FlakeIDBatch, error)
+)
+
+func NewFlakeIdGenerator(config FlakeIDGeneratorConfig, newBatchFn NewFlakeIDBatchFn) *FlakeIDGenerator {
+	return newFlakeIdGenerator(nil, config, func(ctx context.Context, f *FlakeIDGenerator) (flakeIDBatch, error) {
+		batch, err := newBatchFn(ctx, f)
+		return flakeIDBatch(batch), err
+	})
+}
 
 func (c *Config) GetFlakeIDGeneratorConfig(name string) FlakeIDGeneratorConfig {
 	return c.getFlakeIDGeneratorConfig(name)
+}
+
+func NewFlakeIDBatch(base, increment int64, size int32, expiry time.Duration) flakeIDBatch {
+	return flakeIDBatch{
+		expiresAt: time.Now().Add(expiry),
+		index:     new(int32),
+		base:      base,
+		increment: increment,
+		size:      size,
+	}
+}
+
+func (f *flakeIDBatch) NextID() int64 {
+	return f.nextID()
 }

--- a/export_test.go
+++ b/export_test.go
@@ -1,0 +1,12 @@
+package hazelcast
+
+// Exports non-exported types and methods to hazelcast_test package.
+
+const (
+	DefaultFlakeIDPrefetchCount  = defaultFlakeIDPrefetchCount
+	DefaultFlakeIDPrefetchExpiry = defaultFlakeIDPrefetchExpiry
+)
+
+func (c *Config) GetFlakeIDGeneratorConfig(name string) FlakeIDGeneratorConfig {
+	return c.getFlakeIDGeneratorConfig(name)
+}

--- a/flake_id_generator.go
+++ b/flake_id_generator.go
@@ -1,0 +1,96 @@
+package hazelcast
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/hazelcast/hazelcast-go-client/internal/proto/codec"
+)
+
+const invalidFlakeId int64 = -1
+
+type newFlakeIDBatchFn func(ctx context.Context, f *FlakeIdGenerator) (flakeIdBatch, error)
+
+type FlakeIdGenerator struct {
+	*proxy
+	mu         *sync.Mutex
+	batch      atomic.Value
+	newBatchFn newFlakeIDBatchFn
+	config     FlakeIDGeneratorConfig
+}
+
+func newFlakeIdGenerator(p *proxy, config FlakeIDGeneratorConfig, newBatchFn newFlakeIDBatchFn) *FlakeIdGenerator {
+	f := &FlakeIdGenerator{
+		proxy:      p,
+		mu:         &sync.Mutex{},
+		batch:      atomic.Value{},
+		newBatchFn: newBatchFn,
+		config:     config,
+	}
+	f.batch.Store(flakeIdBatch{})
+	return f
+}
+
+func (f *FlakeIdGenerator) NewId(ctx context.Context) (int64, error) {
+	for {
+		batch := f.batch.Load().(flakeIdBatch)
+		id := batch.next()
+		if id != invalidFlakeId {
+			return id, nil
+		}
+		f.mu.Lock()
+		if batch != f.batch.Load().(flakeIdBatch) {
+			f.mu.Unlock()
+			continue
+		}
+		if b, err := f.newBatchFn(ctx, f); err != nil {
+			f.mu.Unlock()
+			return invalidFlakeId, err
+		} else {
+			f.batch.Store(b)
+			f.mu.Unlock()
+		}
+	}
+}
+
+func defaultNewFlakeIDBatchFn(ctx context.Context, f *FlakeIdGenerator) (flakeIdBatch, error) {
+	request := codec.EncodeFlakeIdGeneratorNewIdBatchRequest(f.name, f.config.PrefetchCount)
+	resp, err := f.invokeOnRandomTarget(ctx, request, nil)
+	if err != nil {
+		return flakeIdBatch{}, err
+	}
+	base, inc, size := codec.DecodeFlakeIdGeneratorNewIdBatchResponse(resp)
+	return flakeIdBatch{
+		base:      base,
+		increment: inc,
+		size:      size,
+		index:     new(int32),
+		expiresAt: time.Now().Add(time.Duration(f.config.PrefetchExpiration)),
+	}, nil
+}
+
+type flakeIdBatch struct {
+	base      int64
+	increment int64
+	size      int32
+	index     *int32
+	expiresAt time.Time
+}
+
+func (f *flakeIdBatch) next() int64 {
+	if time.Now().After(f.expiresAt) {
+		return invalidFlakeId
+	}
+	var idx int32
+	for {
+		idx = atomic.LoadInt32(f.index)
+		if idx == f.size {
+			return invalidFlakeId
+		}
+		if atomic.CompareAndSwapInt32(f.index, idx, idx+1) {
+			return f.base + int64(idx)*f.increment
+		}
+	}
+}

--- a/flake_id_generator.go
+++ b/flake_id_generator.go
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package hazelcast
 
 import (

--- a/flake_id_generator_it_test.go
+++ b/flake_id_generator_it_test.go
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package hazelcast_test
+
+import (
+	"context"
+	"testing"
+
+	hz "github.com/hazelcast/hazelcast-go-client"
+	"github.com/hazelcast/hazelcast-go-client/internal/it"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFlakeIDGenerator_NewId(t *testing.T) {
+	it.Tester(t, func(t *testing.T, client *hz.Client) {
+		const idCount = 1_000
+		ctx := context.Background()
+		f, err := client.GetFlakeIDGenerator(ctx, it.NewUniqueObjectName("flake-id-gen"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		ids := map[int64]struct{}{}
+		for i := 0; i < idCount; i++ {
+			if id, err := f.NewId(ctx); err != nil {
+				t.Fatal(err)
+			} else {
+				ids[id] = struct{}{}
+			}
+		}
+		assert.Equal(t, idCount, len(ids)) // assert uniqueness
+	})
+}

--- a/flake_id_generator_it_test.go
+++ b/flake_id_generator_it_test.go
@@ -35,7 +35,7 @@ func TestFlakeIDGenerator_NewId(t *testing.T) {
 		}
 		ids := map[int64]struct{}{}
 		for i := 0; i < idCount; i++ {
-			if id, err := f.NewId(ctx); err != nil {
+			if id, err := f.NewID(ctx); err != nil {
 				t.Fatal(err)
 			} else {
 				ids[id] = struct{}{}

--- a/flake_id_generator_test.go
+++ b/flake_id_generator_test.go
@@ -63,7 +63,7 @@ func TestFlakeIDGenerator_UsedBatch(t *testing.T) {
 		batch2 = hazelcast.NewFlakeIDBatch(20, 1, 2, expiry)
 	)
 
-	f := hazelcast.NewFlakeIdGenerator(hazelcast.FlakeIDGeneratorConfig{}, func(_ context.Context, _ *hazelcast.FlakeIDGenerator) (hazelcast.FlakeIDBatch, error) {
+	f := hazelcast.NewFlakeIdGenerator(hazelcast.FlakeIDGeneratorConfig{}, func(context.Context, *hazelcast.FlakeIDGenerator) (hazelcast.FlakeIDBatch, error) {
 		if once {
 			once = false
 			return hazelcast.FlakeIDBatch(batch1), nil

--- a/flake_id_generator_test.go
+++ b/flake_id_generator_test.go
@@ -39,18 +39,17 @@ func TestFlakeIDGenerator_ExpiredBatch(t *testing.T) {
 		if once {
 			once = false
 			return hazelcast.FlakeIDBatch(batch1), nil
-		} else {
-			return hazelcast.FlakeIDBatch(batch2), nil
 		}
+		return hazelcast.FlakeIDBatch(batch2), nil
 	})
 
-	id1, err := f.NewId(ctx)
+	id1, err := f.NewID(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(0), id1)
 
 	time.Sleep(expiry * 2)
 
-	id2, err := f.NewId(ctx)
+	id2, err := f.NewID(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(20), id2)
 }
@@ -68,18 +67,17 @@ func TestFlakeIDGenerator_UsedBatch(t *testing.T) {
 		if once {
 			once = false
 			return hazelcast.FlakeIDBatch(batch1), nil
-		} else {
-			return hazelcast.FlakeIDBatch(batch2), nil
 		}
+		return hazelcast.FlakeIDBatch(batch2), nil
 	})
 
-	id1, err := f.NewId(ctx)
+	id1, err := f.NewID(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(0), id1)
-	id2, err := f.NewId(ctx)
+	id2, err := f.NewID(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(1), id2)
-	id3, err := f.NewId(ctx)
+	id3, err := f.NewID(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(20), id3)
 }
@@ -143,8 +141,8 @@ func TestFlakeIDBatch_ConcurrentCalls(t *testing.T) {
 		results            = make(chan int64, size)
 	)
 	wg := sync.WaitGroup{}
+	wg.Add(parallelism)
 	for i := 0; i < parallelism; i++ {
-		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			for i := 0; i < idPerRoutine; i++ {
@@ -153,12 +151,12 @@ func TestFlakeIDBatch_ConcurrentCalls(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+	close(results)
 	assert.Equal(t, int(size), len(results))
-	lookup := make(map[int64]struct{})
-	for i := 0; i < int(size); i++ {
-		id := <-results
+	lookup := map[int64]struct{}{}
+	for id := range results {
 		if _, ok := lookup[id]; ok {
-			t.Fatalf("dublicated flake id: %d", id)
+			t.Fatalf("duplicated flake id: %d", id)
 		}
 		lookup[id] = struct{}{}
 	}

--- a/flake_id_generator_test.go
+++ b/flake_id_generator_test.go
@@ -35,7 +35,7 @@ func TestFlakeIDGenerator_ExpiredBatch(t *testing.T) {
 		batch2 = hazelcast.NewFlakeIDBatch(20, 1, 10, expiry*100)
 	)
 
-	f := hazelcast.NewFlakeIdGenerator(hazelcast.FlakeIDGeneratorConfig{}, func(_ context.Context, _ *hazelcast.FlakeIDGenerator) (hazelcast.FlakeIDBatch, error) {
+	f := hazelcast.NewFlakeIdGenerator(hazelcast.FlakeIDGeneratorConfig{}, func(context.Context, *hazelcast.FlakeIDGenerator) (hazelcast.FlakeIDBatch, error) {
 		if once {
 			once = false
 			return hazelcast.FlakeIDBatch(batch1), nil

--- a/flake_id_generator_test.go
+++ b/flake_id_generator_test.go
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package hazelcast_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/hazelcast/hazelcast-go-client"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFlakeIDGenerator_ExpiredBatch(t *testing.T) {
+	var (
+		ctx    = context.Background()
+		once   = true
+		expiry = time.Millisecond * 10
+		batch1 = hazelcast.NewFlakeIDBatch(0, 1, 10, expiry)
+		batch2 = hazelcast.NewFlakeIDBatch(20, 1, 10, expiry*100)
+	)
+
+	f := hazelcast.NewFlakeIdGenerator(hazelcast.FlakeIDGeneratorConfig{}, func(_ context.Context, _ *hazelcast.FlakeIDGenerator) (hazelcast.FlakeIDBatch, error) {
+		if once {
+			once = false
+			return hazelcast.FlakeIDBatch(batch1), nil
+		} else {
+			return hazelcast.FlakeIDBatch(batch2), nil
+		}
+	})
+
+	id1, err := f.NewId(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), id1)
+
+	time.Sleep(expiry * 2)
+
+	id2, err := f.NewId(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(20), id2)
+}
+
+func TestFlakeIDGenerator_UsedBatch(t *testing.T) {
+	var (
+		ctx    = context.Background()
+		once   = true
+		expiry = time.Minute
+		batch1 = hazelcast.NewFlakeIDBatch(0, 1, 2, expiry)
+		batch2 = hazelcast.NewFlakeIDBatch(20, 1, 2, expiry)
+	)
+
+	f := hazelcast.NewFlakeIdGenerator(hazelcast.FlakeIDGeneratorConfig{}, func(_ context.Context, _ *hazelcast.FlakeIDGenerator) (hazelcast.FlakeIDBatch, error) {
+		if once {
+			once = false
+			return hazelcast.FlakeIDBatch(batch1), nil
+		} else {
+			return hazelcast.FlakeIDBatch(batch2), nil
+		}
+	})
+
+	id1, err := f.NewId(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), id1)
+	id2, err := f.NewId(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), id2)
+	id3, err := f.NewId(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(20), id3)
+}
+
+func TestFlakeIDBatch_NextID(t *testing.T) {
+	testCases := []struct {
+		expectedSequence []int64
+		base             int64
+		increment        int64
+		expiry           time.Duration
+		size             int32
+	}{
+		{
+			base:             10,
+			increment:        10,
+			size:             3,
+			expiry:           time.Minute,
+			expectedSequence: []int64{10, 20, 30, hazelcast.InvalidFlakeID},
+		},
+		{
+			base:             10,
+			increment:        10,
+			size:             1,
+			expiry:           time.Minute,
+			expectedSequence: []int64{10, hazelcast.InvalidFlakeID},
+		},
+		{
+			base:             10,
+			increment:        10,
+			size:             0,
+			expiry:           time.Minute,
+			expectedSequence: []int64{hazelcast.InvalidFlakeID},
+		},
+		{
+			base:             10,
+			increment:        10,
+			size:             3,
+			expiry:           0,
+			expectedSequence: []int64{hazelcast.InvalidFlakeID},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run("", func(t *testing.T) {
+			batch := hazelcast.NewFlakeIDBatch(tc.base, tc.increment, tc.size, tc.expiry)
+			for _, v := range tc.expectedSequence {
+				assert.Equal(t, v, batch.NextID())
+			}
+		})
+	}
+}
+
+func TestFlakeIDBatch_ConcurrentCalls(t *testing.T) {
+	var (
+		base         int64 = 0
+		increment    int64 = 1
+		size         int32 = 1000
+		parallelism        = 10
+		idPerRoutine       = 100 // equals to size/parallelism
+		expiry             = time.Minute
+		batch              = hazelcast.NewFlakeIDBatch(base, increment, size, expiry)
+		results            = make(chan int64, size)
+	)
+	wg := sync.WaitGroup{}
+	for i := 0; i < parallelism; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < idPerRoutine; i++ {
+				results <- batch.NextID()
+			}
+		}()
+	}
+	wg.Wait()
+	assert.Equal(t, int(size), len(results))
+	lookup := make(map[int64]struct{})
+	for i := 0; i < int(size); i++ {
+		id := <-results
+		if _, ok := lookup[id]; ok {
+			t.Fatalf("dublicated flake id: %d", id)
+		}
+		lookup[id] = struct{}{}
+	}
+	assert.Equal(t, int(size), len(lookup))
+	assert.Equal(t, hazelcast.InvalidFlakeID, batch.NextID())
+}

--- a/internal/proto/codec/flake_id_generator_new_id_batch_codec.go
+++ b/internal/proto/codec/flake_id_generator_new_id_batch_codec.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package codec
+
+import (
+	"github.com/hazelcast/hazelcast-go-client/internal/proto"
+)
+
+const (
+	// hex: 0x1C0100
+	FlakeIdGeneratorNewIdBatchCodecRequestMessageType = int32(1835264)
+	// hex: 0x1C0101
+	FlakeIdGeneratorNewIdBatchCodecResponseMessageType = int32(1835265)
+
+	FlakeIdGeneratorNewIdBatchCodecRequestBatchSizeOffset  = proto.PartitionIDOffset + proto.IntSizeInBytes
+	FlakeIdGeneratorNewIdBatchCodecRequestInitialFrameSize = FlakeIdGeneratorNewIdBatchCodecRequestBatchSizeOffset + proto.IntSizeInBytes
+
+	FlakeIdGeneratorNewIdBatchResponseBaseOffset      = proto.ResponseBackupAcksOffset + proto.ByteSizeInBytes
+	FlakeIdGeneratorNewIdBatchResponseIncrementOffset = FlakeIdGeneratorNewIdBatchResponseBaseOffset + proto.LongSizeInBytes
+	FlakeIdGeneratorNewIdBatchResponseBatchSizeOffset = FlakeIdGeneratorNewIdBatchResponseIncrementOffset + proto.LongSizeInBytes
+)
+
+// Fetches a new batch of ids for the given flake id generator.
+func EncodeFlakeIdGeneratorNewIdBatchRequest(name string, batchSize int32) *proto.ClientMessage {
+	clientMessage := proto.NewClientMessageForEncode()
+	clientMessage.SetRetryable(true)
+
+	initialFrame := proto.NewFrameWith(make([]byte, FlakeIdGeneratorNewIdBatchCodecRequestInitialFrameSize), proto.UnfragmentedMessage)
+	FixSizedTypesCodec.EncodeInt(initialFrame.Content, FlakeIdGeneratorNewIdBatchCodecRequestBatchSizeOffset, batchSize)
+	clientMessage.AddFrame(initialFrame)
+	clientMessage.SetMessageType(FlakeIdGeneratorNewIdBatchCodecRequestMessageType)
+	clientMessage.SetPartitionId(-1)
+
+	EncodeString(clientMessage, name)
+
+	return clientMessage
+}
+
+func DecodeFlakeIdGeneratorNewIdBatchResponse(clientMessage *proto.ClientMessage) (base int64, increment int64, batchSize int32) {
+	frameIterator := clientMessage.FrameIterator()
+	initialFrame := frameIterator.Next()
+
+	base = FixSizedTypesCodec.DecodeLong(initialFrame.Content, FlakeIdGeneratorNewIdBatchResponseBaseOffset)
+	increment = FixSizedTypesCodec.DecodeLong(initialFrame.Content, FlakeIdGeneratorNewIdBatchResponseIncrementOffset)
+	batchSize = FixSizedTypesCodec.DecodeInt(initialFrame.Content, FlakeIdGeneratorNewIdBatchResponseBatchSizeOffset)
+
+	return base, increment, batchSize
+}

--- a/internal/util/validationutil/util.go
+++ b/internal/util/validationutil/util.go
@@ -36,7 +36,7 @@ func ValidateAsNonNegativeInt32(n int) (int32, error) {
 	return int32(n), nil
 }
 
-func IsWithinInclusiveRangeInt32(n, start, end int32) error {
+func WithinRangeInt32(n, start, end int32) error {
 	if n < start || n > end {
 		return ihzerrors.NewIllegalArgumentError(fmt.Sprintf("number %d is out of range [%d,%d]", n, start, end), nil)
 	}

--- a/internal/util/validationutil/util.go
+++ b/internal/util/validationutil/util.go
@@ -36,7 +36,7 @@ func ValidateAsNonNegativeInt32(n int) (int32, error) {
 	return int32(n), nil
 }
 
-func ValidateWithinInclusiveRangeInt32(n, start, end int32) error {
+func IsWithinInclusiveRangeInt32(n, start, end int32) error {
 	if n < start || n > end {
 		return ihzerrors.NewIllegalArgumentError(fmt.Sprintf("number %d is out of range [%d,%d]", n, start, end), nil)
 	}

--- a/internal/util/validationutil/util.go
+++ b/internal/util/validationutil/util.go
@@ -36,6 +36,13 @@ func ValidateAsNonNegativeInt32(n int) (int32, error) {
 	return int32(n), nil
 }
 
+func ValidateWithinInclusiveRangeInt32(n, start, end int32) error {
+	if n < start || n > end {
+		return ihzerrors.NewIllegalArgumentError(fmt.Sprintf("number %d is out of range [%d,%d]", n, start, end), nil)
+	}
+	return nil
+}
+
 func NonNegativeDuration(v *types.Duration, d time.Duration, msg string) error {
 	if *v < 0 {
 		return fmt.Errorf("%s: %w", msg, hzerrors.ErrIllegalArgument)

--- a/internal/util/validationutil/util_test.go
+++ b/internal/util/validationutil/util_test.go
@@ -81,7 +81,7 @@ func TestIsWithinInclusiveRangeInt32(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run("", func(t *testing.T) {
-			if err := IsWithinInclusiveRangeInt32(tc.number, tc.start, tc.end); tc.valid {
+			if err := WithinRangeInt32(tc.number, tc.start, tc.end); tc.valid {
 				assert.NoError(t, err)
 			} else {
 				assert.Error(t, err)

--- a/internal/util/validationutil/util_test.go
+++ b/internal/util/validationutil/util_test.go
@@ -65,6 +65,31 @@ func TestValidateAsNonNegativeInt32_Error(t *testing.T) {
 	}
 }
 
+func TestIsWithinInclusiveRangeInt32(t *testing.T) {
+	testCases := []struct {
+		start  int32
+		number int32
+		end    int32
+		valid  bool
+	}{
+		{start: 10, number: 20, end: 30, valid: true},
+		{start: -30, number: -20, end: -10, valid: true},
+		{start: 0, number: 0, end: 10, valid: true},
+		{start: 0, number: 10, end: 10, valid: true},
+		{start: 0, number: -1, end: 10, valid: false},
+		{start: 0, number: 11, end: 10, valid: false},
+	}
+	for _, tc := range testCases {
+		t.Run("", func(t *testing.T) {
+			if err := IsWithinInclusiveRangeInt32(tc.number, tc.start, tc.end); tc.valid {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
+}
+
 func TestNonNegativeDuration(t *testing.T) {
 	v := types.Duration(-1)
 	if err := NonNegativeDuration(&v, 5*time.Second, "invalid"); !errors.Is(err, hzerrors.ErrIllegalArgument) {

--- a/proxy.go
+++ b/proxy.go
@@ -39,13 +39,14 @@ import (
 )
 
 const (
-	ServiceNameMap           = "hz:impl:mapService"
-	ServiceNameReplicatedMap = "hz:impl:replicatedMapService"
-	ServiceNameQueue         = "hz:impl:queueService"
-	ServiceNameTopic         = "hz:impl:topicService"
-	ServiceNameList          = "hz:impl:listService"
-	ServiceNameSet           = "hz:impl:setService"
-	ServiceNamePNCounter     = "hz:impl:PNCounterService"
+	ServiceNameMap              = "hz:impl:mapService"
+	ServiceNameReplicatedMap    = "hz:impl:replicatedMapService"
+	ServiceNameQueue            = "hz:impl:queueService"
+	ServiceNameTopic            = "hz:impl:topicService"
+	ServiceNameList             = "hz:impl:listService"
+	ServiceNameSet              = "hz:impl:setService"
+	ServiceNamePNCounter        = "hz:impl:PNCounterService"
+	ServiceNameFlakeIDGenerator = "hz:impl:flakeIdGeneratorService"
 )
 
 const (

--- a/proxy_manager.go
+++ b/proxy_manager.go
@@ -124,7 +124,7 @@ func (m *proxyManager) getPNCounter(ctx context.Context, name string) (*PNCounte
 
 func (m *proxyManager) getFlakeIDGenerator(ctx context.Context, name string) (*FlakeIDGenerator, error) {
 	p, err := m.proxyFor(ctx, ServiceNamePNCounter, name, func(p *proxy) (interface{}, error) {
-		return newFlakeIdGenerator(p, m.serviceBundle.Config.getFlakeIDGeneratorConfig(name), flakeIDBatchFromMemberFn), nil
+		return newFlakeIdGenerator(p, m.getFlakeIDGeneratorConfig(name), flakeIDBatchFromMemberFn), nil
 	})
 	if err != nil {
 		return nil, err
@@ -197,6 +197,16 @@ func (m *proxyManager) proxyFor(
 	}
 	m.proxies[name] = wrapper
 	return wrapper, nil
+}
+
+func (m *proxyManager) getFlakeIDGeneratorConfig(name string) FlakeIDGeneratorConfig {
+	if conf, ok := m.serviceBundle.Config.FlakeIDGenerators[name]; ok {
+		return conf
+	}
+	return FlakeIDGeneratorConfig{
+		PrefetchCount:  defaultFlakeIDPrefetchCount,
+		PrefetchExpiry: defaultFlakeIDPrefetchExpiry,
+	}
 }
 
 func makeProxyName(serviceName string, objectName string) string {

--- a/proxy_manager.go
+++ b/proxy_manager.go
@@ -108,6 +108,20 @@ func (m *proxyManager) getPNCounter(ctx context.Context, name string) (*PNCounte
 	}
 }
 
+func (m *proxyManager) getFlakeIDGenerator(ctx context.Context, name string) (*FlakeIdGenerator, error) {
+	// TODO: need to preserve the batch state for consecutive calls.
+	//  https://github.com/hazelcast/hazelcast-go-client/issues/609
+	config := newDefaultFlakeIDGeneratorConfig()
+	if c, ok := m.serviceBundle.Config.FlakeIDGeneratorConfigs[name]; ok {
+		config = c
+	}
+	if p, err := m.proxyFor(ctx, ServiceNameFlakeIDGenerator, name); err != nil {
+		return nil, err
+	} else {
+		return newFlakeIdGenerator(p, config, defaultNewFlakeIDBatchFn), nil
+	}
+}
+
 func (m *proxyManager) invokeOnRandomTarget(ctx context.Context, request *proto.ClientMessage, handler proto.ClientMessageHandler) (*proto.ClientMessage, error) {
 	return m.invocationProxy.invokeOnRandomTarget(ctx, request, handler)
 }


### PR DESCRIPTION
Adds `FlakeIdGenerator` and `FlakeIdGeneratorConfig`. Also creates `export_test.go` file to make non-exported methods testable.