### PR TITLE
Stop invocation service if there is a cluster connection error

### DIFF
--- a/client.go
+++ b/client.go
@@ -230,6 +230,7 @@ func (c *Client) start(ctx context.Context) error {
 	if err := c.connectionManager.Start(ctx); err != nil {
 		c.eventDispatcher.Stop()
 		c.userEventDispatcher.Stop()
+		c.invocationService.Stop()
 		return err
 	}
 	c.heartbeatService.Start()


### PR DESCRIPTION
* Stops invocation service if there is a cluster connection error during client start up.