### PR TITLE
[DON'T MERGE] Send Member List View Cancel

### DIFF
--- a/client.go
+++ b/client.go
@@ -255,6 +255,7 @@ func (c *Client) Shutdown(ctx context.Context) error {
 	if c.statsService != nil {
 		c.statsService.Stop()
 	}
+	c.viewListenerService.Stop()
 	atomic.StoreInt32(&c.state, stopped)
 	c.eventDispatcher.Publish(newLifecycleStateChanged(LifecycleStateShutDown))
 	// wait for the shut down event to be dispatched


### PR DESCRIPTION
- Times out waiting for member list view after 120 seconds, like the Java client. Fixes #627 
- FIxes #654 
- Cancels sending member list view request if the client is shutting down.