### PR TITLE
Fix lease time argument on tryLock requests

### DIFF
--- a/internal/cb/circuitbreaker_test.go
+++ b/internal/cb/circuitbreaker_test.go
@@ -134,5 +134,5 @@ func TestMakeDeadline(t *testing.T) {
 
 	now := time.Now()
 	deadline = cb.MakeDeadline(100 * time.Hour)
-	assert.InDelta(t, now.Add(100*time.Hour).UnixNano(), deadline.UnixNano(), 1000000)
+	assert.InDelta(t, now.Add(100*time.Hour).UnixNano(), deadline.UnixNano(), float64(time.Millisecond))
 }

--- a/internal/cb/circuitbreaker_test.go
+++ b/internal/cb/circuitbreaker_test.go
@@ -134,5 +134,5 @@ func TestMakeDeadline(t *testing.T) {
 
 	now := time.Now()
 	deadline = cb.MakeDeadline(100 * time.Hour)
-	assert.InDelta(t, now.Add(100*time.Hour).UnixNano(), deadline.UnixNano(), 1000)
+	assert.InDelta(t, now.Add(100*time.Hour).UnixNano(), deadline.UnixNano(), 1000000)
 }

--- a/proxy_map.go
+++ b/proxy_map.go
@@ -37,6 +37,7 @@ const (
 	maxIndexAttributes               = 255
 	defaultLockID                    = 0
 	lockIDKey          lockIDKeyType = "__hz_lock_id"
+	leaseUnset                       = -1
 )
 
 type lockID int64
@@ -811,7 +812,7 @@ func (m *Map) Size(ctx context.Context) (int, error) {
 // TryLock tries to acquire the lock for the specified key.
 // When the lock is not available, the current goroutine doesn't wait and returns false immediately.
 func (m *Map) TryLock(ctx context.Context, key interface{}) (bool, error) {
-	return m.tryLock(ctx, key, 0, 0)
+	return m.tryLock(ctx, key, leaseUnset, 0)
 }
 
 // TryLockWithLease tries to acquire the lock for the specified key.
@@ -823,7 +824,7 @@ func (m *Map) TryLockWithLease(ctx context.Context, key interface{}, lease time.
 // TryLockWithTimeout tries to acquire the lock for the specified key.
 // The current goroutine is blocked until the lock is acquired using the same lock context, or he specified waiting time elapses.
 func (m *Map) TryLockWithTimeout(ctx context.Context, key interface{}, timeout time.Duration) (bool, error) {
-	return m.tryLock(ctx, key, 0, timeout.Milliseconds())
+	return m.tryLock(ctx, key, leaseUnset, timeout.Milliseconds())
 }
 
 // TryLockWithLeaseAndTimeout tries to acquire the lock for the specified key.


### PR DESCRIPTION
These changes address [hazelcast/hazelcast-go-client#522](https://github.com/hazelcast/hazelcast-go-client/issues/522)