### PR TITLE
Fixed ConnectionManager member removed handler [API-693]

### DIFF
--- a/.github/workflows/test-all.yaml
+++ b/.github/workflows/test-all.yaml
@@ -42,4 +42,4 @@ jobs:
 
       - name: "Run All Tests"
         run: |
-          make test-all
+          make test-all TEST_FLAGS='-timeout 20m'

--- a/client.go
+++ b/client.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/hazelcast/hazelcast-go-client/cluster"
 	"github.com/hazelcast/hazelcast-go-client/hzerrors"
+	"github.com/hazelcast/hazelcast-go-client/internal"
 	"github.com/hazelcast/hazelcast-go-client/internal/cloud"
 	icluster "github.com/hazelcast/hazelcast-go-client/internal/cluster"
 	"github.com/hazelcast/hazelcast-go-client/internal/event"
@@ -37,6 +38,10 @@ import (
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 	"github.com/hazelcast/hazelcast-go-client/internal/stats"
 	"github.com/hazelcast/hazelcast-go-client/types"
+)
+
+const (
+	ClientVersion = internal.ClientVersion
 )
 
 var nextId int32

--- a/client.go
+++ b/client.go
@@ -459,7 +459,7 @@ func (c *Client) createComponents(config *Config) {
 		FailoverConfig:       &config.Failover,
 		Labels:               config.Labels,
 	})
-	viewListener := icluster.NewViewListenerService(clusterService, connectionManager, c.eventDispatcher)
+	viewListener := icluster.NewViewListenerService(clusterService, connectionManager, c.eventDispatcher, c.logger)
 	invocationHandler := icluster.NewConnectionInvocationHandler(icluster.ConnectionInvocationHandlerCreationBundle{
 		ConnectionManager: connectionManager,
 		ClusterService:    clusterService,

--- a/client.go
+++ b/client.go
@@ -80,6 +80,7 @@ type Client struct {
 	connectionManager       *icluster.ConnectionManager
 	clusterService          *icluster.Service
 	partitionService        *icluster.PartitionService
+	viewListenerService     *icluster.ViewListenerService
 	invocationService       *invocation.Service
 	serializationService    *serialization.Service
 	eventDispatcher         *event.DispatchService
@@ -458,6 +459,7 @@ func (c *Client) createComponents(config *Config) {
 		FailoverConfig:       &config.Failover,
 		Labels:               config.Labels,
 	})
+	viewListener := icluster.NewViewListenerService(clusterService, connectionManager, c.eventDispatcher)
 	invocationHandler := icluster.NewConnectionInvocationHandler(icluster.ConnectionInvocationHandlerCreationBundle{
 		ConnectionManager: connectionManager,
 		ClusterService:    clusterService,
@@ -499,6 +501,7 @@ func (c *Client) createComponents(config *Config) {
 	c.invocationService = invocationService
 	c.proxyManager = newProxyManager(proxyManagerServiceBundle)
 	c.invocationHandler = invocationHandler
+	c.viewListenerService = viewListener
 }
 
 func (c *Client) clusterDisconnected(e event.Event) {

--- a/client_it_test.go
+++ b/client_it_test.go
@@ -524,7 +524,7 @@ func TestClientFailover_EECluster_Reconnection(t *testing.T) {
 	it.SkipIf(t, "oss")
 	ctx := context.Background()
 	cls1 := it.StartNewClusterWithOptions("failover-test-cluster1", 15701, it.MemberCount())
-	cls2 := it.StartNewClusterWithOptions("failover-test-cluster2", 15702, it.MemberCount())
+	cls2 := it.StartNewClusterWithOptions("failover-test-cluster2", 16701, it.MemberCount())
 	defer cls2.Shutdown()
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -597,7 +597,7 @@ func TestClientFixConnection(t *testing.T) {
 		log.Fatal(err)
 	}
 	log.Printf("===\n\nStarted member: %s\n\n===", m.UUID)
-	time.Sleep(10 * time.Second)
+	time.Sleep(20 * time.Second)
 	assert.Equal(t, int64(memberCount+1), atomic.LoadInt64(&addedCount))
 }
 

--- a/client_it_test.go
+++ b/client_it_test.go
@@ -309,7 +309,7 @@ func TestClusterReconnection_RemoveMembersOneByOne(t *testing.T) {
 	cls.Shutdown()
 	time.Sleep(1 * time.Second)
 
-	cls = it.StartNewClusterWithOptions("go-cli-test-cluster", 15701, 3)
+	cls = it.StartNewClusterWithOptions(clusterName, 11701, 3)
 	time.Sleep(5 * time.Second)
 	// start shutting down members one by one
 	for _, uuid := range cls.MemberUUIDs {

--- a/client_it_test.go
+++ b/client_it_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/hazelcast/hazelcast-go-client/internal"
 	"reflect"
 	"sync"
 	"sync/atomic"
@@ -32,6 +31,7 @@ import (
 	hz "github.com/hazelcast/hazelcast-go-client"
 	"github.com/hazelcast/hazelcast-go-client/cluster"
 	"github.com/hazelcast/hazelcast-go-client/hzerrors"
+	"github.com/hazelcast/hazelcast-go-client/internal"
 	"github.com/hazelcast/hazelcast-go-client/internal/it"
 	"github.com/hazelcast/hazelcast-go-client/logger"
 	"github.com/hazelcast/hazelcast-go-client/types"
@@ -552,4 +552,9 @@ func TestClientFailover_EECluster_Reconnection(t *testing.T) {
 	if err := c.Shutdown(context.Background()); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestClientVersion(t *testing.T) {
+	// adding this test here, so there's no "unused lint warning.
+	assert.Equal(t, "1.1.0", hz.ClientVersion)
 }

--- a/client_it_test.go
+++ b/client_it_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"reflect"
 	"sync"
 	"sync/atomic"
@@ -552,6 +553,52 @@ func TestClientFailover_EECluster_Reconnection(t *testing.T) {
 	if err := c.Shutdown(context.Background()); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestClientFixConnection(t *testing.T) {
+	// This test removes the member that corresponds to the connections which receives membership state changes.
+	// Once that connection is closed, another connection should be randomly selected to receive membership state changes.
+	// A new member is added to confirm that is the case.
+	const memberCount = 3
+	addedCount := int64(0)
+	ctx := context.Background()
+	cls := it.StartNewClusterWithOptions("600-cluster", 20701, memberCount)
+	defer cls.Shutdown()
+	config := hz.Config{}
+	config.Cluster.Network.SetAddresses("localhost:20702")
+	config.Cluster.Name = "600-cluster"
+	config.AddMembershipListener(func(event cluster.MembershipStateChanged) {
+		log.Printf("===\n\n%s member: %s\n\n===", event.State.String(), event.Member.UUID)
+		if event.State == cluster.MembershipStateAdded {
+			atomic.AddInt64(&addedCount, 1)
+		}
+	})
+	if it.TraceLoggingEnabled() {
+		config.Logger.Level = logger.TraceLevel
+	}
+	client, err := hz.StartNewClientWithConfig(ctx, config)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer client.Shutdown(ctx)
+	// terminate the member that corresponds to the connection which receives cluster membership updates
+	mUUID := cls.MemberUUIDs[1]
+	log.Printf("===\n\nTerminated member: %s\n\n===", mUUID)
+	ok, err := cls.RC.TerminateMember(ctx, cls.ClusterID, mUUID)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if !ok {
+		log.Fatalf("could not terminate member: %s", err.Error())
+	}
+	time.Sleep(10 * time.Second)
+	m, err := cls.RC.StartMember(ctx, cls.ClusterID)
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("===\n\nStarted member: %s\n\n===", m.UUID)
+	time.Sleep(10 * time.Second)
+	assert.Equal(t, int64(memberCount+1), atomic.LoadInt64(&addedCount))
 }
 
 func TestClientVersion(t *testing.T) {

--- a/internal/cluster/cluster_service.go
+++ b/internal/cluster/cluster_service.go
@@ -122,7 +122,9 @@ func (s *Service) Reset() {
 }
 
 func (s *Service) handleMembersUpdated(conn *Connection, version int32, memberInfos []pubcluster.MemberInfo) {
-	s.logger.Debug(func() string { return fmt.Sprintf("%d: members updated", conn.connectionID) })
+	s.logger.Debug(func() string {
+		return fmt.Sprintf("%d: members updated: %v", conn.connectionID, memberInfos)
+	})
 	added, removed := s.membersMap.Update(memberInfos, version)
 	if len(added) > 0 {
 		s.eventDispatcher.Publish(NewMembersAdded(added))
@@ -133,7 +135,9 @@ func (s *Service) handleMembersUpdated(conn *Connection, version int32, memberIn
 }
 
 func (s *Service) sendMemberListViewRequest(ctx context.Context, conn *Connection) error {
-	s.logger.Trace(func() string { return "cluster.Service.sendMemberListViewRequest" })
+	s.logger.Trace(func() string {
+		return fmt.Sprintf("%d: cluster.Service.sendMemberListViewRequest", conn.connectionID)
+	})
 	request := codec.EncodeClientAddClusterViewListenerRequest()
 	inv := s.invocationFactory.NewConnectionBoundInvocation(request, conn, func(response *proto.ClientMessage) {
 		codec.HandleClientAddClusterViewListener(response, func(version int32, memberInfos []pubcluster.MemberInfo) {

--- a/internal/cluster/cluster_service.go
+++ b/internal/cluster/cluster_service.go
@@ -199,10 +199,11 @@ func (m *membersMap) Update(members []pubcluster.MemberInfo, version int32) (add
 		newUUIDs := map[types.UUID]struct{}{}
 		added = []pubcluster.MemberInfo{}
 		for _, member := range members {
-			if m.addMember(&member) {
-				added = append(added, member)
+			mc := member
+			if m.addMember(&mc) {
+				added = append(added, mc)
 			}
-			newUUIDs[member.UUID] = struct{}{}
+			newUUIDs[mc.UUID] = struct{}{}
 		}
 		removed = []pubcluster.MemberInfo{}
 		for _, member := range m.members {
@@ -220,14 +221,6 @@ func (m *membersMap) Find(uuid types.UUID) *pubcluster.MemberInfo {
 	member := m.members[uuid]
 	m.membersMu.RUnlock()
 	return member
-}
-
-func (m *membersMap) RemoveMembersWithAddr(addr pubcluster.Address) {
-	m.membersMu.Lock()
-	if uuid, ok := m.addrToMemberUUID[addr]; ok {
-		m.removeMember(m.members[uuid])
-	}
-	m.membersMu.Unlock()
 }
 
 func (m *membersMap) Info(infoFun func(members map[types.UUID]*pubcluster.MemberInfo)) {

--- a/internal/cluster/connection_manager.go
+++ b/internal/cluster/connection_manager.go
@@ -250,10 +250,6 @@ func (m *ConnectionManager) start(ctx context.Context) error {
 	}
 	m.eventDispatcher.Publish(NewConnected(addr))
 	go m.heartbeat()
-	if m.smartRouting {
-		// fix broken connections only in the smart mode
-		go m.detectFixBrokenConnections()
-	}
 	if m.logger.CanLogDebug() {
 		go m.logStatus()
 	}
@@ -334,7 +330,7 @@ func (m *ConnectionManager) handleMembersAdded(event event.Event) {
 		})
 		missingAddrs := m.connMap.FindAddedAddrs(e.Members, m.clusterService)
 		for _, addr := range missingAddrs {
-			if _, err := m.ensureConnection(context.TODO(), addr); err != nil {
+			if _, err := connectMember(context.TODO(), m, addr); err != nil {
 				m.logger.Errorf("connecting address: %w", err)
 			} else {
 				m.logger.Infof("connectionManager member added: %s", addr.String())
@@ -655,34 +651,6 @@ func (m *ConnectionManager) logStatus() {
 				m.logger.Debug(func() string {
 					return fmt.Sprintf("connection to address: %+v", connToAddr)
 				})
-			})
-		}
-	}
-}
-
-func (m *ConnectionManager) detectFixBrokenConnections() {
-	ticker := time.NewTicker(5 * time.Second)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-m.doneCh:
-			return
-		case <-ticker.C:
-			// TODO: very inefficent, fix this
-			// find connections which exist in the cluster but not in the connection manager
-			for _, addr := range m.clusterService.MemberAddrs() {
-				m.checkFixConnection(addr)
-			}
-		}
-	}
-}
-
-func (m *ConnectionManager) checkFixConnection(addr pubcluster.Address) {
-	if conn := m.connMap.GetConnectionForAddr(addr); conn == nil {
-		m.logger.Infof("found a broken connection to: %s, trying to fix it.", addr)
-		if _, err := m.ensureConnection(context.TODO(), addr); err != nil {
-			m.logger.Debug(func() string {
-				return fmt.Sprintf("cannot fix connection to %s: %s", addr, err.Error())
 			})
 		}
 	}

--- a/internal/cluster/connection_manager.go
+++ b/internal/cluster/connection_manager.go
@@ -422,12 +422,8 @@ func (m *ConnectionManager) tryConnectCluster(ctx context.Context) (pubcluster.A
 }
 
 func (m *ConnectionManager) tryConnectCandidateCluster(ctx context.Context, cluster *CandidateCluster, cs *pubcluster.ConnectionStrategyConfig) (pubcluster.Address, error) {
-	retries := math.MaxInt32
-	if m.failoverConfig.Enabled {
-		retries = 1
-	}
 	cbr := cb.NewCircuitBreaker(
-		cb.MaxRetries(retries),
+		cb.MaxRetries(math.MaxInt32),
 		cb.Timeout(time.Duration(cs.Timeout)),
 		cb.MaxFailureCount(3),
 		cb.RetryPolicy(makeRetryPolicy(m.randGen, &cs.Retry)),
@@ -868,5 +864,5 @@ func (m *connectionMap) removeAddr(addr pubcluster.Address) {
 
 func nonRetryableConnectionErr(err error) bool {
 	var ne cb.NonRetryableError
-	return ne.Is(err) || errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) || errors.Is(err, cb.ErrDeadlineExceeded)
+	return ne.Is(err) || errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled)
 }

--- a/internal/cluster/connection_manager.go
+++ b/internal/cluster/connection_manager.go
@@ -60,10 +60,6 @@ const (
 	serializationVersion = 1
 )
 
-const (
-	clusterConnectionFixTimeout = 10 * time.Second
-)
-
 type connectMemberFunc func(ctx context.Context, m *ConnectionManager, addr pubcluster.Address) (pubcluster.Address, error)
 
 func connectMember(ctx context.Context, m *ConnectionManager, addr pubcluster.Address) (pubcluster.Address, error) {

--- a/internal/cluster/connection_manager.go
+++ b/internal/cluster/connection_manager.go
@@ -679,8 +679,7 @@ func (m *ConnectionManager) checkFixConnection(addr pubcluster.Address) {
 		m.logger.Debug(func() string {
 			return fmt.Sprintf("found a broken connection to: %s, trying to fix it.", addr)
 		})
-		ctx, cancel := context.WithTimeout(context.Background(), clusterConnectionFixTimeout)
-		defer cancel()
+		ctx := context.Background()
 		if _, err := connectMember(ctx, m, addr); err != nil {
 			m.logger.Debug(func() string {
 				return fmt.Sprintf("cannot fix connection to %s: %s", addr, err.Error())

--- a/internal/cluster/connection_manager.go
+++ b/internal/cluster/connection_manager.go
@@ -68,12 +68,9 @@ type connectMemberFunc func(ctx context.Context, m *ConnectionManager, addr pubc
 
 func connectMember(ctx context.Context, m *ConnectionManager, addr pubcluster.Address) (pubcluster.Address, error) {
 	var initialAddr pubcluster.Address
-	var conn *Connection
 	var err error
-	if conn, err = m.ensureConnection(ctx, addr); err != nil {
+	if _, err = m.ensureConnection(ctx, addr); err != nil {
 		m.logger.Errorf("cannot connect to %s: %w", addr.String(), err)
-	} else if err = m.clusterService.sendMemberListViewRequest(ctx, conn); err != nil {
-		m.logger.Errorf("could not send member list view request to %s: %w", addr.String(), err)
 	} else if initialAddr == "" {
 		initialAddr = addr
 	}

--- a/internal/cluster/connection_manager.go
+++ b/internal/cluster/connection_manager.go
@@ -767,20 +767,31 @@ func (m *connectionMap) RandomConn() *Connection {
 	if len(m.addrs) == 0 {
 		return nil
 	}
-	var addr pubcluster.Address
 	if len(m.addrs) == 1 {
-		addr = m.addrs[0]
-	} else {
+		addr := m.addrs[0]
+		conn := m.addrToConn[addr]
+		if conn != nil && atomic.LoadInt32(&conn.status) == open {
+			return conn
+		}
+		return nil
+	}
+	var addr pubcluster.Address
+	for {
+		// there is a chance that retrieved connection is closed and not yet removed
+		// loop to ensure that an open connection or nil is returned
 		addr = m.lb.OneOf(m.addrs)
-	}
-	conn := m.addrToConn[addr]
-	if conn != nil {
-		return conn
-	}
-	// if the connection was not found by using the load balancer, select a random one.
-	for _, conn = range m.addrToConn {
-		// Go randomizes maps, this is random enough for now.
-		return conn
+		conn := m.addrToConn[addr]
+		if conn != nil && atomic.LoadInt32(&conn.status) == open {
+			return conn
+		}
+		// if the connection was not found by using the load balancer, select a random one.
+		for _, conn = range m.addrToConn {
+			// Go randomizes maps, this is random enough for now.
+			if atomic.LoadInt32(&conn.status) == open {
+				return conn
+			}
+		}
+		break
 	}
 	return nil
 }

--- a/internal/cluster/view_listener_service.go
+++ b/internal/cluster/view_listener_service.go
@@ -1,0 +1,57 @@
+package cluster
+
+import (
+	"context"
+	"sync/atomic"
+
+	"github.com/hazelcast/hazelcast-go-client/internal/event"
+)
+
+type ViewListenerService struct {
+	cs         *Service
+	cm         *ConnectionManager
+	dispatcher *event.DispatchService
+	connID     int64
+}
+
+func NewViewListenerService(cs *Service, cm *ConnectionManager, dispatcher *event.DispatchService) *ViewListenerService {
+	vs := &ViewListenerService{
+		cs:         cs,
+		cm:         cm,
+		dispatcher: dispatcher,
+		connID:     -1,
+	}
+	dispatcher.Subscribe(EventConnectionOpened, event.DefaultSubscriptionID, vs.handleConnectionOpened)
+	dispatcher.Subscribe(EventConnectionClosed, event.DefaultSubscriptionID, vs.handleConnectionClosed)
+	return vs
+}
+
+func (vs *ViewListenerService) handleConnectionOpened(event event.Event) {
+	if e, ok := event.(*ConnectionOpened); ok {
+		vs.tryRegister(e.Conn)
+	}
+}
+
+func (vs *ViewListenerService) handleConnectionClosed(event event.Event) {
+	if e, ok := event.(*ConnectionClosed); ok {
+		vs.tryReregisterToRandomConnection(e.Conn)
+	}
+}
+
+func (vs *ViewListenerService) tryRegister(conn *Connection) {
+	if !atomic.CompareAndSwapInt64(&vs.connID, -1, conn.connectionID) {
+		return
+	}
+	if err := vs.cs.sendMemberListViewRequest(context.Background(), conn); err != nil {
+		vs.tryReregisterToRandomConnection(conn)
+	}
+}
+
+func (vs *ViewListenerService) tryReregisterToRandomConnection(oldConn *Connection) {
+	if !atomic.CompareAndSwapInt64(&vs.connID, oldConn.connectionID, -1) {
+		return
+	}
+	if conn := vs.cm.RandomConnection(); conn != nil {
+		vs.tryRegister(conn)
+	}
+}

--- a/internal/cluster/view_listener_service.go
+++ b/internal/cluster/view_listener_service.go
@@ -2,23 +2,27 @@ package cluster
 
 import (
 	"context"
+	"fmt"
 	"sync/atomic"
 
 	"github.com/hazelcast/hazelcast-go-client/internal/event"
+	"github.com/hazelcast/hazelcast-go-client/internal/logger"
 )
 
 type ViewListenerService struct {
 	cs         *Service
 	cm         *ConnectionManager
 	dispatcher *event.DispatchService
+	logger     logger.Logger
 	connID     int64
 }
 
-func NewViewListenerService(cs *Service, cm *ConnectionManager, dispatcher *event.DispatchService) *ViewListenerService {
+func NewViewListenerService(cs *Service, cm *ConnectionManager, dispatcher *event.DispatchService, logger logger.Logger) *ViewListenerService {
 	vs := &ViewListenerService{
 		cs:         cs,
 		cm:         cm,
 		dispatcher: dispatcher,
+		logger:     logger,
 	}
 	dispatcher.Subscribe(EventConnectionOpened, event.DefaultSubscriptionID, vs.handleConnectionOpened)
 	dispatcher.Subscribe(EventConnectionClosed, event.DefaultSubscriptionID, vs.handleConnectionClosed)
@@ -26,18 +30,23 @@ func NewViewListenerService(cs *Service, cm *ConnectionManager, dispatcher *even
 }
 
 func (vs *ViewListenerService) handleConnectionOpened(event event.Event) {
+	vs.logger.Trace(func() string { return "cluster.ViewListenerService.handleConnectionOpened" })
 	if e, ok := event.(*ConnectionOpened); ok {
 		vs.tryRegister(e.Conn)
 	}
 }
 
 func (vs *ViewListenerService) handleConnectionClosed(event event.Event) {
+	vs.logger.Trace(func() string { return "cluster.ViewListenerService.handleConnectionClosed" })
 	if e, ok := event.(*ConnectionClosed); ok {
 		vs.tryReregisterToRandomConnection(e.Conn)
 	}
 }
 
 func (vs *ViewListenerService) tryRegister(conn *Connection) {
+	vs.logger.Trace(func() string {
+		return fmt.Sprintf("cluster.ViewListenerService.tryRegister (status: %d): %d", atomic.LoadInt32(&conn.status), conn.connectionID)
+	})
 	if !atomic.CompareAndSwapInt64(&vs.connID, 0, conn.connectionID) {
 		return
 	}
@@ -47,6 +56,9 @@ func (vs *ViewListenerService) tryRegister(conn *Connection) {
 }
 
 func (vs *ViewListenerService) tryReregisterToRandomConnection(oldConn *Connection) {
+	vs.logger.Trace(func() string {
+		return fmt.Sprintf("cluster.ViewListenerService.tryReRegister: %d", oldConn.connectionID)
+	})
 	if !atomic.CompareAndSwapInt64(&vs.connID, oldConn.connectionID, 0) {
 		return
 	}

--- a/internal/cluster/view_listener_service.go
+++ b/internal/cluster/view_listener_service.go
@@ -19,7 +19,6 @@ func NewViewListenerService(cs *Service, cm *ConnectionManager, dispatcher *even
 		cs:         cs,
 		cm:         cm,
 		dispatcher: dispatcher,
-		connID:     -1,
 	}
 	dispatcher.Subscribe(EventConnectionOpened, event.DefaultSubscriptionID, vs.handleConnectionOpened)
 	dispatcher.Subscribe(EventConnectionClosed, event.DefaultSubscriptionID, vs.handleConnectionClosed)
@@ -39,7 +38,7 @@ func (vs *ViewListenerService) handleConnectionClosed(event event.Event) {
 }
 
 func (vs *ViewListenerService) tryRegister(conn *Connection) {
-	if !atomic.CompareAndSwapInt64(&vs.connID, -1, conn.connectionID) {
+	if !atomic.CompareAndSwapInt64(&vs.connID, 0, conn.connectionID) {
 		return
 	}
 	if err := vs.cs.sendMemberListViewRequest(context.Background(), conn); err != nil {
@@ -48,7 +47,7 @@ func (vs *ViewListenerService) tryRegister(conn *Connection) {
 }
 
 func (vs *ViewListenerService) tryReregisterToRandomConnection(oldConn *Connection) {
-	if !atomic.CompareAndSwapInt64(&vs.connID, oldConn.connectionID, -1) {
+	if !atomic.CompareAndSwapInt64(&vs.connID, oldConn.connectionID, 0) {
 		return
 	}
 	if conn := vs.cm.RandomConnection(); conn != nil {

--- a/internal/common.go
+++ b/internal/common.go
@@ -21,5 +21,5 @@ const (
 	ClientType         = "GOO"
 	AggregateFactoryID = -29
 	// ClientVersion should be manually set
-	ClientVersion = "1.1.0-dev"
+	ClientVersion = "1.1.0"
 )

--- a/internal/common.go
+++ b/internal/common.go
@@ -20,8 +20,6 @@ const (
 	// ClientType is used in the Management
 	ClientType         = "GOO"
 	AggregateFactoryID = -29
-
-	// ClientVersion is the build time version
-	// TODO: This should be replaced with a build time version variable, BuildInfo etc.
-	ClientVersion = "1.1.0"
+	// ClientVersion should be manually set
+	ClientVersion = "1.1.0-dev"
 )


### PR DESCRIPTION
* Fixes #600
* Send member list view request is sent to all members, not just the first seed.
* Various connection manager fixes

Tested with:
* https://github.com/SeriyBg/hazelcast-enterprise-operator/tree/hazelcast-status
* https://github.com/hazelcast-guides/kubernetes