### PR TITLE
Remove sleep statements from various tests

### DIFF
--- a/internal/event/dispatch_service_test.go
+++ b/internal/event/dispatch_service_test.go
@@ -20,9 +20,9 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/hazelcast/hazelcast-go-client/internal/event"
+	"github.com/hazelcast/hazelcast-go-client/internal/it"
 	"github.com/hazelcast/hazelcast-go-client/internal/logger"
 )
 
@@ -67,11 +67,10 @@ func TestDispatchServiceUnsubscribe(t *testing.T) {
 	}
 	service.Subscribe("sample.event", 100, handler)
 	service.Publish(sampleEvent{})
-	wg.Wait()
+	it.WaitEventually(t, wg)
 	service.Unsubscribe("sample.event", 100)
 	service.Publish(sampleEvent{})
-	wg.Wait()
-	time.Sleep(100 * time.Millisecond)
+	it.WaitEventually(t, wg)
 	service.Stop()
 	if int32(1) != dispatchCount {
 		t.Fatalf("target 1 != %d", dispatchCount)

--- a/internal/stats/stats_service_test.go
+++ b/internal/stats/stats_service_test.go
@@ -39,15 +39,15 @@ func TestNewService(t *testing.T) {
 	srv := stats.NewService(requestCh, invFac, ed, lg, 100*time.Millisecond, "hz1")
 	srv.Start()
 	ed.Publish(cluster.NewConnected(pubcluster.NewAddress("100.200.300.400", 12345)))
-	time.Sleep(100 * time.Millisecond)
-	srv.Stop()
 	select {
 	case _, ok := <-requestCh:
 		// TODO: decode the request and check whether it's correct.
+		srv.Stop()
 		if ok != true {
 			t.Fatalf("an invocation was expected")
 		}
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(time.Minute):
+		srv.Stop()
 		t.Fatalf("invocation not received in time")
 	}
 }

--- a/list_it_test.go
+++ b/list_it_test.go
@@ -22,7 +22,6 @@ import (
 	"math"
 	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -46,19 +45,13 @@ func TestList_AddListener(t *testing.T) {
 			item := fmt.Sprintf("item-%d", i)
 			it.MustValue(l.Add(context.Background(), item))
 		}
-		time.Sleep(1 * time.Second)
-		if !assert.Equal(t, targetCallCount, atomic.LoadInt32(&callCount)) {
-			t.FailNow()
-		}
+		it.Eventually(t, func() bool { return atomic.LoadInt32(&callCount) == targetCallCount })
 		atomic.StoreInt32(&callCount, 0)
 		if err = l.RemoveListener(context.Background(), subscriptionID); err != nil {
 			t.Fatal(err)
 		}
 		it.MustValue(l.Add(context.Background(), "item-42"))
-		time.Sleep(1 * time.Second)
-		if !assert.Equal(t, int32(0), atomic.LoadInt32(&callCount)) {
-			t.FailNow()
-		}
+		it.Never(t, func() bool { return atomic.LoadInt32(&callCount) != 0 })
 	})
 }
 
@@ -79,20 +72,14 @@ func TestList_AddListener_IncludeValue(t *testing.T) {
 			it.MustValue(l.Add(context.Background(), item))
 			it.MustBool(l.Remove(context.Background(), item))
 		}
-		time.Sleep(1 * time.Second)
-		if !assert.Equal(t, targetCallCount, atomic.LoadInt32(&callCount)) {
-			t.FailNow()
-		}
+		it.Eventually(t, func() bool { return atomic.LoadInt32(&callCount) == targetCallCount })
 		atomic.StoreInt32(&callCount, 0)
 		if err = l.RemoveListener(context.Background(), subscriptionID); err != nil {
 			t.Fatal(err)
 		}
 		it.MustValue(l.Add(context.Background(), "item-42"))
 		it.MustValue(l.Remove(context.Background(), "item-42"))
-		time.Sleep(1 * time.Second)
-		if !assert.Equal(t, int32(0), atomic.LoadInt32(&callCount)) {
-			t.FailNow()
-		}
+		it.Never(t, func() bool { return atomic.LoadInt32(&callCount) != 0 })
 	})
 }
 

--- a/proxy_it_test.go
+++ b/proxy_it_test.go
@@ -65,7 +65,6 @@ func retryResult(t *testing.T, redo bool, target bool) {
 	time.Sleep(1 * time.Second)
 	cluster = it.StartNewCluster(1)
 	defer cluster.Shutdown()
-	time.Sleep(5 * time.Second)
 	ok := <-okCh
 	assert.Equal(t, target, ok)
 }

--- a/queue_it_test.go
+++ b/queue_it_test.go
@@ -75,18 +75,13 @@ func TestQueue_AddListener(t *testing.T) {
 			value := fmt.Sprintf("value-%d", i)
 			it.MustValue(q.Add(context.Background(), value))
 		}
-		time.Sleep(1 * time.Second)
-		if !assert.Equal(t, targetCallCount, atomic.LoadInt32(&callCount)) {
-			t.FailNow()
-		}
+		it.Eventually(t, func() bool { return atomic.LoadInt32(&callCount) == targetCallCount })
 		atomic.StoreInt32(&callCount, 0)
 		if err = q.RemoveListener(context.Background(), subscriptionID); err != nil {
 			t.Fatal(err)
 		}
 		it.MustValue(q.Add(context.Background(), "value2"))
-		if !assert.Equal(t, int32(0), atomic.LoadInt32(&callCount)) {
-			t.FailNow()
-		}
+		it.Never(t, func() bool { return atomic.LoadInt32(&callCount) != 0 })
 	})
 }
 
@@ -105,19 +100,13 @@ func TestQueue_AddListener_IncludeValue(t *testing.T) {
 			value := fmt.Sprintf("value-%d", i)
 			it.MustValue(q.Add(context.Background(), value))
 		}
-
-		time.Sleep(1 * time.Second)
-		if !assert.Equal(t, targetCallCount, atomic.LoadInt32(&callCount)) {
-			t.FailNow()
-		}
+		it.Eventually(t, func() bool { return atomic.LoadInt32(&callCount) == targetCallCount })
 		atomic.StoreInt32(&callCount, 0)
 		if err = q.RemoveListener(context.Background(), subscriptionID); err != nil {
 			t.Fatal(err)
 		}
 		it.MustValue(q.Add(context.Background(), "value2"))
-		if !assert.Equal(t, int32(0), atomic.LoadInt32(&callCount)) {
-			t.FailNow()
-		}
+		it.Never(t, func() bool { return atomic.LoadInt32(&callCount) != 0 })
 	})
 }
 

--- a/set_it_test.go
+++ b/set_it_test.go
@@ -22,7 +22,6 @@ import (
 	"log"
 	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -69,18 +68,13 @@ func TestSet_AddListener(t *testing.T) {
 			value := fmt.Sprintf("value-%d", i)
 			it.MustValue(s.Add(context.Background(), value))
 		}
-		time.Sleep(1 * time.Second)
-		if !assert.Equal(t, targetCallCount, atomic.LoadInt32(&callCount)) {
-			t.FailNow()
-		}
+		it.Eventually(t, func() bool { return atomic.LoadInt32(&callCount) == targetCallCount })
 		atomic.StoreInt32(&callCount, 0)
 		if err = s.RemoveListener(context.Background(), subscriptionID); err != nil {
 			t.Fatal(err)
 		}
 		it.MustValue(s.Add(context.Background(), "value2"))
-		if !assert.Equal(t, int32(0), atomic.LoadInt32(&callCount)) {
-			t.FailNow()
-		}
+		it.Never(t, func() bool { return atomic.LoadInt32(&callCount) != 0 })
 	})
 }
 
@@ -100,18 +94,13 @@ func TestSet_AddListener_IncludeValue(t *testing.T) {
 			it.MustValue(s.Add(context.Background(), value))
 		}
 
-		time.Sleep(1 * time.Second)
-		if !assert.Equal(t, targetCallCount, atomic.LoadInt32(&callCount)) {
-			t.FailNow()
-		}
+		it.Eventually(t, func() bool { return atomic.LoadInt32(&callCount) == targetCallCount })
 		atomic.StoreInt32(&callCount, 0)
 		if err = s.RemoveListener(context.Background(), subscriptionID); err != nil {
 			t.Fatal(err)
 		}
 		it.MustValue(s.Add(context.Background(), "value2"))
-		if !assert.Equal(t, int32(0), atomic.LoadInt32(&callCount)) {
-			t.FailNow()
-		}
+		it.Never(t, func() bool { return atomic.LoadInt32(&callCount) != 0 })
 	})
 }
 


### PR DESCRIPTION
list/proxy/queue/replicated map/set and dispatch service
sleep statements are removed as much as we can.

related to https://github.com/hazelcast/hazelcast-go-client/issues/621