### PR TITLE
remove sleep statements from client and map integration tests

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -31,8 +31,10 @@ go vet ./... 2>&1 | \
   grep -v "# github.com/hazelcast/hazelcast-go-client/internal/serialization" \
   || true
 
+# If missing install via: go get honnef.co/go/tools/cmd/staticcheck@latest
 staticcheck ./...
 
 # Ensure fields are optimally aligned
 # From: https://pkg.go.dev/golang.org/x/tools@v0.1.0/go/analysis/passes/fieldalignment
+# If missing install via: go get -u golang.org/x/tools/...
 fieldalignment ./...

--- a/client_it_test.go
+++ b/client_it_test.go
@@ -215,10 +215,10 @@ func TestClient_AddDistributedObjectListener(t *testing.T) {
 		it.Eventually(t, func() bool {
 			mu.Lock()
 			defer mu.Unlock()
-			if !assert.Equal(t, targetObjInfo, created) {
+			if targetObjInfo != created {
 				return false
 			}
-			return assert.Equal(t, targetObjInfo, destroyed)
+			return targetObjInfo == destroyed
 		})
 
 		if err := client.RemoveDistributedObjectListener(context.Background(), subID); err != nil {
@@ -229,10 +229,10 @@ func TestClient_AddDistributedObjectListener(t *testing.T) {
 		it.Eventually(t, func() bool {
 			mu.Lock()
 			defer mu.Unlock()
-			if !assert.Equal(t, targetObjInfo, created) {
+			if targetObjInfo != created {
 				return false
 			}
-			return assert.Equal(t, targetObjInfo, destroyed)
+			return targetObjInfo == destroyed
 		})
 	})
 }
@@ -564,7 +564,7 @@ func TestClientFixConnection(t *testing.T) {
 	}
 	highlight(t, "Started member: %s", m.UUID)
 	it.Eventually(t, func() bool {
-		return assert.Equal(t, int64(memberCount+1), atomic.LoadInt64(&addedCount))
+		return int64(memberCount+1) == atomic.LoadInt64(&addedCount)
 	})
 
 }

--- a/client_it_test.go
+++ b/client_it_test.go
@@ -304,9 +304,7 @@ func TestClusterReconnection_ReconnectModeOff(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	time.Sleep(2 * time.Second)
 	cls.Shutdown()
-	time.Sleep(100 * time.Millisecond)
 	assert.Equal(t, false, c.Running())
 }
 
@@ -565,8 +563,10 @@ func TestClientFixConnection(t *testing.T) {
 		log.Fatal(err)
 	}
 	highlight(t, "Started member: %s", m.UUID)
-	time.Sleep(30 * time.Second)
-	assert.Equal(t, int64(memberCount+1), atomic.LoadInt64(&addedCount))
+	it.Eventually(t, func() bool {
+		return assert.Equal(t, int64(memberCount+1), atomic.LoadInt64(&addedCount))
+	})
+
 }
 
 func TestClientVersion(t *testing.T) {

--- a/internal/it/util.go
+++ b/internal/it/util.go
@@ -400,7 +400,9 @@ func getDefaultClient(config *hz.Config) *hz.Client {
 // Eventually asserts that given condition will be met in 2 minutes,
 // checking target function every 200 milliseconds.
 func Eventually(t *testing.T, condition func() bool, msgAndArgs ...interface{}) {
-	assert.Eventually(t, condition, time.Minute*2, time.Millisecond*200, msgAndArgs)
+	if !assert.Eventually(t, condition, time.Minute*2, time.Millisecond*200, msgAndArgs) {
+		t.FailNow()
+	}
 }
 
 // Never asserts that the given condition doesn't satisfy in 3 seconds,

--- a/map_it_test.go
+++ b/map_it_test.go
@@ -59,8 +59,9 @@ func TestMap_PutWithTTL(t *testing.T) {
 			t.Fatal(err)
 		}
 		assert.Equal(t, targetValue, it.MustValue(m.Get(context.Background(), "key")))
-		time.Sleep(2 * time.Second)
-		assert.Equal(t, nil, it.MustValue(m.Get(context.Background(), "key")))
+		it.Eventually(t, func() bool {
+			return assert.Equal(t, nil, it.MustValue(m.Get(context.Background(), "key")))
+		})
 	})
 }
 
@@ -70,8 +71,9 @@ func TestMap_PutWithMaxIdle(t *testing.T) {
 		if _, err := m.PutWithMaxIdle(context.Background(), "key", targetValue, 1*time.Second); err != nil {
 			t.Fatal(err)
 		}
-		time.Sleep(4 * time.Second)
-		assert.Equal(t, nil, it.MustValue(m.Get(context.Background(), "key")))
+		it.Eventually(t, func() bool {
+			return assert.Equal(t, nil, it.MustValue(m.Get(context.Background(), "key")))
+		})
 	})
 }
 
@@ -82,8 +84,9 @@ func TestMap_PutWithTTLAndMaxIdle(t *testing.T) {
 			t.Fatal(err)
 		}
 		assert.Equal(t, targetValue, it.MustValue(m.Get(context.Background(), "key")))
-		time.Sleep(4 * time.Second)
-		assert.Equal(t, nil, it.MustValue(m.Get(context.Background(), "key")))
+		it.Eventually(t, func() bool {
+			return assert.Equal(t, nil, it.MustValue(m.Get(context.Background(), "key")))
+		})
 	})
 }
 
@@ -108,8 +111,9 @@ func TestMap_PutIfAbsentWithTTL(t *testing.T) {
 			t.Fatal(err)
 		}
 		assert.Equal(t, targetValue, it.MustValue(m.Get(context.Background(), "key")))
-		time.Sleep(4 * time.Second)
-		assert.Equal(t, nil, it.MustValue(m.Get(context.Background(), "key")))
+		it.Eventually(t, func() bool {
+			return assert.Equal(t, nil, it.MustValue(m.Get(context.Background(), "key")))
+		})
 	})
 }
 
@@ -122,8 +126,9 @@ func TestMap_PutIfAbsentWithTTLAndMaxIdle(t *testing.T) {
 			t.Fatal(err)
 		}
 		assert.Equal(t, targetValue, it.MustValue(m.Get(context.Background(), "key")))
-		time.Sleep(4 * time.Second)
-		assert.Equal(t, nil, it.MustValue(m.Get(context.Background(), "key")))
+		it.Eventually(t, func() bool {
+			return assert.Equal(t, nil, it.MustValue(m.Get(context.Background(), "key")))
+		})
 	})
 }
 
@@ -144,8 +149,9 @@ func TestMap_PutTransientWithTTL(t *testing.T) {
 			t.Fatal(err)
 		}
 		it.AssertEquals(t, targetValue, it.MustValue(m.Get(context.Background(), "key")))
-		time.Sleep(4 * time.Second)
-		it.AssertEquals(t, nil, it.MustValue(m.Get(context.Background(), "key")))
+		it.Eventually(t, func() bool {
+			return assert.Equal(t, nil, it.MustValue(m.Get(context.Background(), "key")))
+		})
 	})
 }
 
@@ -156,8 +162,10 @@ func TestMap_PutTransientWithMaxIdle(t *testing.T) {
 			t.Fatal(err)
 		}
 		it.AssertEquals(t, targetValue, it.MustValue(m.Get(context.Background(), "key")))
-		time.Sleep(4 * time.Second)
-		it.AssertEquals(t, nil, it.MustValue(m.Get(context.Background(), "key")))
+		it.Eventually(t, func() bool {
+			return assert.Equal(t, nil, it.MustValue(m.Get(context.Background(), "key")))
+		})
+
 	})
 }
 
@@ -169,8 +177,9 @@ func TestMap_PutTransientWithTTLAndMaxIdle(t *testing.T) {
 			t.Fatal(err)
 		}
 		it.AssertEquals(t, targetValue, it.MustValue(m.Get(context.Background(), "key")))
-		time.Sleep(4 * time.Second)
-		it.AssertEquals(t, nil, it.MustValue(m.Get(context.Background(), "key")))
+		it.Eventually(t, func() bool {
+			return assert.Equal(t, nil, it.MustValue(m.Get(context.Background(), "key")))
+		})
 	})
 }
 
@@ -195,8 +204,9 @@ func TestMap_SetWithTTL(t *testing.T) {
 			t.Fatal(err)
 		}
 		assert.Equal(t, targetValue, it.MustValue(m.Get(ctx, "key")))
-		time.Sleep(2 * time.Second)
-		assert.Equal(t, nil, it.MustValue(m.Get(ctx, "key")))
+		it.Eventually(t, func() bool {
+			return assert.Equal(t, nil, it.MustValue(m.Get(ctx, "key")))
+		})
 	})
 }
 
@@ -296,7 +306,6 @@ func TestMap_GetAll(t *testing.T) {
 		for _, pair := range allPairs {
 			it.Must(m.Set(context.Background(), pair.Key, pair.Value))
 		}
-		time.Sleep(1 * time.Second)
 		for _, pair := range allPairs {
 			it.AssertEquals(t, pair.Value, it.MustValue(m.Get(context.Background(), pair.Key)))
 		}
@@ -314,7 +323,6 @@ func TestMap_GetKeySet(t *testing.T) {
 		it.Must(m.Set(context.Background(), "k1", "v1"))
 		it.Must(m.Set(context.Background(), "k2", "v2"))
 		it.Must(m.Set(context.Background(), "k3", "v3"))
-		time.Sleep(1 * time.Second)
 		it.AssertEquals(t, "v1", it.MustValue(m.Get(context.Background(), "k1")))
 		it.AssertEquals(t, "v2", it.MustValue(m.Get(context.Background(), "k2")))
 		it.AssertEquals(t, "v3", it.MustValue(m.Get(context.Background(), "k3")))
@@ -346,7 +354,6 @@ func TestMap_GetValues(t *testing.T) {
 		it.Must(m.Set(context.Background(), "k1", "v1"))
 		it.Must(m.Set(context.Background(), "k2", "v2"))
 		it.Must(m.Set(context.Background(), "k3", "v3"))
-		time.Sleep(1 * time.Second)
 		it.AssertEquals(t, "v1", it.MustValue(m.Get(context.Background(), "k1")))
 		it.AssertEquals(t, "v2", it.MustValue(m.Get(context.Background(), "k2")))
 		it.AssertEquals(t, "v3", it.MustValue(m.Get(context.Background(), "k3")))
@@ -386,7 +393,6 @@ func TestMap_PutAll(t *testing.T) {
 		if err := m.PutAll(context.Background(), pairs...); err != nil {
 			t.Fatal(err)
 		}
-		time.Sleep(1 * time.Second)
 		it.AssertEquals(t, "v1", it.MustValue(m.Get(context.Background(), "k1")))
 		it.AssertEquals(t, "v2", it.MustValue(m.Get(context.Background(), "k2")))
 		it.AssertEquals(t, "v3", it.MustValue(m.Get(context.Background(), "k3")))
@@ -403,7 +409,6 @@ func TestMap_GetEntrySet(t *testing.T) {
 		if err := m.PutAll(context.Background(), target...); err != nil {
 			t.Fatal(err)
 		}
-		time.Sleep(1 * time.Second)
 		if entries, err := m.GetEntrySet(context.Background()); err != nil {
 			t.Fatal(err)
 		} else if !entriesEqualUnordered(target, entries) {
@@ -427,7 +432,6 @@ func TestMap_GetEntrySetWithPredicateUsingPortable(t *testing.T) {
 		if err := m.PutAll(context.Background(), entries...); err != nil {
 			t.Fatal(err)
 		}
-		time.Sleep(1 * time.Second)
 		target := []types.Entry{
 			types.NewEntry("k1", &it.SamplePortable{A: okValue, B: 10}),
 			types.NewEntry("k3", &it.SamplePortable{A: okValue, B: 10}),
@@ -450,7 +454,6 @@ func TestMap_GetEntrySetWithPredicateUsingJSON(t *testing.T) {
 		if err := m.PutAll(context.Background(), entries...); err != nil {
 			t.Fatal(err)
 		}
-		time.Sleep(1 * time.Second)
 		target := []types.Entry{
 			types.NewEntry("k1", it.SamplePortable{A: "foo", B: 10}.Json()),
 			types.NewEntry("k3", it.SamplePortable{A: "foo", B: 10}.Json()),
@@ -552,7 +555,6 @@ func TestMap_LoadAllWithoutReplacing(t *testing.T) {
 		it.Must(m.EvictAll(context.Background()))
 		it.Must(m.PutTransient(context.Background(), "k0", "new-v0"))
 		it.Must(m.PutTransient(context.Background(), "k1", "new-v1"))
-		time.Sleep(1 * time.Second)
 		it.Must(m.LoadAllWithoutReplacing(context.Background(), "k0", "k1"))
 		targetEntrySet := []types.Entry{
 			{Key: "k0", Value: "new-v0"},
@@ -687,7 +689,6 @@ func TestMap_RemoveAll(t *testing.T) {
 			types.NewEntry("k3", &it.SamplePortable{A: "foo", B: 10}),
 		}
 		it.Must(m.PutAll(context.Background(), entries...))
-		time.Sleep(1 * time.Second)
 		if err := m.RemoveAll(context.Background(), predicate.Equal("B", 10)); err != nil {
 			t.Fatal(err)
 		}
@@ -772,10 +773,9 @@ func TestMap_EntryNotifiedEvent(t *testing.T) {
 			value := fmt.Sprintf("value-%d", i)
 			it.MustValue(m.Put(context.Background(), key, value))
 		}
-		time.Sleep(1 * time.Second)
-		if !assert.Equal(t, totalCallCount, atomic.LoadInt32(&callCount)) {
-			t.FailNow()
-		}
+		it.Eventually(t, func() bool {
+			return assert.Equal(t, totalCallCount, atomic.LoadInt32(&callCount))
+		})
 		atomic.StoreInt32(&callCount, 0)
 		if err := m.RemoveEntryListener(context.Background(), subscriptionID); err != nil {
 			t.Fatal(err)
@@ -806,10 +806,9 @@ func TestMap_EntryNotifiedEventToKey(t *testing.T) {
 			t.Fatal(err)
 		}
 		it.MustValue(m.Put(context.Background(), "k1", "v1"))
-		time.Sleep(1 * time.Second)
-		if !assert.Equal(t, int32(1), atomic.LoadInt32(&callCount)) {
-			t.FailNow()
-		}
+		it.Eventually(t, func() bool {
+			return assert.Equal(t, int32(1), atomic.LoadInt32(&callCount))
+		})
 	})
 }
 
@@ -836,10 +835,9 @@ func TestMap_EntryNotifiedEventWithPredicate(t *testing.T) {
 			value := &it.SamplePortable{A: "foo", B: int32(i)}
 			it.MustValue(m.Put(context.Background(), key, value))
 		}
-		time.Sleep(1 * time.Second)
-		if !assert.Equal(t, totalCallCount, atomic.LoadInt32(&callCount)) {
-			t.FailNow()
-		}
+		it.Eventually(t, func() bool {
+			return assert.Equal(t, totalCallCount, atomic.LoadInt32(&callCount))
+		})
 	})
 }
 
@@ -864,10 +862,9 @@ func TestMap_EntryNotifiedEventToKeyAndPredicate(t *testing.T) {
 		it.MustValue(m.Put(context.Background(), "k1", &it.SamplePortable{A: "foo", B: 10}))
 		it.MustValue(m.Put(context.Background(), "k1", &it.SamplePortable{A: "bar", B: 10}))
 		it.MustValue(m.Put(context.Background(), "k2", &it.SamplePortable{A: "foo", B: 10}))
-		time.Sleep(1 * time.Second)
-		if !assert.Equal(t, int32(1), atomic.LoadInt32(&callCount)) {
-			t.FailNow()
-		}
+		it.Eventually(t, func() bool {
+			return assert.Equal(t, int32(1), atomic.LoadInt32(&callCount))
+		})
 	})
 }
 
@@ -935,8 +932,9 @@ func TestMap_SetWithTTLAndMaxIdle(t *testing.T) {
 			t.Fatal(err)
 		}
 		assert.Equal(t, targetValue, it.MustValue(m.Get(ctx, "key")))
-		time.Sleep(4 * time.Second)
-		assert.Equal(t, nil, it.MustValue(m.Get(ctx, "key")))
+		it.Eventually(t, func() bool {
+			return assert.Equal(t, nil, it.MustValue(m.Get(ctx, "key")))
+		})
 	})
 }
 
@@ -1051,8 +1049,9 @@ func TestMap_SetTTL(t *testing.T) {
 			t.Fatal(err)
 		}
 		assert.Equal(t, targetValue, it.MustValue(m.Get(ctx, "key")))
-		time.Sleep(2 * time.Second)
-		assert.Equal(t, nil, it.MustValue(m.Get(ctx, "key")))
+		it.Eventually(t, func() bool {
+			return assert.Equal(t, nil, it.MustValue(m.Get(ctx, "key")))
+		})
 	})
 }
 

--- a/map_it_test.go
+++ b/map_it_test.go
@@ -55,12 +55,12 @@ func TestMap_Put(t *testing.T) {
 func TestMap_PutWithTTL(t *testing.T) {
 	it.MapTester(t, func(t *testing.T, m *hz.Map) {
 		targetValue := "value"
-		if _, err := m.PutWithTTL(context.Background(), "key", targetValue, 1*time.Second); err != nil {
+		if _, err := m.PutWithTTL(context.Background(), "key", targetValue, 20*time.Second); err != nil {
 			t.Fatal(err)
 		}
 		assert.Equal(t, targetValue, it.MustValue(m.Get(context.Background(), "key")))
 		it.Eventually(t, func() bool {
-			return assert.Equal(t, nil, it.MustValue(m.Get(context.Background(), "key")))
+			return it.MustValue(m.Get(context.Background(), "key")) == nil
 		})
 	})
 }
@@ -72,7 +72,7 @@ func TestMap_PutWithMaxIdle(t *testing.T) {
 			t.Fatal(err)
 		}
 		it.Eventually(t, func() bool {
-			return assert.Equal(t, nil, it.MustValue(m.Get(context.Background(), "key")))
+			return it.MustValue(m.Get(context.Background(), "key")) == nil
 		})
 	})
 }
@@ -85,7 +85,7 @@ func TestMap_PutWithTTLAndMaxIdle(t *testing.T) {
 		}
 		assert.Equal(t, targetValue, it.MustValue(m.Get(context.Background(), "key")))
 		it.Eventually(t, func() bool {
-			return assert.Equal(t, nil, it.MustValue(m.Get(context.Background(), "key")))
+			return it.MustValue(m.Get(context.Background(), "key")) == nil
 		})
 	})
 }
@@ -112,7 +112,7 @@ func TestMap_PutIfAbsentWithTTL(t *testing.T) {
 		}
 		assert.Equal(t, targetValue, it.MustValue(m.Get(context.Background(), "key")))
 		it.Eventually(t, func() bool {
-			return assert.Equal(t, nil, it.MustValue(m.Get(context.Background(), "key")))
+			return it.MustValue(m.Get(context.Background(), "key")) == nil
 		})
 	})
 }
@@ -127,7 +127,7 @@ func TestMap_PutIfAbsentWithTTLAndMaxIdle(t *testing.T) {
 		}
 		assert.Equal(t, targetValue, it.MustValue(m.Get(context.Background(), "key")))
 		it.Eventually(t, func() bool {
-			return assert.Equal(t, nil, it.MustValue(m.Get(context.Background(), "key")))
+			return it.MustValue(m.Get(context.Background(), "key")) == nil
 		})
 	})
 }
@@ -150,7 +150,7 @@ func TestMap_PutTransientWithTTL(t *testing.T) {
 		}
 		it.AssertEquals(t, targetValue, it.MustValue(m.Get(context.Background(), "key")))
 		it.Eventually(t, func() bool {
-			return assert.Equal(t, nil, it.MustValue(m.Get(context.Background(), "key")))
+			return it.MustValue(m.Get(context.Background(), "key")) == nil
 		})
 	})
 }
@@ -163,7 +163,7 @@ func TestMap_PutTransientWithMaxIdle(t *testing.T) {
 		}
 		it.AssertEquals(t, targetValue, it.MustValue(m.Get(context.Background(), "key")))
 		it.Eventually(t, func() bool {
-			return assert.Equal(t, nil, it.MustValue(m.Get(context.Background(), "key")))
+			return it.MustValue(m.Get(context.Background(), "key")) == nil
 		})
 
 	})
@@ -178,7 +178,7 @@ func TestMap_PutTransientWithTTLAndMaxIdle(t *testing.T) {
 		}
 		it.AssertEquals(t, targetValue, it.MustValue(m.Get(context.Background(), "key")))
 		it.Eventually(t, func() bool {
-			return assert.Equal(t, nil, it.MustValue(m.Get(context.Background(), "key")))
+			return it.MustValue(m.Get(context.Background(), "key")) == nil
 		})
 	})
 }
@@ -205,7 +205,7 @@ func TestMap_SetWithTTL(t *testing.T) {
 		}
 		assert.Equal(t, targetValue, it.MustValue(m.Get(ctx, "key")))
 		it.Eventually(t, func() bool {
-			return assert.Equal(t, nil, it.MustValue(m.Get(ctx, "key")))
+			return it.MustValue(m.Get(ctx, "key")) == nil
 		})
 	})
 }
@@ -933,7 +933,7 @@ func TestMap_SetWithTTLAndMaxIdle(t *testing.T) {
 		}
 		assert.Equal(t, targetValue, it.MustValue(m.Get(ctx, "key")))
 		it.Eventually(t, func() bool {
-			return assert.Equal(t, nil, it.MustValue(m.Get(ctx, "key")))
+			return it.MustValue(m.Get(ctx, "key")) == nil
 		})
 	})
 }
@@ -1050,7 +1050,7 @@ func TestMap_SetTTL(t *testing.T) {
 		}
 		assert.Equal(t, targetValue, it.MustValue(m.Get(ctx, "key")))
 		it.Eventually(t, func() bool {
-			return assert.Equal(t, nil, it.MustValue(m.Get(ctx, "key")))
+			return it.MustValue(m.Get(ctx, "key")) == nil
 		})
 	})
 }

--- a/topic_it_test.go
+++ b/topic_it_test.go
@@ -49,7 +49,7 @@ func TestTopic_Publish(t *testing.T) {
 		if err = tp.Publish(context.Background(), "HEY!"); err != nil {
 			t.Fatal(err)
 		}
-		it.Never(t, func() bool { return "base-value" != handlerValue.Load() })
+		it.Never(t, func() bool { return handlerValue.Load() != "base-value" })
 	})
 }
 func TestTopic_PublishAll(t *testing.T) {


### PR DESCRIPTION
related to https://github.com/hazelcast/hazelcast-go-client/issues/621

Dont use assert inside Eventual, as it causes failure of the test. 
Add failNow to it.Eventual