### PR TITLE
Uses a mutex instead of channels in dispatch service [API-892, API-888]

### DIFF
--- a/client.go
+++ b/client.go
@@ -257,8 +257,6 @@ func (c *Client) Shutdown(ctx context.Context) error {
 	}
 	atomic.StoreInt32(&c.state, stopped)
 	c.eventDispatcher.Publish(newLifecycleStateChanged(LifecycleStateShutDown))
-	// wait for the shut down event to be dispatched
-	time.Sleep(1 * time.Millisecond)
 	c.eventDispatcher.Stop()
 	c.userEventDispatcher.Stop()
 	return nil

--- a/internal/event/dispatch_service.go
+++ b/internal/event/dispatch_service.go
@@ -32,14 +32,6 @@ type Event interface {
 
 type Handler func(event Event)
 
-type controlType int
-
-const (
-	subscribe controlType = iota
-	subscribeSync
-	unsubscribe
-)
-
 const (
 	created int32 = iota
 	ready
@@ -49,10 +41,9 @@ const (
 type DispatchService struct {
 	logger            logger.Logger
 	syncSubscriptions map[string]map[int64]Handler
-	doneCh            chan struct{}
 	subscriptions     map[string]map[int64]Handler
-	state             int32
 	eventMu           *sync.RWMutex
+	state             int32
 }
 
 func NewDispatchService(logger logger.Logger) *DispatchService {

--- a/internal/event/dispatch_service.go
+++ b/internal/event/dispatch_service.go
@@ -99,7 +99,7 @@ func (s *DispatchService) Subscribe(eventName string, subscriptionID int64, hand
 // SubscribeSync attaches handler to listen for events with the given event name.
 // Sync handlers are dispatched first, the events are ordered.
 // Do not rely on the subscription order of handlers, they may be called back in a random order.
-// The handler is called in the same goroutine with the dispatch service and executes until the end of the corresponding function.
+// The handler is called in the same goroutine with the caller and executes until the end.
 // Make sure sync handlers do no block.
 func (s *DispatchService) SubscribeSync(eventName string, subscriptionID int64, handler SyncHandler) {
 	// subscribing to a not-runnning service is no-op

--- a/internal/event/dispatch_service.go
+++ b/internal/event/dispatch_service.go
@@ -33,9 +33,8 @@ type Event interface {
 type Handler func(event Event)
 
 const (
-	created int32 = iota
-	ready
-	stopped
+	ready   = 0
+	stopped = 1
 )
 
 type DispatchService struct {
@@ -51,10 +50,8 @@ func NewDispatchService(logger logger.Logger) *DispatchService {
 		subscriptions:     map[string]map[int64]Handler{},
 		syncSubscriptions: map[string]map[int64]Handler{},
 		eventMu:           &sync.RWMutex{},
-		state:             created,
 		logger:            logger,
 	}
-	atomic.StoreInt32(&service.state, ready)
 	return service
 }
 

--- a/internal/event/doc.go
+++ b/internal/event/doc.go
@@ -1,0 +1,2 @@
+// Package event contains the internal dispatch service
+package event


### PR DESCRIPTION
We select on two channels in the dispatch service, one for events (publish) and one for control (subscribe, unsubscribe). In some cases that causes a race condition, since the order of subsribe/unsubscribe and publish is not deterministic. That caused occasional test failure of https://github.com/hazelcast/hazelcast-go-client/blob/5017195b7f03afba8fcfd9d8955694e8b3a172e8/internal/event/dispatch_service_test.go#L58

Fixed that by using a mutex instead of two channels.

Fixes https://github.com/hazelcast/hazelcast-go-client/issues/621