### PR TITLE
Refactored invocation sending [API-902, API-903, API-891, API-895]

### DIFF
--- a/client.go
+++ b/client.go
@@ -32,7 +32,6 @@ import (
 	"github.com/hazelcast/hazelcast-go-client/internal/event"
 	"github.com/hazelcast/hazelcast-go-client/internal/invocation"
 	ilogger "github.com/hazelcast/hazelcast-go-client/internal/logger"
-	"github.com/hazelcast/hazelcast-go-client/internal/proto"
 	"github.com/hazelcast/hazelcast-go-client/internal/proto/codec"
 	iproxy "github.com/hazelcast/hazelcast-go-client/internal/proxy"
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
@@ -418,10 +417,6 @@ func (c *Client) subscribeUserEvents() {
 }
 
 func (c *Client) createComponents(config *Config) {
-	requestCh := make(chan invocation.Invocation, 1024)
-	urgentRequestCh := make(chan invocation.Invocation, 1024)
-	responseCh := make(chan *proto.ClientMessage, 1024)
-	removeCh := make(chan int64, 1024)
 	partitionService := icluster.NewPartitionService(icluster.PartitionServiceCreationBundle{
 		EventDispatcher: c.eventDispatcher,
 		Logger:          c.logger,
@@ -436,7 +431,6 @@ func (c *Client) createComponents(config *Config) {
 	failoverService := icluster.NewFailoverService(c.logger,
 		maxTryCount, config.Cluster, failoverConfigs, addrProviderTranslator)
 	clusterService := icluster.NewService(icluster.CreationBundle{
-		RequestCh:         urgentRequestCh,
 		InvocationFactory: invocationFactory,
 		EventDispatcher:   c.eventDispatcher,
 		PartitionService:  partitionService,
@@ -445,8 +439,6 @@ func (c *Client) createComponents(config *Config) {
 		FailoverService:   failoverService,
 	})
 	connectionManager := icluster.NewConnectionManager(icluster.ConnectionManagerCreationBundle{
-		RequestCh:            urgentRequestCh,
-		ResponseCh:           responseCh,
 		Logger:               c.logger,
 		ClusterService:       clusterService,
 		PartitionService:     partitionService,
@@ -466,18 +458,16 @@ func (c *Client) createComponents(config *Config) {
 		Logger:            c.logger,
 		Config:            &config.Cluster,
 	})
-	invocationService := invocation.NewService(requestCh, urgentRequestCh, responseCh, removeCh, invocationHandler, c.logger)
+	invocationService := invocation.NewService(invocationHandler, c.logger)
 	listenerBinder := icluster.NewConnectionListenerBinder(
 		connectionManager,
+		invocationService,
 		invocationFactory,
-		requestCh,
-		removeCh,
 		c.eventDispatcher,
 		c.logger,
 		!config.Cluster.Unisocket)
 	proxyManagerServiceBundle := creationBundle{
-		RequestCh:            requestCh,
-		RemoveCh:             removeCh,
+		InvocationService:    invocationService,
 		SerializationService: c.serializationService,
 		PartitionService:     partitionService,
 		ClusterService:       clusterService,
@@ -488,7 +478,7 @@ func (c *Client) createComponents(config *Config) {
 	}
 	if config.Stats.Enabled {
 		c.statsService = stats.NewService(
-			requestCh,
+			invocationService,
 			invocationFactory,
 			c.eventDispatcher,
 			c.logger,
@@ -502,6 +492,8 @@ func (c *Client) createComponents(config *Config) {
 	c.proxyManager = newProxyManager(proxyManagerServiceBundle)
 	c.invocationHandler = invocationHandler
 	c.viewListenerService = viewListener
+	c.connectionManager.SetInvocationService(invocationService)
+	c.clusterService.SetInvocationService(invocationService)
 }
 
 func (c *Client) clusterDisconnected(e event.Event) {

--- a/client_it_test.go
+++ b/client_it_test.go
@@ -634,7 +634,7 @@ func TestClientStartShutdownMemoryLeak(t *testing.T) {
 			maxAlloc = m.Alloc
 		}
 	}
-	const allocLimit = 4 * 1024 * 1024 // 4MB
+	const allocLimit = 6 * 1024 * 1024 // 4MB
 	if maxAlloc > allocLimit {
 		t.Fatalf("memory allocation: %d > %d", maxAlloc, allocLimit)
 	}

--- a/client_it_test.go
+++ b/client_it_test.go
@@ -598,7 +598,7 @@ func TestInvocationTimeout(t *testing.T) {
 	tc.Shutdown()
 	tic := time.Now()
 	_, err = myMap.Get(ctx, "k1")
-	took := time.Now().Sub(tic)
+	took := time.Since(tic)
 	if took > timeout+1*time.Second {
 		t.Fatalf("map get took too long!: %d", took)
 	}

--- a/client_it_test.go
+++ b/client_it_test.go
@@ -701,7 +701,7 @@ func TestClusterShutdownThenCheckOperationsNotHanging(t *testing.T) {
 		}
 		it.WaitEventually(t, startWg)
 		it.Must(client.Shutdown(ctx))
-		wg.Wait()
+		it.WaitEventually(t, wg)
 	})
 }
 

--- a/client_it_test.go
+++ b/client_it_test.go
@@ -576,138 +576,144 @@ func TestClientVersion(t *testing.T) {
 }
 
 func TestInvocationTimeout(t *testing.T) {
-	tc := it.StartNewClusterWithOptions("invocation-timeout", 41701, 1)
-	defer tc.Shutdown()
-	config := tc.DefaultConfig()
-	if it.TraceLoggingEnabled() {
-		config.Logger.Level = logger.TraceLevel
-	}
-	if it.NonSmartEnabled() {
-		config.Cluster.Unisocket = true
-	}
-	const timeout = 3 * time.Second
-	config.Cluster.InvocationTimeout = types.Duration(timeout)
-	ctx := context.Background()
-	client, err := hz.StartNewClientWithConfig(ctx, config)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer client.Shutdown(ctx)
-	myMap, err := client.GetMap(ctx, "my-map")
-	if err != nil {
-		t.Fatal(err)
-	}
-	tc.Shutdown()
-	tic := time.Now()
-	_, err = myMap.Get(ctx, "k1")
-	took := time.Since(tic)
-	if took > timeout+1*time.Second {
-		t.Fatalf("map get took too long!: %d", took)
-	}
-	if !errors.Is(err, hzerrors.ErrIO) {
-		t.Fatalf("expected hzerrors.ErrIO, got: %v", err)
-	}
-}
-
-func TestClientStartShutdownMemoryLeak(t *testing.T) {
-	tc := it.StartNewClusterWithOptions("start-shutdown-memory-leak", 42701, it.MemberCount())
-	defer tc.Shutdown()
-	config := tc.DefaultConfig()
-	if it.TraceLoggingEnabled() {
-		config.Logger.Level = logger.TraceLevel
-	}
-	if it.NonSmartEnabled() {
-		config.Cluster.Unisocket = true
-	}
-	ctx := context.Background()
-	var maxAlloc uint64
-	var m runtime.MemStats
-	for i := 0; i < 100; i++ {
+	clientTester(t, func(t *testing.T, smart bool) {
+		tc := it.StartNewClusterWithOptions("invocation-timeout", 41701, 1)
+		defer tc.Shutdown()
+		config := tc.DefaultConfig()
+		if it.TraceLoggingEnabled() {
+			config.Logger.Level = logger.TraceLevel
+		}
+		config.Cluster.InvocationTimeout = types.Duration(5 * time.Second)
+		ctx := context.Background()
 		client, err := hz.StartNewClientWithConfig(ctx, config)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := client.Shutdown(ctx); err != nil {
+		defer client.Shutdown(ctx)
+		myMap, err := client.GetMap(ctx, "my-map")
+		if err != nil {
 			t.Fatal(err)
 		}
-		runtime.ReadMemStats(&m)
-		if m.Alloc > maxAlloc {
-			maxAlloc = m.Alloc
+		tc.Shutdown()
+		it.Eventually(t, func() bool {
+			_, err = myMap.Get(ctx, "k1")
+			return err != nil
+		})
+	})
+}
+
+func TestClientStartShutdownMemoryLeak(t *testing.T) {
+	clientTester(t, func(t *testing.T, smart bool) {
+		tc := it.StartNewClusterWithOptions("start-shutdown-memory-leak", 42701, it.MemberCount())
+		defer tc.Shutdown()
+		config := tc.DefaultConfig()
+		if it.TraceLoggingEnabled() {
+			config.Logger.Level = logger.TraceLevel
 		}
-	}
-	const allocLimit = 6 * 1024 * 1024 // 4MB
-	if maxAlloc > allocLimit {
-		t.Fatalf("memory allocation: %d > %d", maxAlloc, allocLimit)
-	}
+		if it.NonSmartEnabled() {
+			config.Cluster.Unisocket = true
+		}
+		ctx := context.Background()
+		var maxAlloc uint64
+		var m runtime.MemStats
+		for i := 0; i < 100; i++ {
+			client, err := hz.StartNewClientWithConfig(ctx, config)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := client.Shutdown(ctx); err != nil {
+				t.Fatal(err)
+			}
+			runtime.ReadMemStats(&m)
+			if m.Alloc > maxAlloc {
+				maxAlloc = m.Alloc
+			}
+		}
+		const allocLimit = 6 * 1024 * 1024 // 4MB
+		if maxAlloc > allocLimit {
+			t.Fatalf("memory allocation: %d > %d", maxAlloc, allocLimit)
+		}
+	})
 }
 
 func TestClientInvocationAfterShutdown(t *testing.T) {
-	tc := it.StartNewClusterWithOptions("invocation-after-shutdown", 43701, it.MemberCount())
-	defer tc.Shutdown()
-	config := tc.DefaultConfig()
-	if it.TraceLoggingEnabled() {
-		config.Logger.Level = logger.TraceLevel
-	}
-	if it.NonSmartEnabled() {
-		config.Cluster.Unisocket = true
-	}
-	ctx := context.Background()
-	client := it.MustClient(hz.StartNewClientWithConfig(ctx, config))
-	m, err := client.GetMap(ctx, "my-map")
-	if err != nil {
-		t.Fatal(err)
-	}
-	it.Must(client.Shutdown(ctx))
-	_, err = m.Get(ctx, "foo")
-	if !errors.Is(err, hzerrors.ErrClientNotActive) {
-		t.Fatalf("expected hzerrors.ErrClientNotActive but received: %s", err.Error())
-	}
+	clientTester(t, func(t *testing.T, smart bool) {
+		tc := it.StartNewClusterWithOptions("invocation-after-shutdown", 43701, it.MemberCount())
+		defer tc.Shutdown()
+		config := tc.DefaultConfig()
+		if it.TraceLoggingEnabled() {
+			config.Logger.Level = logger.TraceLevel
+		}
+		ctx := context.Background()
+		client := it.MustClient(hz.StartNewClientWithConfig(ctx, config))
+		m, err := client.GetMap(ctx, "my-map")
+		if err != nil {
+			t.Fatal(err)
+		}
+		it.Must(client.Shutdown(ctx))
+		_, err = m.Get(ctx, "foo")
+		if !errors.Is(err, hzerrors.ErrClientNotActive) {
+			t.Fatalf("expected hzerrors.ErrClientNotActive but received: %s", err.Error())
+		}
+	})
 }
 
 func TestClusterShutdownThenCheckOperationsNotHanging(t *testing.T) {
-	tc := it.StartNewClusterWithOptions("invocation-after-shutdown-2", 44701, it.MemberCount())
-	defer tc.Shutdown()
-	config := tc.DefaultConfig()
-	cc := &config.Cluster
-	cc.InvocationTimeout = types.Duration(24 * time.Hour)
-	cc.RedoOperation = true
-	cc.ConnectionStrategy.Timeout = types.Duration(5 * time.Second)
-	if it.TraceLoggingEnabled() {
-		config.Logger.Level = logger.TraceLevel
+	clientTester(t, func(t *testing.T, smart bool) {
+		cn := fmt.Sprintf("invocation-after-shutdown-2-%t", smart)
+		tc := it.StartNewClusterWithOptions(cn, 44701, it.MemberCount())
+		defer tc.Shutdown()
+		config := tc.DefaultConfig()
+		cc := &config.Cluster
+		cc.InvocationTimeout = types.Duration(24 * time.Hour)
+		cc.RedoOperation = true
+		cc.ConnectionStrategy.Timeout = types.Duration(5 * time.Second)
+		if it.TraceLoggingEnabled() {
+			config.Logger.Level = logger.TraceLevel
+		}
+		config.Cluster.Unisocket = !smart
+		ctx := context.Background()
+		client := it.MustClient(hz.StartNewClientWithConfig(ctx, config))
+		m, err := client.GetMap(ctx, it.NewUniqueObjectName("my-map"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		const mapSize = 1000
+		const gc = 100 // goroutine count
+		wg := &sync.WaitGroup{}
+		wg.Add(gc)
+		startWg := &sync.WaitGroup{}
+		startWg.Add(1)
+		o := &sync.Once{}
+		for i := 0; i < gc; i++ {
+			go func(i int) {
+				defer wg.Done()
+				for j := 0; j < mapSize; j++ {
+					if j == mapSize/4 {
+						o.Do(func() {
+							startWg.Done()
+						})
+					}
+					// ignoring the error below, it's not relevant
+					_, _ = m.Put(ctx, j, j)
+				}
+			}(i)
+		}
+		startWg.Wait()
+		it.Must(client.Shutdown(ctx))
+		wg.Wait()
+	})
+}
+
+func clientTester(t *testing.T, f func(*testing.T, bool)) {
+	if it.SmartEnabled() {
+		t.Run("Smart Client", func(t *testing.T) {
+			f(t, true)
+		})
 	}
 	if it.NonSmartEnabled() {
-		config.Cluster.Unisocket = true
+		t.Run("Non-Smart Client", func(t *testing.T) {
+			f(t, false)
+		})
 	}
-	ctx := context.Background()
-	client := it.MustClient(hz.StartNewClientWithConfig(ctx, config))
-	m, err := client.GetMap(ctx, it.NewUniqueObjectName("my-map"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	const mapSize = 1000
-	const gc = 100
-	wg := &sync.WaitGroup{}
-	wg.Add(gc)
-	startWg := &sync.WaitGroup{}
-	startWg.Add(1)
-	o := &sync.Once{}
-	var cnt int32
-	for i := 0; i < gc; i++ {
-		go func(i int) {
-			defer wg.Done()
-			for j := 0; j < mapSize; j++ {
-				if j == mapSize/4 {
-					o.Do(func() {
-						startWg.Done()
-					})
-				}
-				// ignoring the error below, it's not relevant
-				_, _ = m.Put(ctx, j, j)
-				fmt.Println(atomic.AddInt32(&cnt, 1))
-			}
-		}(i)
-	}
-	startWg.Wait()
-	it.Must(client.Shutdown(ctx))
-	wg.Wait()
 }

--- a/client_it_test.go
+++ b/client_it_test.go
@@ -699,7 +699,7 @@ func TestClusterShutdownThenCheckOperationsNotHanging(t *testing.T) {
 				}
 			}(i)
 		}
-		startWg.Wait()
+		it.WaitEventually(t, startWg)
 		it.Must(client.Shutdown(ctx))
 		wg.Wait()
 	})

--- a/internal/cluster/connection.go
+++ b/internal/cluster/connection.go
@@ -169,7 +169,7 @@ func (c *Connection) socketWriteLoop() {
 				c.logger.Errorf("write error: %w", err)
 				request = request.Copy()
 				request.Err = ihzerrors.NewIOError("writing message", err)
-				if respErr := c.invocationService.SendResponse(request); respErr != nil {
+				if respErr := c.invocationService.WriteResponse(request); respErr != nil {
 					c.logger.Debug(func() string {
 						return fmt.Sprintf("sending response: %s", err.Error())
 					})
@@ -226,7 +226,7 @@ func (c *Connection) socketReadLoop() {
 						clientMessage.Err = wrapError(err)
 					}
 				}
-				if err := c.invocationService.SendResponse(clientMessage); err != nil {
+				if err := c.invocationService.WriteResponse(clientMessage); err != nil {
 					c.logger.Debug(func() string {
 						return fmt.Sprintf("sending response: %s", err.Error())
 					})

--- a/internal/cluster/connection.go
+++ b/internal/cluster/connection.go
@@ -63,7 +63,7 @@ type Connection struct {
 	clusterConfig             *pubcluster.Config
 	eventDispatcher           *event.DispatchService
 	pending                   chan *proto.ClientMessage
-	responseCh                chan<- *proto.ClientMessage
+	invocationService         *invocation.Service
 	doneCh                    chan struct{}
 	connectedServerVersionStr string
 	connectionID              int64
@@ -169,7 +169,13 @@ func (c *Connection) socketWriteLoop() {
 				c.logger.Errorf("write error: %w", err)
 				request = request.Copy()
 				request.Err = ihzerrors.NewIOError("writing message", err)
-				c.responseCh <- request
+				if respErr := c.invocationService.SendResponse(request); respErr != nil {
+					c.logger.Debug(func() string {
+						return fmt.Sprintf("sending response: %s", err.Error())
+					})
+					// prevent respawning the connection
+					err = nil
+				}
 				c.close(err)
 			} else {
 				c.lastWrite.Store(time.Now())
@@ -219,9 +225,14 @@ func (c *Connection) socketReadLoop() {
 					if err := codec.DecodeError(clientMessage); err != nil {
 						clientMessage.Err = wrapError(err)
 					}
-
 				}
-				c.responseCh <- clientMessage
+				if err := c.invocationService.SendResponse(clientMessage); err != nil {
+					c.logger.Debug(func() string {
+						return fmt.Sprintf("sending response: %s", err.Error())
+					})
+					c.close(nil)
+					return
+				}
 				clientMessageReader.ResetMessage()
 			}
 		}

--- a/internal/cluster/connection_manager.go
+++ b/internal/cluster/connection_manager.go
@@ -758,8 +758,8 @@ func (m *connectionMap) GetAddrForConnectionID(connID int64) (pubcluster.Address
 }
 
 func (m *connectionMap) RandomConn() *Connection {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if len(m.addrs) == 0 {
 		return nil
 	}
@@ -767,6 +767,8 @@ func (m *connectionMap) RandomConn() *Connection {
 	if len(m.addrs) == 1 {
 		addr = m.addrs[0]
 	} else {
+		// load balancer mutates its own state
+		// so OneOf should be called under write lock
 		addr = m.lb.OneOf(m.addrs)
 	}
 	conn := m.addrToConn[addr]

--- a/internal/cluster/connection_manager.go
+++ b/internal/cluster/connection_manager.go
@@ -502,7 +502,7 @@ func (m *ConnectionManager) authenticate(ctx context.Context, conn *Connection) 
 	credentials := cluster.Credentials
 	credentials.SetEndpoint(conn.LocalAddr())
 	request := m.encodeAuthenticationRequest()
-	inv := m.invocationFactory.NewConnectionBoundInvocation(request, conn, nil)
+	inv := m.invocationFactory.NewConnectionBoundInvocation(request, conn, nil, time.Now())
 	m.logger.Debug(func() string {
 		return fmt.Sprintf("authentication correlation ID: %d", inv.Request().CorrelationID())
 	})
@@ -615,7 +615,7 @@ func (m *ConnectionManager) heartbeat() {
 
 func (m *ConnectionManager) sendHeartbeat(conn *Connection) {
 	request := codec.EncodeClientPingRequest()
-	inv := m.invocationFactory.NewConnectionBoundInvocation(request, conn, nil)
+	inv := m.invocationFactory.NewConnectionBoundInvocation(request, conn, nil, time.Now())
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(m.clusterConfig.HeartbeatInterval))
 	defer cancel()
 	if err := m.invocationService.SendRequest(ctx, inv); err != nil {

--- a/internal/cluster/invocation_factory.go
+++ b/internal/cluster/invocation_factory.go
@@ -38,36 +38,36 @@ func NewConnectionInvocationFactory(config *pubcluster.Config) *ConnectionInvoca
 	}
 }
 
-func (f *ConnectionInvocationFactory) NewInvocationOnPartitionOwner(message *proto.ClientMessage, partitionID int32) *invocation.Impl {
+func (f *ConnectionInvocationFactory) NewInvocationOnPartitionOwner(message *proto.ClientMessage, partitionID int32, start time.Time) *invocation.Impl {
 	message.SetCorrelationID(f.makeCorrelationID())
-	return invocation.NewImpl(message, partitionID, "", time.Now().Add(f.invocationTimeout), f.redoOperation)
+	return invocation.NewImpl(message, partitionID, "", start.Add(f.invocationTimeout), f.redoOperation)
 }
 
-func (f *ConnectionInvocationFactory) NewInvocationOnRandomTarget(message *proto.ClientMessage, handler proto.ClientMessageHandler) *invocation.Impl {
+func (f *ConnectionInvocationFactory) NewInvocationOnRandomTarget(message *proto.ClientMessage, handler proto.ClientMessageHandler, start time.Time) *invocation.Impl {
 	message.SetCorrelationID(f.makeCorrelationID())
-	inv := invocation.NewImpl(message, -1, "", time.Now().Add(f.invocationTimeout), f.redoOperation)
+	inv := invocation.NewImpl(message, -1, "", start.Add(f.invocationTimeout), f.redoOperation)
 	inv.SetEventHandler(handler)
 	return inv
 }
 
-func (f *ConnectionInvocationFactory) NewInvocationOnTarget(message *proto.ClientMessage, addr pubcluster.Address) *invocation.Impl {
+func (f *ConnectionInvocationFactory) NewInvocationOnTarget(message *proto.ClientMessage, addr pubcluster.Address, start time.Time) *invocation.Impl {
 	message.SetCorrelationID(f.makeCorrelationID())
-	inv := invocation.NewImpl(message, -1, addr, time.Now().Add(f.invocationTimeout), f.redoOperation)
+	inv := invocation.NewImpl(message, -1, addr, start.Add(f.invocationTimeout), f.redoOperation)
 	return inv
 }
 
-func (f *ConnectionInvocationFactory) NewConnectionBoundInvocation(message *proto.ClientMessage, conn *Connection, handler proto.ClientMessageHandler) *ConnectionBoundInvocation {
+func (f *ConnectionInvocationFactory) NewConnectionBoundInvocation(message *proto.ClientMessage, conn *Connection, handler proto.ClientMessageHandler, start time.Time) *ConnectionBoundInvocation {
 	message = message.Copy()
 	message.SetCorrelationID(f.makeCorrelationID())
-	inv := newConnectionBoundInvocation(message, -1, "", conn, time.Now().Add(f.invocationTimeout), f.redoOperation)
+	inv := newConnectionBoundInvocation(message, -1, "", conn, start.Add(f.invocationTimeout), f.redoOperation)
 	inv.SetEventHandler(handler)
 	return inv
 }
 
-func (f *ConnectionInvocationFactory) NewMemberBoundInvocation(message *proto.ClientMessage, member *pubcluster.MemberInfo) *MemberBoundInvocation {
+func (f *ConnectionInvocationFactory) NewMemberBoundInvocation(message *proto.ClientMessage, member *pubcluster.MemberInfo, start time.Time) *MemberBoundInvocation {
 	message = message.Copy()
 	message.SetCorrelationID(f.makeCorrelationID())
-	deadline := time.Now().Add(f.invocationTimeout)
+	deadline := start.Add(f.invocationTimeout)
 	inv := NewMemberBoundInvocation(message, member, deadline, f.redoOperation)
 	return inv
 }

--- a/internal/cluster/invocation_test.go
+++ b/internal/cluster/invocation_test.go
@@ -35,7 +35,7 @@ import (
 func TestConnectionBoundInvocation_CanRetry(t *testing.T) {
 	fac := icluster.NewConnectionInvocationFactory(&pubcluster.Config{})
 	msg := proto.NewClientMessage(proto.NewFrame(make([]byte, 64)))
-	inv := fac.NewConnectionBoundInvocation(msg, nil, nil)
+	inv := fac.NewConnectionBoundInvocation(msg, nil, nil, time.Now())
 	err := errors.New("foo")
 	if !assert.False(t, inv.CanRetry(err)) {
 		t.FailNow()

--- a/internal/invocation/invocation.go
+++ b/internal/invocation/invocation.go
@@ -47,6 +47,7 @@ type Invocation interface {
 	Address() pubcluster.Address
 	Close()
 	CanRetry(err error) bool
+	Deadline() time.Time
 }
 
 type Impl struct {
@@ -120,6 +121,10 @@ func (i *Impl) Address() pubcluster.Address {
 	return i.address
 }
 
+func (i *Impl) Deadline() time.Time {
+	return i.deadline
+}
+
 /*
 func (i *Proxy) StoreSentConnection(conn interface{}) {
 	i.sentConnection.Store(conn)
@@ -161,6 +166,10 @@ func (i *Impl) MaybeCanRetry(err error) bool {
 func (i *Impl) unwrapResponse(response *proto.ClientMessage) (*proto.ClientMessage, error) {
 	if response.Err != nil {
 		if i.CanRetry(response.Err) {
+			return nil, response.Err
+		}
+		if _, ok := response.Err.(*cb.NonRetryableError); ok {
+			// the error was already wrapped as nonretryable
 			return nil, response.Err
 		}
 		return nil, cb.WrapNonRetryableError(response.Err)

--- a/internal/invocation/invocation_service.go
+++ b/internal/invocation/invocation_service.go
@@ -135,25 +135,13 @@ func (s *Service) processIncoming() {
 loop:
 	for {
 		select {
-		case inv, ok := <-s.requestCh:
-			if !ok {
-				break loop
-			}
+		case inv := <-s.requestCh:
 			s.sendInvocation(inv)
-		case inv, ok := <-s.urgentRequestCh:
-			if !ok {
-				break loop
-			}
+		case inv := <-s.urgentRequestCh:
 			s.sendInvocation(inv)
-		case msg, ok := <-s.responseCh:
-			if !ok {
-				break loop
-			}
+		case msg := <-s.responseCh:
 			s.handleClientMessage(msg)
-		case id, ok := <-s.removeCh:
-			if !ok {
-				break loop
-			}
+		case id := <-s.removeCh:
 			s.removeCorrelationID(id)
 		case <-s.doneCh:
 			break loop

--- a/internal/invocation/invocation_service.go
+++ b/internal/invocation/invocation_service.go
@@ -54,10 +54,10 @@ func NewService(
 	handler Handler,
 	logger ilogger.Logger) *Service {
 	service := &Service{
-		requestCh:       make(chan Invocation, 1024),
-		urgentRequestCh: make(chan Invocation, 1024),
-		responseCh:      make(chan *proto.ClientMessage, 1024),
-		removeCh:        make(chan int64, 1024),
+		requestCh:       make(chan Invocation),
+		urgentRequestCh: make(chan Invocation),
+		responseCh:      make(chan *proto.ClientMessage),
+		removeCh:        make(chan int64),
 		doneCh:          make(chan struct{}),
 		invocations:     map[int64]Invocation{},
 		handler:         handler,

--- a/internal/invocation/invocation_service.go
+++ b/internal/invocation/invocation_service.go
@@ -80,9 +80,6 @@ func (s *Service) SetHandler(handler Handler) {
 }
 
 func (s *Service) SendRequest(ctx context.Context, inv Invocation) error {
-	if atomic.LoadInt32(&s.state) != ready {
-		return cb.WrapNonRetryableError(hzerrors.ErrClientNotActive)
-	}
 	select {
 	case <-ctx.Done():
 		return fmt.Errorf("sending invocation: %w", ctx.Err())
@@ -94,9 +91,6 @@ func (s *Service) SendRequest(ctx context.Context, inv Invocation) error {
 }
 
 func (s *Service) SendUrgentRequest(ctx context.Context, inv Invocation) error {
-	if atomic.LoadInt32(&s.state) != ready {
-		return cb.WrapNonRetryableError(hzerrors.ErrClientNotActive)
-	}
 	select {
 	case <-ctx.Done():
 		return fmt.Errorf("sending urgent invocation: %w", ctx.Err())
@@ -108,9 +102,6 @@ func (s *Service) SendUrgentRequest(ctx context.Context, inv Invocation) error {
 }
 
 func (s *Service) WriteResponse(msg *proto.ClientMessage) error {
-	if atomic.LoadInt32(&s.state) != ready {
-		return cb.WrapNonRetryableError(hzerrors.ErrClientNotActive)
-	}
 	select {
 	case <-s.doneCh:
 		return cb.WrapNonRetryableError(fmt.Errorf("writing response: %w", hzerrors.ErrClientNotActive))
@@ -120,9 +111,6 @@ func (s *Service) WriteResponse(msg *proto.ClientMessage) error {
 }
 
 func (s *Service) Remove(correlationID int64) error {
-	if atomic.LoadInt32(&s.state) != ready {
-		return cb.WrapNonRetryableError(hzerrors.ErrClientNotActive)
-	}
 	select {
 	case <-s.doneCh:
 		return cb.WrapNonRetryableError(fmt.Errorf("removing correlation: %w", hzerrors.ErrClientNotActive))

--- a/internal/invocation/invocation_service.go
+++ b/internal/invocation/invocation_service.go
@@ -73,10 +73,6 @@ func (s *Service) Stop() {
 		return
 	}
 	close(s.doneCh)
-	close(s.requestCh)
-	close(s.urgentRequestCh)
-	close(s.responseCh)
-	close(s.removeCh)
 }
 
 func (s *Service) SetHandler(handler Handler) {

--- a/internal/invocation/invocation_service.go
+++ b/internal/invocation/invocation_service.go
@@ -87,7 +87,7 @@ func (s *Service) SendRequest(ctx context.Context, inv Invocation) error {
 	case <-ctx.Done():
 		return fmt.Errorf("sending invocation: %w", ctx.Err())
 	case <-s.doneCh:
-		return cb.WrapNonRetryableError(fmt.Errorf("sending urgent invocation: %w", hzerrors.ErrClientNotActive))
+		return cb.WrapNonRetryableError(fmt.Errorf("sending invocation: %w", hzerrors.ErrClientNotActive))
 	case s.requestCh <- inv:
 		return nil
 	}

--- a/internal/invocation/invocation_service.go
+++ b/internal/invocation/invocation_service.go
@@ -107,13 +107,13 @@ func (s *Service) SendUrgentRequest(ctx context.Context, inv Invocation) error {
 	}
 }
 
-func (s *Service) SendResponse(msg *proto.ClientMessage) error {
+func (s *Service) WriteResponse(msg *proto.ClientMessage) error {
 	if atomic.LoadInt32(&s.state) != ready {
 		return cb.WrapNonRetryableError(hzerrors.ErrClientNotActive)
 	}
 	select {
 	case <-s.doneCh:
-		return cb.WrapNonRetryableError(fmt.Errorf("sending response: %w", hzerrors.ErrClientNotActive))
+		return cb.WrapNonRetryableError(fmt.Errorf("writing response: %w", hzerrors.ErrClientNotActive))
 	case s.responseCh <- msg:
 		return nil
 	}

--- a/internal/stats/stats_service.go
+++ b/internal/stats/stats_service.go
@@ -139,7 +139,7 @@ func (s *Service) sendStats(ctx context.Context) {
 		return fmt.Sprintf("sending stats: %s", statsStr)
 	})
 	request := codec.EncodeClientStatisticsRequest(now.Unix()*1000, statsStr, blob)
-	inv := s.invFactory.NewInvocationOnRandomTarget(request, nil)
+	inv := s.invFactory.NewInvocationOnRandomTarget(request, nil, time.Now())
 	if err := s.invocationService.SendRequest(ctx, inv); err != nil {
 		s.logger.Debug(func() string {
 			return fmt.Sprintf("sending stats: %s", err.Error())

--- a/map_it_test.go
+++ b/map_it_test.go
@@ -655,17 +655,21 @@ func TestMap_IsEmptySize(t *testing.T) {
 		it.MustValue(m.Put(context.Background(), "k1", "v1"))
 		it.MustValue(m.Put(context.Background(), "k2", "v2"))
 		it.MustValue(m.Put(context.Background(), "k3", "v3"))
-		if value, err := m.IsEmpty(context.Background()); err != nil {
-			t.Fatal(err)
-		} else if value {
-			t.Fatalf("target: false != true")
-		}
+		it.Eventually(t, func() bool {
+			value, err := m.IsEmpty(context.Background())
+			if err != nil {
+				t.Fatal(err)
+			}
+			return !value
+		})
 		targetSize = 3
-		if value, err := m.Size(context.Background()); err != nil {
-			t.Fatal(err)
-		} else if targetSize != value {
-			t.Fatalf("target: %d != %d", targetSize, value)
-		}
+		it.Eventually(t, func() bool {
+			value, err := m.Size(context.Background())
+			if err != nil {
+				t.Fatal(err)
+			}
+			return targetSize == value
+		})
 	})
 }
 

--- a/proxy_map.go
+++ b/proxy_map.go
@@ -592,11 +592,12 @@ func (m *Map) PutAll(ctx context.Context, entries ...types.Entry) error {
 	}
 	f := func(partitionID int32, entries []proto.Pair) cb.Future {
 		request := codec.EncodeMapPutAllRequest(m.name, entries, true)
+		now := time.Now()
 		return m.cb.TryContextFuture(ctx, func(ctx context.Context, attempt int) (interface{}, error) {
 			if attempt > 0 {
 				request = request.Copy()
 			}
-			if inv, err := m.invokeOnPartitionAsync(ctx, request, partitionID); err != nil {
+			if inv, err := m.invokeOnPartitionAsync(ctx, request, partitionID, now); err != nil {
 				return nil, err
 			} else {
 				return inv.GetWithContext(ctx)

--- a/proxy_pn_counter.go
+++ b/proxy_pn_counter.go
@@ -19,6 +19,7 @@ package hazelcast
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/hazelcast/hazelcast-go-client/cluster"
 	"github.com/hazelcast/hazelcast-go-client/hzerrors"
@@ -175,6 +176,7 @@ func (pn *PNCounter) invokeOnMember(ctx context.Context, makeReq func(target typ
 	var excluded map[cluster.Address]struct{}
 	var lastAddr cluster.Address
 	var request *proto.ClientMessage
+	now := time.Now()
 	return pn.tryInvoke(ctx, func(ctx context.Context, attempt int) (interface{}, error) {
 		if attempt == 1 {
 			// this is the first failure, time to allocate the excluded set
@@ -190,7 +192,7 @@ func (pn *PNCounter) invokeOnMember(ctx context.Context, makeReq func(target typ
 			return nil, cb.WrapNonRetryableError(err)
 		}
 		request = makeReq(mem.UUID, clocks)
-		inv := pn.invocationFactory.NewMemberBoundInvocation(request, mem)
+		inv := pn.invocationFactory.NewMemberBoundInvocation(request, mem, now)
 		if err := pn.sendInvocation(ctx, inv); err != nil {
 			return nil, err
 		}

--- a/proxy_replicated_map.go
+++ b/proxy_replicated_map.go
@@ -19,6 +19,7 @@ package hazelcast
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/hazelcast/hazelcast-go-client/internal/cb"
 	"github.com/hazelcast/hazelcast-go-client/internal/proto"
@@ -210,11 +211,12 @@ func (m *ReplicatedMap) PutAll(ctx context.Context, keyValuePairs ...types.Entry
 	}
 	f := func(partitionID int32, entries []proto.Pair) cb.Future {
 		request := codec.EncodeReplicatedMapPutAllRequest(m.name, entries)
+		now := time.Now()
 		return m.cb.TryContextFuture(ctx, func(ctx context.Context, attempt int) (interface{}, error) {
 			if attempt > 0 {
 				request = request.Copy()
 			}
-			if inv, err := m.invokeOnPartitionAsync(ctx, request, partitionID); err != nil {
+			if inv, err := m.invokeOnPartitionAsync(ctx, request, partitionID, now); err != nil {
 				return nil, err
 			} else {
 				return inv.GetWithContext(ctx)

--- a/replicated_map_it_test.go
+++ b/replicated_map_it_test.go
@@ -152,11 +152,13 @@ func TestReplicatedMap_IsEmptySize(t *testing.T) {
 		it.MustValue(m.Put(context.Background(), "k1", "v1"))
 		it.MustValue(m.Put(context.Background(), "k2", "v2"))
 		it.MustValue(m.Put(context.Background(), "k3", "v3"))
-		if value, err := m.IsEmpty(context.Background()); err != nil {
-			t.Fatal(err)
-		} else if value {
-			t.Fatalf("target: false != true")
-		}
+		it.Eventually(t, func() bool {
+			value, err := m.IsEmpty(context.Background())
+			if err != nil {
+				t.Fatal(err)
+			}
+			return !value
+		})
 		targetSize = 3
 		it.Eventually(t, func() bool {
 			value, err := m.Size(context.Background())

--- a/replicated_map_it_test.go
+++ b/replicated_map_it_test.go
@@ -89,11 +89,13 @@ func TestReplicatedMap_GetEntrySet(t *testing.T) {
 		if err := m.PutAll(context.Background(), target...); err != nil {
 			t.Fatal(err)
 		}
-		if entries, err := m.GetEntrySet(context.Background()); err != nil {
-			t.Fatal(err)
-		} else if !entriesEqualUnordered(target, entries) {
-			t.Fatalf("target: %#v != %#v", target, entries)
-		}
+		it.Eventually(t, func() bool {
+			entries, err := m.GetEntrySet(context.Background())
+			if err != nil {
+				t.Fatal(err)
+			}
+			return entriesEqualUnordered(target, entries)
+		})
 	})
 }
 
@@ -124,11 +126,13 @@ func TestReplicatedMap_GetValues(t *testing.T) {
 		it.AssertEquals(t, "v1", it.MustValue(m.Get(context.Background(), "k1")))
 		it.AssertEquals(t, "v2", it.MustValue(m.Get(context.Background(), "k2")))
 		it.AssertEquals(t, "v3", it.MustValue(m.Get(context.Background(), "k3")))
-		if values, err := m.GetValues(context.Background()); err != nil {
-			t.Fatal(err)
-		} else if !reflect.DeepEqual(makeStringSet(targetValues), makeStringSet(values)) {
-			t.Fatalf("target: %#v != %#v", targetValues, values)
-		}
+		it.Eventually(t, func() bool {
+			values, err := m.GetValues(context.Background())
+			if err != nil {
+				t.Fatal(err)
+			}
+			return reflect.DeepEqual(makeStringSet(targetValues), makeStringSet(values))
+		})
 	})
 }
 
@@ -154,11 +158,13 @@ func TestReplicatedMap_IsEmptySize(t *testing.T) {
 			t.Fatalf("target: false != true")
 		}
 		targetSize = 3
-		if value, err := m.Size(context.Background()); err != nil {
-			t.Fatal(err)
-		} else if targetSize != value {
-			t.Fatalf("target: %d != %d", targetSize, value)
-		}
+		it.Eventually(t, func() bool {
+			value, err := m.Size(context.Background())
+			if err != nil {
+				t.Fatal(err)
+			}
+			return targetSize == value
+		})
 	})
 }
 

--- a/topic_it_test.go
+++ b/topic_it_test.go
@@ -64,7 +64,9 @@ func TestTopic_PublishAll(t *testing.T) {
 		if err = tp.PublishAll(context.Background(), "v1", "v2", "v3"); err != nil {
 			t.Fatal(err)
 		}
-		it.Eventually(t, func() bool { return assert.Equal(t, int32(3), atomic.LoadInt32(&handlerValue)) })
+		it.Eventually(t, func() bool {
+			return int32(3) == atomic.LoadInt32(&handlerValue)
+		})
 
 		if err := tp.RemoveListener(context.Background(), subscriptionID); err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
- Moved invocation channels to the invocation service
- Returns `hzerrors.ErrClientNotActive` if an invocation is sent after the invocation service is closed
- Added 120 seconds timeout for waiting the initial member list
- Fixes #654 
- Fixes #653 
- Fixes #627
- Fixes #638 