### PR TITLE
Failover Updates [API-626]

### DIFF
--- a/client.go
+++ b/client.go
@@ -19,6 +19,7 @@ package hazelcast
 import (
 	"context"
 	"fmt"
+	"math"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -421,7 +422,7 @@ func (c *Client) createComponents(config *Config) {
 	})
 	invocationFactory := icluster.NewConnectionInvocationFactory(&config.Cluster)
 	var failoverConfigs []cluster.Config
-	maxTryCount := 0
+	maxTryCount := math.MaxInt64
 	if config.Failover.Enabled {
 		maxTryCount = config.Failover.TryCount
 		failoverConfigs = config.Failover.Configs
@@ -453,7 +454,7 @@ func (c *Client) createComponents(config *Config) {
 		ClusterConfig:        &config.Cluster,
 		ClientName:           c.name,
 		FailoverService:      failoverService,
-		FailoverEnabled:      config.Failover.Enabled,
+		FailoverConfig:       &config.Failover,
 		Labels:               config.Labels,
 	})
 	invocationHandler := icluster.NewConnectionInvocationHandler(icluster.ConnectionInvocationHandlerCreationBundle{

--- a/client.go
+++ b/client.go
@@ -91,10 +91,10 @@ type Client struct {
 }
 
 func newClient(config Config) (*Client, error) {
+	config = config.Clone()
 	if err := config.Validate(); err != nil {
 		return nil, err
 	}
-	config = config.Clone()
 	id := atomic.AddInt32(&nextId, 1)
 	name := ""
 	if config.ClientName != "" {

--- a/client.go
+++ b/client.go
@@ -428,11 +428,7 @@ func (c *Client) createComponents(config *Config) {
 		failoverConfigs = config.Failover.Configs
 	}
 	failoverService := icluster.NewFailoverService(c.logger,
-		maxTryCount, config.Cluster, failoverConfigs, addrProviderTranslator,
-		func() bool {
-			state := atomic.LoadInt32(&c.state)
-			return state != stopping && state != stopped
-		})
+		maxTryCount, config.Cluster, failoverConfigs, addrProviderTranslator)
 	clusterService := icluster.NewService(icluster.CreationBundle{
 		RequestCh:         urgentRequestCh,
 		InvocationFactory: invocationFactory,

--- a/cluster/cluster_config.go
+++ b/cluster/cluster_config.go
@@ -19,6 +19,7 @@ package cluster
 import (
 	"time"
 
+	"github.com/hazelcast/hazelcast-go-client/internal"
 	validate "github.com/hazelcast/hazelcast-go-client/internal/util/validationutil"
 	"github.com/hazelcast/hazelcast-go-client/types"
 )
@@ -73,13 +74,16 @@ func (c *Config) Validate() error {
 	if c.Name == "" {
 		c.Name = defaultName
 	}
-	if err := validate.NonNegativeDuration(&c.HeartbeatInterval, 5*time.Second, "invalid heartbeat interval"); err != nil {
+	err := validate.NonNegativeDuration(&c.HeartbeatInterval, 5*time.Second, "invalid heartbeat interval")
+	if err != nil {
 		return err
 	}
-	if err := validate.NonNegativeDuration(&c.HeartbeatTimeout, 60*time.Second, "invalid heartbeat timeout"); err != nil {
+	err = validate.NonNegativeDuration(&c.HeartbeatTimeout, 60*time.Second, "invalid heartbeat timeout")
+	if err != nil {
 		return err
 	}
-	if err := validate.NonNegativeDuration(&c.InvocationTimeout, 120*time.Second, "invalid heartbeat timeout"); err != nil {
+	err = validate.NonNegativeDuration(&c.InvocationTimeout, 120*time.Second, "invalid heartbeat timeout")
+	if err != nil {
 		return err
 	}
 	if c.loadBalancer == nil {
@@ -99,6 +103,10 @@ func (c *Config) Validate() error {
 	}
 	if err := c.ConnectionStrategy.Validate(); err != nil {
 		return err
+	}
+	if c.ConnectionStrategy.Timeout == 0 {
+		// infinity
+		c.ConnectionStrategy.Timeout = types.Duration(internal.DefaultConnectionTimeoutWithoutFailover)
 	}
 	return nil
 }

--- a/cluster/connection_strategy_config.go
+++ b/cluster/connection_strategy_config.go
@@ -63,6 +63,7 @@ type ConnectionStrategyConfig struct {
 	// Retry contains the backoff configuration.
 	Retry ConnectionRetryConfig
 	// Timeout is the maximum time before giving up reconnecting to a cluster.
+	// Default is 0, infinite duration.
 	Timeout types.Duration `json:",omitempty"`
 	// ReconnectMode enables or disables reconnecting to a cluster.
 	ReconnectMode ReconnectMode `json:",omitempty"`

--- a/cluster/connection_strategy_config.go
+++ b/cluster/connection_strategy_config.go
@@ -63,7 +63,7 @@ type ConnectionStrategyConfig struct {
 	// Retry contains the backoff configuration.
 	Retry ConnectionRetryConfig
 	// Timeout is the maximum time before giving up reconnecting to a cluster.
-	// Default is 0, infinite duration.
+	// Default is 0, infinite duration when failover is not enabled and 120 seconds when it is enabled.
 	Timeout types.Duration `json:",omitempty"`
 	// ReconnectMode enables or disables reconnecting to a cluster.
 	ReconnectMode ReconnectMode `json:",omitempty"`

--- a/cluster/connection_strategy_config.go
+++ b/cluster/connection_strategy_config.go
@@ -73,7 +73,8 @@ func (c ConnectionStrategyConfig) Clone() ConnectionStrategyConfig {
 }
 
 func (c *ConnectionStrategyConfig) Validate() error {
-	if err := validate.NonNegativeDuration(&c.Timeout, 1<<63-1, "invalid timeout"); err != nil {
+	// we set the default to 0 in order to be able to override it in failover and cluster configs
+	if err := validate.NonNegativeDuration(&c.Timeout, 0, "invalid timeout"); err != nil {
 		return err
 	}
 	return c.Retry.Validate()

--- a/config_test.go
+++ b/config_test.go
@@ -375,7 +375,7 @@ func checkDefault(t *testing.T, c *hazelcast.Config) {
 	assert.Equal(t, "", c.Cluster.Cloud.Token)
 
 	assert.Equal(t, cluster.ReconnectModeOn, c.Cluster.ConnectionStrategy.ReconnectMode)
-	assert.Equal(t, types.Duration(9223372036854775807), c.Cluster.ConnectionStrategy.Timeout)
+	assert.Equal(t, types.Duration(31622400000000000), c.Cluster.ConnectionStrategy.Timeout)
 	cr := &c.Cluster.ConnectionStrategy.Retry
 	assert.Equal(t, types.Duration(1*time.Second), cr.InitialBackoff)
 	assert.Equal(t, types.Duration(30*time.Second), cr.MaxBackoff)
@@ -390,6 +390,7 @@ func checkDefault(t *testing.T, c *hazelcast.Config) {
 
 	assert.Equal(t, logger.InfoLevel, c.Logger.Level)
 
+	assert.Equal(t, false, c.Failover.Enabled)
 }
 
 func assertStringEquivalent(t *testing.T, s1, s2 string) {

--- a/config_test.go
+++ b/config_test.go
@@ -23,13 +23,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/hazelcast/hazelcast-go-client"
 	"github.com/hazelcast/hazelcast-go-client/cluster"
 	"github.com/hazelcast/hazelcast-go-client/hzerrors"
+	"github.com/hazelcast/hazelcast-go-client/internal"
 	"github.com/hazelcast/hazelcast-go-client/logger"
 	"github.com/hazelcast/hazelcast-go-client/types"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDefaultConfig(t *testing.T) {
@@ -375,7 +375,7 @@ func checkDefault(t *testing.T, c *hazelcast.Config) {
 	assert.Equal(t, "", c.Cluster.Cloud.Token)
 
 	assert.Equal(t, cluster.ReconnectModeOn, c.Cluster.ConnectionStrategy.ReconnectMode)
-	assert.Equal(t, types.Duration(31622400000000000), c.Cluster.ConnectionStrategy.Timeout)
+	assert.Equal(t, types.Duration(internal.DefaultConnectionTimeoutWithoutFailover), c.Cluster.ConnectionStrategy.Timeout)
 	cr := &c.Cluster.ConnectionStrategy.Retry
 	assert.Equal(t, types.Duration(1*time.Second), cr.InitialBackoff)
 	assert.Equal(t, types.Duration(30*time.Second), cr.MaxBackoff)

--- a/events.go
+++ b/events.go
@@ -116,6 +116,8 @@ func (s LifecycleState) String() string {
 		return "client connected"
 	case LifecycleStateDisconnected:
 		return "client disconnected"
+	case LifecycleStateChangedCluster:
+		return "changed cluster"
 	default:
 		return "UNKNOWN"
 	}

--- a/examples/cluster/failover/main.go
+++ b/examples/cluster/failover/main.go
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hazelcast/hazelcast-go-client"
+	"github.com/hazelcast/hazelcast-go-client/cluster"
+	"github.com/hazelcast/hazelcast-go-client/logger"
+)
+
+/*
+In order to test this example:
+
+1. Create two clusters running at localhost with names dev1 and dev2.
+2. Run the code sample in this file
+3. The client should connect to the `dev1` cluster and print out values.
+4. Terminate `dev1` cluster, the client should connect to the dev2 cluster and continue printing out values.
+
+*/
+
+var loggingLevel = logger.WarnLevel
+
+func makeKeyValue(i int) (key string, value string) {
+	key = fmt.Sprintf("key-%d", i)
+	value = fmt.Sprintf("value-%d", i)
+	return
+}
+
+func updateFailover(fo *cluster.FailoverConfig) {
+	cluster1 := cluster.Config{Name: "dev1"}
+	cluster1.Network.SetAddresses("localhost:5701")
+	cluster2 := cluster.Config{Name: "dev2"}
+	cluster2.Network.SetAddresses("localhost:5702")
+	fo.Enabled = true
+	fo.SetConfigs(cluster1, cluster2)
+}
+
+func getClient(ctx context.Context) *hazelcast.Client {
+	config := hazelcast.NewConfig()
+	config.Logger.Level = loggingLevel
+	updateFailover(&config.Failover)
+	client, err := hazelcast.StartNewClientWithConfig(ctx, config)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return client
+}
+
+func main() {
+	ctx := context.TODO()
+	client := getClient(ctx)
+	m, err := client.GetMap(ctx, "sample-map")
+	if err != nil {
+		log.Fatal(err)
+	}
+	for i := 0; i < 1000; i++ {
+		key, value := makeKeyValue(i)
+		log.Printf("writing %s=%s", key, value)
+		if err = m.Set(ctx, key, value); err != nil {
+			log.Fatal(err)
+		}
+		log.Printf("reading %s", key)
+		readValue, err := m.Get(ctx, key)
+		if err != nil {
+			log.Fatal(err)
+		}
+		log.Printf("read: %v\n", readValue)
+		time.Sleep(1000 * time.Millisecond)
+	}
+	if err = client.Shutdown(ctx); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/examples/cluster/failover/main.go
+++ b/examples/cluster/failover/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hazelcast/hazelcast-go-client"
 	"github.com/hazelcast/hazelcast-go-client/cluster"
 	"github.com/hazelcast/hazelcast-go-client/logger"
+	"github.com/hazelcast/hazelcast-go-client/types"
 )
 
 /*
@@ -37,7 +38,7 @@ In order to test this example:
 
 */
 
-var loggingLevel = logger.WarnLevel
+var loggingLevel = logger.DebugLevel
 
 func makeKeyValue(i int) (key string, value string) {
 	key = fmt.Sprintf("key-%d", i)
@@ -48,9 +49,12 @@ func makeKeyValue(i int) (key string, value string) {
 func updateFailover(fo *cluster.FailoverConfig) {
 	cluster1 := cluster.Config{Name: "dev1"}
 	cluster1.Network.SetAddresses("localhost:5701")
+	cluster1.ConnectionStrategy.Timeout = types.Duration(5 * time.Second)
 	cluster2 := cluster.Config{Name: "dev2"}
 	cluster2.Network.SetAddresses("localhost:5702")
+	cluster2.ConnectionStrategy.Timeout = types.Duration(15 * time.Second)
 	fo.Enabled = true
+	fo.TryCount = 3
 	fo.SetConfigs(cluster1, cluster2)
 }
 

--- a/examples/cluster/failover/main.go
+++ b/examples/cluster/failover/main.go
@@ -54,12 +54,12 @@ func updateFailover(fo *cluster.FailoverConfig) {
 	cluster2.Network.SetAddresses("localhost:5702")
 	cluster2.ConnectionStrategy.Timeout = types.Duration(15 * time.Second)
 	fo.Enabled = true
-	fo.TryCount = 3
+	fo.TryCount = 100
 	fo.SetConfigs(cluster1, cluster2)
 }
 
 func getClient(ctx context.Context) *hazelcast.Client {
-	config := hazelcast.NewConfig()
+	config := hazelcast.Config{}
 	config.Logger.Level = loggingLevel
 	updateFailover(&config.Failover)
 	client, err := hazelcast.StartNewClientWithConfig(ctx, config)
@@ -70,7 +70,8 @@ func getClient(ctx context.Context) *hazelcast.Client {
 }
 
 func main() {
-	ctx := context.TODO()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
 	client := getClient(ctx)
 	m, err := client.GetMap(ctx, "sample-map")
 	if err != nil {

--- a/internal/cb/circuitbreaker.go
+++ b/internal/cb/circuitbreaker.go
@@ -34,15 +34,14 @@ type EventHandler func(state int32)
 type RetryPolicyFunc func(currentTry int) time.Duration
 
 type CircuitBreaker struct {
+	Deadline            time.Time
 	RetryPolicyFunc     RetryPolicyFunc
 	StateChangeHandler  EventHandler
 	MaxRetries          int
 	ResetTimeout        time.Duration
-	Deadline            time.Time
 	MaxFailureCount     int32
 	CurrentFailureCount int32
 	State               int32
-	// TODO: add a setting for failure window
 }
 
 func NewCircuitBreaker(fs ...CircuitBreakerOptionFunc) *CircuitBreaker {

--- a/internal/cb/circuitbreaker_test.go
+++ b/internal/cb/circuitbreaker_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/hazelcast/hazelcast-go-client/internal/cb"
 )
 
@@ -124,4 +126,13 @@ func TestCancelFuture(t *testing.T) {
 	if atomic.LoadInt32(&funcCancelled) != 1 {
 		t.Fatalf("try handler was not cancelled")
 	}
+}
+
+func TestMakeDeadline(t *testing.T) {
+	deadline := cb.MakeDeadline(time.Duration(cb.MaxDuration))
+	assert.Equal(t, time.Unix(1<<63-62135596801, 999999999), deadline)
+
+	now := time.Now()
+	deadline = cb.MakeDeadline(100 * time.Hour)
+	assert.InDelta(t, now.Add(100*time.Hour).UnixNano(), deadline.UnixNano(), 1000)
 }

--- a/internal/cb/errors.go
+++ b/internal/cb/errors.go
@@ -19,6 +19,7 @@ package cb
 import "errors"
 
 var ErrCircuitOpen = errors.New("circuit open")
+var ErrDeadlineExceeded = errors.New("deadline exceeded")
 
 type NonRetryableError struct {
 	Err error

--- a/internal/cb/options.go
+++ b/internal/cb/options.go
@@ -22,7 +22,7 @@ import (
 	"time"
 )
 
-const maxDuration int64 = 1<<63 - 1
+const MaxDuration int64 = 1<<63 - 1
 
 type CircuitBreakerOptions struct {
 	RetryPolicyFunc    RetryPolicyFunc
@@ -50,7 +50,7 @@ func DefaultCircuitBreakerOptions() *CircuitBreakerOptions {
 		MaxRetries:      0,
 		MaxFailureCount: 0,
 		ResetTimeout:    0,
-		Timeout:         time.Duration(maxDuration),
+		Timeout:         time.Duration(MaxDuration),
 		RetryPolicyFunc: func(tries int) time.Duration {
 			return 0
 		},

--- a/internal/cb/options.go
+++ b/internal/cb/options.go
@@ -22,6 +22,8 @@ import (
 	"time"
 )
 
+const maxDuration int64 = 1<<63 - 1
+
 type CircuitBreakerOptions struct {
 	RetryPolicyFunc    RetryPolicyFunc
 	StateChangeHandler EventHandler
@@ -48,7 +50,7 @@ func DefaultCircuitBreakerOptions() *CircuitBreakerOptions {
 		MaxRetries:      0,
 		MaxFailureCount: 0,
 		ResetTimeout:    0,
-		Timeout:         time.Duration(1<<63 - 1),
+		Timeout:         time.Duration(maxDuration),
 		RetryPolicyFunc: func(tries int) time.Duration {
 			return 0
 		},

--- a/internal/cb/options.go
+++ b/internal/cb/options.go
@@ -27,6 +27,7 @@ type CircuitBreakerOptions struct {
 	StateChangeHandler EventHandler
 	MaxRetries         int
 	ResetTimeout       time.Duration
+	Timeout            time.Duration
 	MaxFailureCount    int32
 }
 
@@ -47,6 +48,7 @@ func DefaultCircuitBreakerOptions() *CircuitBreakerOptions {
 		MaxRetries:      0,
 		MaxFailureCount: 0,
 		ResetTimeout:    0,
+		Timeout:         time.Duration(1<<63 - 1),
 		RetryPolicyFunc: func(tries int) time.Duration {
 			return 0
 		},
@@ -79,6 +81,13 @@ func MaxFailureCount(failureCount int) CircuitBreakerOptionFunc {
 func ResetTimeout(timeout time.Duration) CircuitBreakerOptionFunc {
 	return func(opts *CircuitBreakerOptions) error {
 		opts.ResetTimeout = timeout
+		return nil
+	}
+}
+
+func Timeout(timeout time.Duration) CircuitBreakerOptionFunc {
+	return func(opts *CircuitBreakerOptions) error {
+		opts.Timeout = timeout
 		return nil
 	}
 }

--- a/internal/cluster/connection_manager.go
+++ b/internal/cluster/connection_manager.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"math/rand"
 	"sync"
 	"sync/atomic"
@@ -417,8 +418,12 @@ func (m *ConnectionManager) tryConnectCluster(ctx context.Context) (pubcluster.A
 }
 
 func (m *ConnectionManager) tryConnectCandidateCluster(ctx context.Context, cluster *CandidateCluster, cs *pubcluster.ConnectionStrategyConfig) (pubcluster.Address, error) {
+	tryCount := math.MaxInt32
+	if m.failoverConfig.Enabled {
+		tryCount = m.failoverConfig.TryCount
+	}
 	cbr := cb.NewCircuitBreaker(
-		cb.MaxRetries(m.failoverConfig.TryCount),
+		cb.MaxRetries(tryCount),
 		cb.Timeout(time.Duration(cs.Timeout)),
 		cb.MaxFailureCount(3),
 		cb.RetryPolicy(makeRetryPolicy(m.randGen, &cs.Retry)),

--- a/internal/cluster/connection_manager.go
+++ b/internal/cluster/connection_manager.go
@@ -114,18 +114,18 @@ func tryConnectAddress(
 
 type ConnectionManagerCreationBundle struct {
 	Logger               ilogger.Logger
-	ClusterService       *Service
+	RequestCh            chan<- invocation.Invocation
 	ResponseCh           chan<- *proto.ClientMessage
 	PartitionService     *PartitionService
 	InvocationFactory    *ConnectionInvocationFactory
 	ClusterConfig        *pubcluster.Config
-	RequestCh            chan<- invocation.Invocation
+	ClusterService       *Service
 	SerializationService *iserialization.Service
 	EventDispatcher      *event.DispatchService
 	FailoverService      *FailoverService
+	FailoverConfig       *pubcluster.FailoverConfig
 	ClientName           string
 	Labels               []string
-	FailoverConfig       *pubcluster.FailoverConfig
 }
 
 func (b ConnectionManagerCreationBundle) Check() {
@@ -169,7 +169,7 @@ func (b ConnectionManagerCreationBundle) Check() {
 
 type ConnectionManager struct {
 	logger               ilogger.Logger
-	clusterIDMu          *sync.Mutex
+	failoverConfig       *pubcluster.FailoverConfig
 	partitionService     *PartitionService
 	serializationService *iserialization.Service
 	eventDispatcher      *event.DispatchService
@@ -180,18 +180,18 @@ type ConnectionManager struct {
 	connMap              *connectionMap
 	doneCh               chan struct{}
 	clusterConfig        *pubcluster.Config
-	failoverService      *FailoverService
-	clusterID            *types.UUID // protected by clusterIDMu
+	clusterIDMu          *sync.Mutex
+	clusterID            *types.UUID
 	requestCh            chan<- invocation.Invocation
-	prevClusterID        *types.UUID // protected by clusterIDMu
+	prevClusterID        *types.UUID
+	failoverService      *FailoverService
+	randGen              *rand.Rand
 	clientName           string
 	labels               []string
 	clientUUID           types.UUID
 	nextConnID           int64
 	state                int32
 	smartRouting         bool
-	failoverConfig       *pubcluster.FailoverConfig
-	randGen              *rand.Rand
 }
 
 func NewConnectionManager(bundle ConnectionManagerCreationBundle) *ConnectionManager {

--- a/internal/cluster/connection_manager.go
+++ b/internal/cluster/connection_manager.go
@@ -524,7 +524,6 @@ func (m *ConnectionManager) processAuthenticationResult(conn *Connection, result
 		}
 		m.connMap.AddConnection(conn, connAddr)
 		m.clusterIDMu.Unlock()
-
 		m.logger.Debug(func() string {
 			return fmt.Sprintf("opened connection to: %s", connAddr)
 		})

--- a/internal/cluster/failover_service.go
+++ b/internal/cluster/failover_service.go
@@ -36,8 +36,8 @@ type CandidateCluster struct {
 	AddressProvider    AddressProvider
 	AddressTranslator  AddressTranslator
 	Credentials        security.Credentials
-	ClusterName        string
 	ConnectionStrategy *pubcluster.ConnectionStrategyConfig
+	ClusterName        string
 }
 
 type addrFun func(*pubcluster.Config, ilogger.Logger) (AddressProvider, AddressTranslator)

--- a/internal/cluster/failover_service.go
+++ b/internal/cluster/failover_service.go
@@ -24,9 +24,9 @@ import (
 	"github.com/hazelcast/hazelcast-go-client/internal/security"
 )
 
-// Responsible for cluster failover state and attempts management.
+// FailoverService is responsible for cluster failover state and attempts management.
 type FailoverService struct {
-	isClientRunningFn func() bool
+	clientRunningFn   func() bool
 	candidateClusters []CandidateCluster
 	maxTryCount       int
 	index             uint64
@@ -60,7 +60,7 @@ func NewFailoverService(
 	}
 
 	return &FailoverService{
-		isClientRunningFn: isClientRunningFn,
+		clientRunningFn:   isClientRunningFn,
 		maxTryCount:       maxTryCount,
 		candidateClusters: candidateClusters,
 	}
@@ -72,7 +72,7 @@ func makeCredentials(config *pubcluster.SecurityConfig) *security.UsernamePasswo
 
 func (s *FailoverService) TryNextCluster(fn func(next *CandidateCluster) (pubcluster.Address, bool)) (pubcluster.Address, bool) {
 	tryCount := 0
-	for s.isClientRunningFn() && tryCount < s.maxTryCount {
+	for s.clientRunningFn() && tryCount < s.maxTryCount {
 		for i := 0; i < len(s.candidateClusters); i++ {
 			if addr, connected := fn(s.Next()); connected {
 				return addr, true

--- a/internal/cluster/failover_service.go
+++ b/internal/cluster/failover_service.go
@@ -26,7 +26,6 @@ import (
 
 // FailoverService is responsible for cluster failover state and attempts management.
 type FailoverService struct {
-	clientRunningFn   func() bool
 	candidateClusters []CandidateCluster
 	maxTryCount       int
 	index             uint64
@@ -42,7 +41,7 @@ type CandidateCluster struct {
 
 type addrFun func(*pubcluster.Config, ilogger.Logger) (AddressProvider, AddressTranslator)
 
-func NewFailoverService(logger ilogger.Logger, maxTries int, rootConfig pubcluster.Config, foConfigs []pubcluster.Config, addrFn addrFun, clientRunningFn func() bool) *FailoverService {
+func NewFailoverService(logger ilogger.Logger, maxTries int, rootConfig pubcluster.Config, foConfigs []pubcluster.Config, addrFn addrFun) *FailoverService {
 	candidates := []CandidateCluster{}
 	configs := []pubcluster.Config{}
 	if len(foConfigs) > 0 {
@@ -63,7 +62,6 @@ func NewFailoverService(logger ilogger.Logger, maxTries int, rootConfig pubclust
 	}
 
 	return &FailoverService{
-		clientRunningFn:   clientRunningFn,
 		maxTryCount:       maxTries,
 		candidateClusters: candidates,
 	}

--- a/internal/cluster/failover_service.go
+++ b/internal/cluster/failover_service.go
@@ -73,17 +73,11 @@ func makeCredentials(config *pubcluster.SecurityConfig) *security.UsernamePasswo
 	return security.NewUsernamePasswordCredentials(config.Credentials.Username, config.Credentials.Password)
 }
 
-func (s *FailoverService) TryNextCluster(fn func(next *CandidateCluster) (pubcluster.Address, error)) (pubcluster.Address, error) {
-	return fn(s.Next())
-}
-
 func (s *FailoverService) Current() *CandidateCluster {
 	idx := atomic.LoadUint64(&s.index)
 	return &s.candidateClusters[idx%uint64(len(s.candidateClusters))]
 }
 
-func (s *FailoverService) Next() *CandidateCluster {
-	// get and increment
-	idx := atomic.AddUint64(&s.index, 1) - 1
-	return &s.candidateClusters[idx%uint64(len(s.candidateClusters))]
+func (s *FailoverService) Next() {
+	atomic.AddUint64(&s.index, 1)
 }

--- a/internal/common.go
+++ b/internal/common.go
@@ -20,8 +20,8 @@ const (
 	// ClientType is used in the Management
 	ClientType         = "GOO"
 	AggregateFactoryID = -29
-)
 
-// ClientVersion is the build time version
-// TODO: This should be replace with a build time version variable, BuildInfo etc.
-var ClientVersion = "1.0.0"
+	// ClientVersion is the build time version
+	// TODO: This should be replaced with a build time version variable, BuildInfo etc.
+	ClientVersion = "1.1.0"
+)

--- a/internal/defaults.go
+++ b/internal/defaults.go
@@ -1,0 +1,8 @@
+package internal
+
+import "time"
+
+const (
+	DefaultConnectionTimeoutWithoutFailover = 24 * 366 * time.Hour
+	DefaultConnectionTimeoutWithFailover    = 120 * time.Second
+)

--- a/internal/defaults.go
+++ b/internal/defaults.go
@@ -3,6 +3,6 @@ package internal
 import "time"
 
 const (
-	DefaultConnectionTimeoutWithoutFailover = 24 * 366 * time.Hour
+	DefaultConnectionTimeoutWithoutFailover = time.Duration(1<<63 - 1)
 	DefaultConnectionTimeoutWithFailover    = 120 * time.Second
 )

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -20,8 +20,6 @@ import (
 	pubcluster "github.com/hazelcast/hazelcast-go-client/cluster"
 )
 
-const defaultHost = "127.0.0.1"
-
 func GetAddresses(host string, portRange pubcluster.PortRange) []pubcluster.Address {
 	var addrs []pubcluster.Address
 	for i := portRange.Min; i <= portRange.Max; i++ {


### PR DESCRIPTION
- Updated failover support to work in a way closer to how Java client works
- Fixed failover support, so only clusters in the failover config are used when it is enabled
- Fixed cluster connection timeouts.
- Added a code sample for failover support. 