### PR TITLE
Return same proxy struct instance from Get calls

### DIFF
--- a/.github/workflows/test-all.yaml
+++ b/.github/workflows/test-all.yaml
@@ -36,11 +36,10 @@ jobs:
           go get -u golang.org/x/tools/...
           go get honnef.co/go/tools/cmd/staticcheck@latest
 
-      - name: "Run All Tests"
-        run: |
-          make test-all
-
       - name: "Run Checkers"
         run: |
           make check
 
+      - name: "Run All Tests"
+        run: |
+          make test-all

--- a/client_it_test.go
+++ b/client_it_test.go
@@ -369,8 +369,8 @@ func TestClient_GetDistributedObjects(t *testing.T) {
 
 func TestClient_GetProxyInstance(t *testing.T) {
 	testCases := []struct {
-		name  string
 		getFn func(ctx context.Context, client *hz.Client, name string) (interface{}, error)
+		name  string
 	}{
 		{
 			name: "map",

--- a/client_it_test.go
+++ b/client_it_test.go
@@ -366,3 +366,71 @@ func TestClient_GetDistributedObjects(t *testing.T) {
 		assert.NotContains(t, objects, setInfo)
 	})
 }
+
+func TestClient_GetProxyInstance(t *testing.T) {
+	testCases := []struct {
+		name  string
+		getFn func(ctx context.Context, client *hz.Client, name string) (interface{}, error)
+	}{
+		{
+			name: "map",
+			getFn: func(ctx context.Context, client *hz.Client, name string) (interface{}, error) {
+				return client.GetMap(ctx, name)
+			},
+		},
+		{
+			name: "replicated-map",
+			getFn: func(ctx context.Context, client *hz.Client, name string) (interface{}, error) {
+				return client.GetReplicatedMap(ctx, name)
+			},
+		},
+		{
+			name: "list",
+			getFn: func(ctx context.Context, client *hz.Client, name string) (interface{}, error) {
+				return client.GetList(ctx, name)
+			},
+		},
+		{
+			name: "queue",
+			getFn: func(ctx context.Context, client *hz.Client, name string) (interface{}, error) {
+				return client.GetQueue(ctx, name)
+			},
+		},
+		{
+			name: "topic",
+			getFn: func(ctx context.Context, client *hz.Client, name string) (interface{}, error) {
+				return client.GetTopic(ctx, name)
+			},
+		},
+		{
+			name: "set",
+			getFn: func(ctx context.Context, client *hz.Client, name string) (interface{}, error) {
+				return client.GetSet(ctx, name)
+			},
+		},
+		{
+			name: "pn-counter",
+			getFn: func(ctx context.Context, client *hz.Client, name string) (interface{}, error) {
+				return client.GetPNCounter(ctx, name)
+			},
+		},
+	}
+	it.Tester(t, func(t *testing.T, client *hz.Client) {
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				dsName := it.NewUniqueObjectName(tc.name)
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel()
+				p1, err := tc.getFn(ctx, client, dsName)
+				if err != nil {
+					t.Fatal(err)
+				}
+				p2, err := tc.getFn(ctx, client, dsName)
+				if err != nil {
+					t.Fatal(err)
+				}
+				assert.Same(t, p1, p2, "same proxy struct instances expected")
+			})
+		}
+	})
+}

--- a/proxy_manager.go
+++ b/proxy_manager.go
@@ -53,7 +53,7 @@ func newProxyManager(bundle creationBundle) *proxyManager {
 }
 
 func (m *proxyManager) getMap(ctx context.Context, name string) (*Map, error) {
-	p, err := m.proxyWrapperFor(ctx, ServiceNameMap, name, func(p *proxy) (interface{}, error) {
+	p, err := m.proxyFor(ctx, ServiceNameMap, name, func(p *proxy) (interface{}, error) {
 		return newMap(p), nil
 	})
 	if err != nil {
@@ -63,7 +63,7 @@ func (m *proxyManager) getMap(ctx context.Context, name string) (*Map, error) {
 }
 
 func (m *proxyManager) getReplicatedMap(ctx context.Context, name string) (*ReplicatedMap, error) {
-	p, err := m.proxyWrapperFor(ctx, ServiceNameReplicatedMap, name, func(p *proxy) (interface{}, error) {
+	p, err := m.proxyFor(ctx, ServiceNameReplicatedMap, name, func(p *proxy) (interface{}, error) {
 		return newReplicatedMap(p, m.refIDGenerator)
 	})
 	if err != nil {
@@ -73,7 +73,7 @@ func (m *proxyManager) getReplicatedMap(ctx context.Context, name string) (*Repl
 }
 
 func (m *proxyManager) getQueue(ctx context.Context, name string) (*Queue, error) {
-	p, err := m.proxyWrapperFor(ctx, ServiceNameQueue, name, func(p *proxy) (interface{}, error) {
+	p, err := m.proxyFor(ctx, ServiceNameQueue, name, func(p *proxy) (interface{}, error) {
 		return newQueue(p)
 	})
 	if err != nil {
@@ -83,7 +83,7 @@ func (m *proxyManager) getQueue(ctx context.Context, name string) (*Queue, error
 }
 
 func (m *proxyManager) getTopic(ctx context.Context, name string) (*Topic, error) {
-	p, err := m.proxyWrapperFor(ctx, ServiceNameTopic, name, func(p *proxy) (interface{}, error) {
+	p, err := m.proxyFor(ctx, ServiceNameTopic, name, func(p *proxy) (interface{}, error) {
 		return newTopic(p)
 	})
 	if err != nil {
@@ -93,7 +93,7 @@ func (m *proxyManager) getTopic(ctx context.Context, name string) (*Topic, error
 }
 
 func (m *proxyManager) getList(ctx context.Context, name string) (*List, error) {
-	p, err := m.proxyWrapperFor(ctx, ServiceNameList, name, func(p *proxy) (interface{}, error) {
+	p, err := m.proxyFor(ctx, ServiceNameList, name, func(p *proxy) (interface{}, error) {
 		return newList(p)
 	})
 	if err != nil {
@@ -103,7 +103,7 @@ func (m *proxyManager) getList(ctx context.Context, name string) (*List, error) 
 }
 
 func (m *proxyManager) getSet(ctx context.Context, name string) (*Set, error) {
-	p, err := m.proxyWrapperFor(ctx, ServiceNameSet, name, func(p *proxy) (interface{}, error) {
+	p, err := m.proxyFor(ctx, ServiceNameSet, name, func(p *proxy) (interface{}, error) {
 		return newSet(p)
 	})
 	if err != nil {
@@ -113,7 +113,7 @@ func (m *proxyManager) getSet(ctx context.Context, name string) (*Set, error) {
 }
 
 func (m *proxyManager) getPNCounter(ctx context.Context, name string) (*PNCounter, error) {
-	p, err := m.proxyWrapperFor(ctx, ServiceNamePNCounter, name, func(p *proxy) (interface{}, error) {
+	p, err := m.proxyFor(ctx, ServiceNamePNCounter, name, func(p *proxy) (interface{}, error) {
 		return newPNCounter(p), nil
 	})
 	if err != nil {
@@ -156,7 +156,7 @@ func (m *proxyManager) remove(serviceName string, objectName string) bool {
 	return true
 }
 
-func (m *proxyManager) proxyWrapperFor(
+func (m *proxyManager) proxyFor(
 	ctx context.Context,
 	serviceName string,
 	objectName string,

--- a/proxy_manager.go
+++ b/proxy_manager.go
@@ -29,7 +29,7 @@ import (
 
 type proxyManager struct {
 	mu              *sync.RWMutex
-	proxies         map[string]*proxy
+	proxies         map[string]interface{}
 	invocationProxy *proxy
 	serviceBundle   creationBundle
 	refIDGenerator  *iproxy.ReferenceIDGenerator
@@ -39,7 +39,7 @@ func newProxyManager(bundle creationBundle) *proxyManager {
 	bundle.Check()
 	pm := &proxyManager{
 		mu:             &sync.RWMutex{},
-		proxies:        map[string]*proxy{},
+		proxies:        map[string]interface{}{},
 		serviceBundle:  bundle,
 		refIDGenerator: iproxy.NewReferenceIDGenerator(1),
 	}
@@ -53,59 +53,73 @@ func newProxyManager(bundle creationBundle) *proxyManager {
 }
 
 func (m *proxyManager) getMap(ctx context.Context, name string) (*Map, error) {
-	if p, err := m.proxyFor(ctx, ServiceNameMap, name); err != nil {
-		return nil, err
-	} else {
+	p, err := m.proxyWrapperFor(ctx, ServiceNameMap, name, func(p *proxy) (interface{}, error) {
 		return newMap(p), nil
+	})
+	if err != nil {
+		return nil, err
 	}
+	return p.(*Map), nil
 }
 
 func (m *proxyManager) getReplicatedMap(ctx context.Context, name string) (*ReplicatedMap, error) {
-	if p, err := m.proxyFor(ctx, ServiceNameReplicatedMap, name); err != nil {
-		return nil, err
-	} else {
+	p, err := m.proxyWrapperFor(ctx, ServiceNameReplicatedMap, name, func(p *proxy) (interface{}, error) {
 		return newReplicatedMap(p, m.refIDGenerator)
+	})
+	if err != nil {
+		return nil, err
 	}
+	return p.(*ReplicatedMap), nil
 }
 
 func (m *proxyManager) getQueue(ctx context.Context, name string) (*Queue, error) {
-	if p, err := m.proxyFor(ctx, ServiceNameQueue, name); err != nil {
-		return nil, err
-	} else {
+	p, err := m.proxyWrapperFor(ctx, ServiceNameQueue, name, func(p *proxy) (interface{}, error) {
 		return newQueue(p)
+	})
+	if err != nil {
+		return nil, err
 	}
+	return p.(*Queue), nil
 }
 
 func (m *proxyManager) getTopic(ctx context.Context, name string) (*Topic, error) {
-	if p, err := m.proxyFor(ctx, ServiceNameTopic, name); err != nil {
-		return nil, err
-	} else {
+	p, err := m.proxyWrapperFor(ctx, ServiceNameTopic, name, func(p *proxy) (interface{}, error) {
 		return newTopic(p)
+	})
+	if err != nil {
+		return nil, err
 	}
+	return p.(*Topic), nil
 }
 
 func (m *proxyManager) getList(ctx context.Context, name string) (*List, error) {
-	if p, err := m.proxyFor(ctx, ServiceNameList, name); err != nil {
-		return nil, err
-	} else {
+	p, err := m.proxyWrapperFor(ctx, ServiceNameList, name, func(p *proxy) (interface{}, error) {
 		return newList(p)
+	})
+	if err != nil {
+		return nil, err
 	}
+	return p.(*List), nil
 }
 
 func (m *proxyManager) getSet(ctx context.Context, name string) (*Set, error) {
-	if p, err := m.proxyFor(ctx, ServiceNameSet, name); err != nil {
-		return nil, err
-	} else {
+	p, err := m.proxyWrapperFor(ctx, ServiceNameSet, name, func(p *proxy) (interface{}, error) {
 		return newSet(p)
+	})
+	if err != nil {
+		return nil, err
 	}
+	return p.(*Set), nil
 }
 
 func (m *proxyManager) getPNCounter(ctx context.Context, name string) (*PNCounter, error) {
-	if p, err := m.proxyFor(ctx, ServiceNamePNCounter, name); err != nil {
-		return nil, err
-	} else {
+	p, err := m.proxyWrapperFor(ctx, ServiceNamePNCounter, name, func(p *proxy) (interface{}, error) {
 		return newPNCounter(p), nil
+	})
+	if err != nil {
+		return nil, err
 	}
+	return p.(*PNCounter), nil
 }
 
 func (m *proxyManager) invokeOnRandomTarget(ctx context.Context, request *proto.ClientMessage, handler proto.ClientMessageHandler) (*proto.ClientMessage, error) {
@@ -142,13 +156,24 @@ func (m *proxyManager) remove(serviceName string, objectName string) bool {
 	return true
 }
 
-func (m *proxyManager) proxyFor(ctx context.Context, serviceName string, objectName string) (*proxy, error) {
+func (m *proxyManager) proxyWrapperFor(
+	ctx context.Context,
+	serviceName string,
+	objectName string,
+	wrapProxyFn func(p *proxy) (interface{}, error)) (interface{}, error) {
+
 	name := makeProxyName(serviceName, objectName)
 	m.mu.RLock()
-	obj, ok := m.proxies[name]
+	wrapper, ok := m.proxies[name]
 	m.mu.RUnlock()
 	if ok {
-		return obj, nil
+		return wrapper, nil
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if wrapper, ok := m.proxies[name]; ok {
+		// someone has already created the proxy
+		return wrapper, nil
 	}
 	p, err := newProxy(ctx, m.serviceBundle, serviceName, objectName, m.refIDGenerator, func() bool {
 		return m.remove(serviceName, objectName)
@@ -156,10 +181,12 @@ func (m *proxyManager) proxyFor(ctx context.Context, serviceName string, objectN
 	if err != nil {
 		return nil, err
 	}
-	m.mu.Lock()
-	m.proxies[name] = p
-	m.mu.Unlock()
-	return p, nil
+	wrapper, err = wrapProxyFn(p)
+	if err != nil {
+		return nil, err
+	}
+	m.proxies[name] = wrapper
+	return wrapper, nil
 }
 
 func makeProxyName(serviceName string, objectName string) string {


### PR DESCRIPTION
Fixes #609

Also moves linter checks before tests in GH actions definition. It makes no sense to wait for all tests to pass when `fieldalignment` or `go vet` will fail the GHA run. So, it's better to fail fast.