### PR TITLE
Add code sample for FlakeIDGenerator.

### DIFF
--- a/config.go
+++ b/config.go
@@ -17,9 +17,11 @@
 package hazelcast
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/hazelcast/hazelcast-go-client/cluster"
+	"github.com/hazelcast/hazelcast-go-client/internal/hzerrors"
 	validate "github.com/hazelcast/hazelcast-go-client/internal/util/validationutil"
 	"github.com/hazelcast/hazelcast-go-client/logger"
 	"github.com/hazelcast/hazelcast-go-client/serialization"
@@ -116,9 +118,7 @@ func (c *Config) Validate() error {
 	if err := c.Stats.Validate(); err != nil {
 		return err
 	}
-	if c.FlakeIDGenerators == nil {
-		c.FlakeIDGenerators = map[string]FlakeIDGeneratorConfig{}
-	}
+	c.ensureFlakeIDGenerators()
 	for _, v := range c.FlakeIDGenerators {
 		if err := v.Validate(); err != nil {
 			return err
@@ -139,15 +139,22 @@ func (c *Config) ensureMembershipListeners() {
 	}
 }
 
+func (c *Config) ensureFlakeIDGenerators() {
+	if c.FlakeIDGenerators == nil {
+		c.FlakeIDGenerators = map[string]FlakeIDGeneratorConfig{}
+	}
+}
+
 // AddFlakeIDGenerator validates the values and adds new FlakeIDGeneratorConfig with the given name.
 func (c *Config) AddFlakeIDGenerator(name string, prefetchCount int32, prefetchExpiry types.Duration) error {
+	if _, ok := c.FlakeIDGenerators[name]; ok {
+		return hzerrors.NewIllegalArgumentError(fmt.Sprintf("config already exists for %s", name), nil)
+	}
 	idConfig := FlakeIDGeneratorConfig{PrefetchCount: prefetchCount, PrefetchExpiry: prefetchExpiry}
 	if err := idConfig.Validate(); err != nil {
 		return err
 	}
-	if c.FlakeIDGenerators == nil {
-		c.FlakeIDGenerators = map[string]FlakeIDGeneratorConfig{}
-	}
+	c.ensureFlakeIDGenerators()
 	c.FlakeIDGenerators[name] = idConfig
 	return nil
 }

--- a/config.go
+++ b/config.go
@@ -139,6 +139,7 @@ func (c *Config) ensureMembershipListeners() {
 	}
 }
 
+// AddFlakeIDGenerator validates the values and adds new FlakeIDGeneratorConfig with the given name.
 func (c *Config) AddFlakeIDGenerator(name string, prefetchCount int32, prefetchExpiry types.Duration) error {
 	idConfig := FlakeIDGeneratorConfig{PrefetchCount: prefetchCount, PrefetchExpiry: prefetchExpiry}
 	if err := idConfig.Validate(); err != nil {

--- a/config_test.go
+++ b/config_test.go
@@ -248,6 +248,13 @@ func TestConfig_AddFlakeIDGenerator(t *testing.T) {
 	}
 }
 
+func TestConfig_AddExistingFlakeIDGenerator(t *testing.T) {
+	config := hazelcast.Config{}
+	assert.NoError(t, config.AddFlakeIDGenerator("foo", 1, 1))
+	err := config.AddFlakeIDGenerator("foo", 2, 2)
+	assert.True(t, errors.Is(err, hzerrors.ErrIllegalArgument))
+}
+
 func checkDefault(t *testing.T, c *hazelcast.Config) {
 	assert.Equal(t, "", c.ClientName)
 	assert.Equal(t, []string(nil), c.Labels)

--- a/examples/flake_id_generator/main.go
+++ b/examples/flake_id_generator/main.go
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hazelcast/hazelcast-go-client"
+	"github.com/hazelcast/hazelcast-go-client/types"
+)
+
+const (
+	// number of pre-fetched IDs from cluster.
+	idPrefetchCount int32 = 10
+	// validity duration for pre-fetched IDs.
+	idPrefetchExpiry = types.Duration(time.Minute)
+)
+
+func main() {
+	ctx := context.Background()
+	config := hazelcast.NewConfig()
+	if err := config.AddFlakeIDGenerator("id-gen", idPrefetchCount, idPrefetchExpiry); err != nil {
+		log.Fatal(err)
+	}
+	client, err := hazelcast.StartNewClientWithConfig(ctx, config)
+	if err != nil {
+		log.Fatal(err)
+	}
+	idGen, err := client.GetFlakeIDGenerator(ctx, "id-gen")
+	if err != nil {
+		log.Fatal(err)
+	}
+	for i := 0; i < 20; i++ {
+		id, err := idGen.NewID(ctx)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Printf("flakeID(%d):\t%d\n", i, id)
+	}
+	if err := client.Shutdown(ctx); err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
Follow up to #611

Adds code sample for FlakeIDGenerator. It generates`(idPrefetchCount * 2)` ids to indicate that prefetch count does not limit the total number of generated IDs by generator. Instead, the result of prefetch behavior can be observed from the output at 10th id:
```
flakeID(8):     482885333181530113
flakeID(9):     482885333181595649
			  ^^
flakeID(10):    482885333185200129
			  ^^
flakeID(11):    482885333185265665
flakeID(12):    482885333185331201
```