### PR TITLE
Fix event subscription race

### DIFF
--- a/client_it_test.go
+++ b/client_it_test.go
@@ -572,7 +572,7 @@ func TestClientFixConnection(t *testing.T) {
 
 func TestClientVersion(t *testing.T) {
 	// adding this test here, so there's no "unused lint warning.
-	assert.Equal(t, "1.1.0", hz.ClientVersion)
+	assert.Equal(t, "1.1.1", hz.ClientVersion)
 }
 
 func TestInvocationTimeout(t *testing.T) {

--- a/internal/common.go
+++ b/internal/common.go
@@ -21,5 +21,5 @@ const (
 	ClientType         = "GOO"
 	AggregateFactoryID = -29
 	// ClientVersion should be manually set
-	ClientVersion = "1.1.0"
+	ClientVersion = "1.1.1"
 )

--- a/internal/event/dispatch_service.go
+++ b/internal/event/dispatch_service.go
@@ -67,7 +67,7 @@ func NewDispatchService(logger logger.Logger) *DispatchService {
 		subscriptions:     map[string]map[int64]Handler{},
 		syncSubscriptions: map[string]map[int64]Handler{},
 		eventCh:           make(chan Event, 1024),
-		controlCh:         make(chan controlMessage, 1024),
+		controlCh:         make(chan controlMessage),
 		doneCh:            make(chan struct{}),
 		state:             created,
 		logger:            logger,


### PR DESCRIPTION
The event control messages used a buffered channel, which made it possible the case that, between an attempt to subscribe an event and the actual subscription, an event would be published. In that case, the handler for the corresponding subscription would never be called.

Here is how to reproduce. Use the following program, which starts and immediately shuts down a client forever. During client start, a member list view request must be sent to the member. When the aforementioned race hits and actual subscription is done to ConnectionOpened after the connection is opened, the member list view request is never sent, so the client waits for 120 seconds and exits.

The client should return with a timeout error in about 50_000 iterations:
```go
func main() {
	cfg := hz.Config{}
	cfg.Logger.Level = logger.TraceLevel
	ctx := context.Background()
	var i int
	var maxAlloc uint64
	var firstAlloc uint64
	var m runtime.MemStats
	var tic, toc uint64
	for {
		runtime.ReadMemStats(&m)
		tic = m.Alloc
		client, err := hz.StartNewClientWithConfig(ctx, cfg)
		if err != nil {
			panic(fmt.Errorf("starting the client: %w", err))
		}
		if err = client.Shutdown(ctx); err != nil {
			panic(fmt.Errorf("stopping the client: %w", err))
		}
		runtime.ReadMemStats(&m)
		toc = m.Alloc
		if m.Alloc > maxAlloc {
			maxAlloc = m.Alloc
		}
		if i == 0 {
			firstAlloc = m.Alloc
		}
		diff := toc - tic
		if toc < tic {
			diff = 0
		}
		fmt.Printf("%d: first: %d, thisAlloc: %d, diffAlloc: %d, maxAlloc: %d, gc: %d\n", i, firstAlloc, m.Alloc, diff, maxAlloc, runtime.NumGoroutine())
		time.Sleep(1 * time.Millisecond)
		i++
	}
}
```
In order to ensure the actual subscription is registered right after the attempt, I've made the control channel of dispatcher service unbuffered.