### PR TITLE
Fixes #654

### DIFF
--- a/client_it_test.go
+++ b/client_it_test.go
@@ -616,7 +616,7 @@ func TestClientStartShutdownMemoryLeak(t *testing.T) {
 		ctx := context.Background()
 		var maxAlloc uint64
 		var m runtime.MemStats
-		for i := 0; i < 100; i++ {
+		for i := 0; i < 10_000; i++ {
 			client, err := hz.StartNewClientWithConfig(ctx, config)
 			if err != nil {
 				t.Fatal(err)

--- a/internal/cluster/connection_manager.go
+++ b/internal/cluster/connection_manager.go
@@ -226,10 +226,12 @@ func (m *ConnectionManager) start(ctx context.Context) error {
 	}
 	// wait for initial member list
 	m.logger.Debug(func() string { return "cluster.ConnectionManager.start: waiting for the initial member list" })
+	timer := time.NewTimer(initialMembersTimeout)
+	defer timer.Stop()
 	select {
 	case <-ctx.Done():
 		return fmt.Errorf("getting initial member list from cluster: %w", ctx.Err())
-	case <-time.After(initialMembersTimeout):
+	case <-timer.C:
 		return fmt.Errorf("timed out getting initial member list from cluster: %w", hzerrors.ErrIllegalState)
 	case <-m.startCh:
 		break

--- a/internal/it/util.go
+++ b/internal/it/util.go
@@ -436,10 +436,12 @@ func WaitEventuallyWithTimeout(t *testing.T, wg *sync.WaitGroup, timeout time.Du
 		defer close(c)
 		wg.Wait()
 	}()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
 	select {
 	case <-c:
 		//done successfully
-	case <-time.After(timeout):
+	case <-timer.C:
 		t.FailNow()
 	}
 }


### PR DESCRIPTION
The `time.After` statement in `ConnectionManager.Start` leaked memory. Replaced it with `time.NewTimer` and explicitly stopping the timer.