### PR TITLE
[v1.1.1] Handle Lost Invocations [API-992]

### DIFF
--- a/client.go
+++ b/client.go
@@ -222,6 +222,9 @@ func (c *Client) start(ctx context.Context) error {
 		return nil
 	}
 	c.eventDispatcher.Publish(lifecycle.NewLifecycleStateChanged(lifecycle.StateStarting))
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if err := c.connectionManager.Start(ctx); err != nil {
 		c.eventDispatcher.Stop(ctx)
 		c.invocationService.Stop()
@@ -241,6 +244,9 @@ func (c *Client) start(ctx context.Context) error {
 func (c *Client) Shutdown(ctx context.Context) error {
 	if !atomic.CompareAndSwapInt32(&c.state, ready, stopping) {
 		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
 	}
 	c.eventDispatcher.Publish(lifecycle.NewLifecycleStateChanged(lifecycle.StateShuttingDown))
 	c.invocationService.Stop()

--- a/client.go
+++ b/client.go
@@ -453,7 +453,7 @@ func (c *Client) createComponents(config *Config) {
 		Logger:            c.logger,
 		Config:            &config.Cluster,
 	})
-	invocationService := invocation.NewService(invocationHandler, c.logger)
+	invocationService := invocation.NewService(invocationHandler, c.eventDispatcher, c.logger)
 	listenerBinder := icluster.NewConnectionListenerBinder(
 		connectionManager,
 		invocationService,

--- a/client_internals.go
+++ b/client_internals.go
@@ -1,3 +1,4 @@
+//go:build hazelcastinternal
 // +build hazelcastinternal
 
 /*
@@ -18,16 +19,32 @@
 
 package hazelcast
 
-import "github.com/hazelcast/hazelcast-go-client/internal/cluster"
+import (
+	"github.com/hazelcast/hazelcast-go-client/internal/cluster"
+	"github.com/hazelcast/hazelcast-go-client/internal/event"
+	"github.com/hazelcast/hazelcast-go-client/internal/invocation"
+)
 
-type ClientInternals struct {
+type ClientInternal struct {
 	client *Client
 }
 
-func NewClientInternals(c *Client) *ClientInternals {
-	return &ClientInternals{client: c}
+func NewClientInternal(c *Client) *ClientInternal {
+	return &ClientInternal{client: c}
 }
 
-func (ci *ClientInternals) ConnectionManager() *cluster.ConnectionManager {
+func (ci *ClientInternal) ConnectionManager() *cluster.ConnectionManager {
 	return ci.client.connectionManager
+}
+
+func (ci *ClientInternal) DispatchService() *event.DispatchService {
+	return ci.client.eventDispatcher
+}
+
+func (ci *ClientInternal) InvocationService() *invocation.Service {
+	return ci.client.invocationService
+}
+
+func (ci *ClientInternal) InvocationHandler() invocation.Handler {
+	return ci.client.invocationHandler
 }

--- a/client_internals_it_test.go
+++ b/client_internals_it_test.go
@@ -59,7 +59,7 @@ func TestNotReceivedInvocation(t *testing.T) {
 		ctx := context.Background()
 		config := tc.DefaultConfig()
 		config.Cluster.Unisocket = !smart
-		client := it.MustClient(hz.StartNewClientWithConfig(ctx, tc.DefaultConfig()))
+		client := it.MustClient(hz.StartNewClientWithConfig(ctx, config))
 		defer client.Shutdown(ctx)
 		ci := hz.NewClientInternal(client)
 		var cnt int32

--- a/client_internals_it_test.go
+++ b/client_internals_it_test.go
@@ -26,7 +26,10 @@ import (
 	"time"
 
 	hz "github.com/hazelcast/hazelcast-go-client"
+	"github.com/hazelcast/hazelcast-go-client/hzerrors"
+	"github.com/hazelcast/hazelcast-go-client/internal/invocation"
 	"github.com/hazelcast/hazelcast-go-client/internal/it"
+	"github.com/hazelcast/hazelcast-go-client/internal/proto/codec"
 	"github.com/hazelcast/hazelcast-go-client/logger"
 )
 
@@ -44,6 +47,42 @@ func TestListenersAfterClientDisconnected(t *testing.T) {
 	})
 	t.Run("MemberIP_ClientHostname", func(t *testing.T) {
 		testListenersAfterClientDisconnected(t, "127.0.0.1", "localhost", 49501)
+	})
+}
+
+func TestNotReceivedInvocation(t *testing.T) {
+	// This test skips sending an invocation to the member in order to simulate lost connection.
+	// After 5 seconds, a GroupLost event is published to simulate the disconnection.
+	clientTester(t, func(t *testing.T, smart bool) {
+		tc := it.StartNewClusterWithOptions("not-received-invocation", 55701, 1)
+		defer tc.Shutdown()
+		ctx := context.Background()
+		config := tc.DefaultConfig()
+		config.Cluster.Unisocket = !smart
+		client := it.MustClient(hz.StartNewClientWithConfig(ctx, tc.DefaultConfig()))
+		defer client.Shutdown(ctx)
+		ci := hz.NewClientInternal(client)
+		var cnt int32
+		handler := newRiggedInvocationHandler(ci.InvocationHandler(), func(inv invocation.Invocation) bool {
+			if inv.Request().Type() == codec.MapSetCodecRequestMessageType {
+				return atomic.AddInt32(&cnt, 1) != 1
+			}
+			return true
+		})
+		ci.InvocationService().SetHandler(handler)
+		m := it.MustValue(client.GetMap(ctx, "test-map")).(*hz.Map)
+		go func() {
+			time.Sleep(5 * time.Second)
+			conns := ci.ConnectionManager().ActiveConnections()
+			ci.DispatchService().Publish(invocation.NewGroupLost(conns[0].ConnectionID(), fmt.Errorf("foo error: %w", hzerrors.ErrIO)))
+		}()
+		// the invocation should be sent after 5 seconds, make sure the set operation below succeeds in 10 seconds or times out.
+		ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
+		err := m.Set(ctx, "foo", "bar")
+		if err != nil {
+			t.Fatal(err)
+		}
 	})
 }
 
@@ -68,7 +107,7 @@ func testListenersAfterClientDisconnected(t *testing.T, memberHost string, clien
 	it.MustValue(m.AddEntryListener(ctx, lc, func(event *hz.EntryNotified) {
 		atomic.AddInt64(&ec, 1)
 	}))
-	ci := hz.NewClientInternals(client)
+	ci := hz.NewClientInternal(client)
 	// make sure the client connected to the member
 	it.Eventually(t, func() bool {
 		ac := len(ci.ConnectionManager().ActiveConnections())
@@ -87,4 +126,22 @@ func testListenersAfterClientDisconnected(t *testing.T, memberHost string, clien
 		it.MustValue(m.Put(ctx, 1, 2))
 		return atomic.LoadInt64(&ec) > 0
 	})
+}
+
+type invokeFilter func(inv invocation.Invocation) (ok bool)
+
+type riggedInvocationHandler struct {
+	invocation.Handler
+	invokeFilter invokeFilter
+}
+
+func newRiggedInvocationHandler(handler invocation.Handler, filter invokeFilter) *riggedInvocationHandler {
+	return &riggedInvocationHandler{Handler: handler, invokeFilter: filter}
+}
+
+func (h *riggedInvocationHandler) Invoke(inv invocation.Invocation) (int64, error) {
+	if !h.invokeFilter(inv) {
+		return 1, nil
+	}
+	return h.Handler.Invoke(inv)
 }

--- a/client_it_test.go
+++ b/client_it_test.go
@@ -706,11 +706,10 @@ func TestClusterShutdownThenCheckOperationsNotHanging(t *testing.T) {
 }
 
 func TestClientStartShutdownWithNilContext(t *testing.T) {
-	config := hz.Config{}
-	config.Cluster.ConnectionStrategy.Timeout = types.Duration(1 * time.Second)
-	// ignoring the error here, since it's OK to get an error here.
-	client, _ := hz.StartNewClientWithConfig(nil, config)
-	client.Shutdown(nil)
+	tc := it.StartNewClusterWithOptions("nil-context-cluster", 45701, 1)
+	defer tc.Shutdown()
+	client := it.MustClient(hz.StartNewClientWithConfig(nil, tc.DefaultConfig()))
+	it.Must(client.Shutdown(nil))
 }
 
 func clientTester(t *testing.T, f func(*testing.T, bool)) {

--- a/client_it_test.go
+++ b/client_it_test.go
@@ -705,6 +705,14 @@ func TestClusterShutdownThenCheckOperationsNotHanging(t *testing.T) {
 	})
 }
 
+func TestClientStartShutdownWithNilContext(t *testing.T) {
+	config := hz.Config{}
+	config.Cluster.ConnectionStrategy.Timeout = types.Duration(1 * time.Second)
+	// ignoring the error here, since it's OK to get an error here.
+	client, _ := hz.StartNewClientWithConfig(nil, config)
+	client.Shutdown(nil)
+}
+
 func clientTester(t *testing.T, f func(*testing.T, bool)) {
 	if it.SmartEnabled() {
 		t.Run("Smart Client", func(t *testing.T) {

--- a/internal/cluster/cluster_service.go
+++ b/internal/cluster/cluster_service.go
@@ -234,12 +234,6 @@ func (m *membersMap) Find(uuid types.UUID) *pubcluster.MemberInfo {
 	return member
 }
 
-func (m *membersMap) Info(infoFun func(members map[types.UUID]*pubcluster.MemberInfo)) {
-	m.membersMu.RLock()
-	infoFun(m.members)
-	m.membersMu.RUnlock()
-}
-
 func (m *membersMap) OrderedMembers() []pubcluster.MemberInfo {
 	m.membersMu.Lock()
 	members := make([]pubcluster.MemberInfo, len(m.orderedMembers))

--- a/internal/cluster/connection.go
+++ b/internal/cluster/connection.go
@@ -288,6 +288,7 @@ func (c *Connection) close(closeErr error) {
 	c.socket.Close()
 	c.closedTime.Store(time.Now())
 	c.eventDispatcher.Publish(NewConnectionClosed(c, closeErr))
+	c.eventDispatcher.Publish(invocation.NewGroupLost(c.connectionID, closeErr))
 	c.logger.Trace(func() string {
 		reason := "normally"
 		if closeErr != nil {

--- a/internal/cluster/connection.go
+++ b/internal/cluster/connection.go
@@ -285,10 +285,20 @@ func (c *Connection) close(closeErr error) {
 		return
 	}
 	close(c.doneCh)
-	c.socket.Close()
+	if err := c.socket.Close(); err != nil {
+		c.logger.Trace(func() string {
+			return fmt.Sprintf("error closing socket: %s", err.Error())
+		})
+	}
 	c.closedTime.Store(time.Now())
 	c.eventDispatcher.Publish(NewConnectionClosed(c, closeErr))
-	c.eventDispatcher.Publish(invocation.NewGroupLost(c.connectionID, closeErr))
+	var groupErr error
+	if closeErr == nil {
+		groupErr = ihzerrors.NewTargetDisconnectedError("", closeErr)
+	} else {
+		groupErr = ihzerrors.NewTargetDisconnectedError(closeErr.Error(), closeErr)
+	}
+	c.eventDispatcher.Publish(invocation.NewGroupLost(c.connectionID, groupErr))
 	c.logger.Trace(func() string {
 		reason := "normally"
 		if closeErr != nil {

--- a/internal/cluster/connection_bound_invocation.go
+++ b/internal/cluster/connection_bound_invocation.go
@@ -71,3 +71,7 @@ func (i *ConnectionBoundInvocation) CanRetry(err error) bool {
 	}
 	return false
 }
+
+func (i *ConnectionBoundInvocation) HasGroup(groupID int64) bool {
+	return i.boundConnection != nil && i.boundConnection.connectionID == groupID
+}

--- a/internal/cluster/connection_bound_invocation.go
+++ b/internal/cluster/connection_bound_invocation.go
@@ -71,7 +71,3 @@ func (i *ConnectionBoundInvocation) CanRetry(err error) bool {
 	}
 	return false
 }
-
-func (i *ConnectionBoundInvocation) HasGroup(groupID int64) bool {
-	return i.boundConnection != nil && i.boundConnection.connectionID == groupID
-}

--- a/internal/cluster/connection_invocation_handler.go
+++ b/internal/cluster/connection_invocation_handler.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"time"
 
 	pubcluster "github.com/hazelcast/hazelcast-go-client/cluster"
@@ -64,7 +65,7 @@ type ConnectionInvocationHandler struct {
 func NewConnectionInvocationHandler(bundle ConnectionInvocationHandlerCreationBundle) *ConnectionInvocationHandler {
 	bundle.Check()
 	cbr := cb.NewCircuitBreaker(
-		cb.MaxRetries(3),
+		cb.MaxRetries(math.MaxInt32),
 		cb.RetryPolicy(func(attempt int) time.Duration {
 			return time.Duration(attempt) * time.Second
 		}))

--- a/internal/cluster/connection_invocation_handler.go
+++ b/internal/cluster/connection_invocation_handler.go
@@ -63,10 +63,8 @@ type ConnectionInvocationHandler struct {
 
 func NewConnectionInvocationHandler(bundle ConnectionInvocationHandlerCreationBundle) *ConnectionInvocationHandler {
 	bundle.Check()
-	// TODO: make circuit breaker configurable
 	cbr := cb.NewCircuitBreaker(
 		cb.MaxRetries(3),
-		cb.MaxFailureCount(3),
 		cb.RetryPolicy(func(attempt int) time.Duration {
 			return time.Duration(attempt) * time.Second
 		}))

--- a/internal/cluster/connection_invocation_handler.go
+++ b/internal/cluster/connection_invocation_handler.go
@@ -17,14 +17,10 @@
 package cluster
 
 import (
-	"context"
 	"errors"
 	"fmt"
-	"math"
-	"time"
 
 	pubcluster "github.com/hazelcast/hazelcast-go-client/cluster"
-	"github.com/hazelcast/hazelcast-go-client/internal/cb"
 	ihzerrors "github.com/hazelcast/hazelcast-go-client/internal/hzerrors"
 	"github.com/hazelcast/hazelcast-go-client/internal/invocation"
 	ilogger "github.com/hazelcast/hazelcast-go-client/internal/logger"
@@ -58,43 +54,32 @@ type ConnectionInvocationHandler struct {
 	logger            ilogger.Logger
 	connectionManager *ConnectionManager
 	clusterService    *Service
-	cb                *cb.CircuitBreaker
 	smart             bool
 }
 
 func NewConnectionInvocationHandler(bundle ConnectionInvocationHandlerCreationBundle) *ConnectionInvocationHandler {
 	bundle.Check()
-	cbr := cb.NewCircuitBreaker(
-		cb.MaxRetries(math.MaxInt32),
-		cb.RetryPolicy(func(attempt int) time.Duration {
-			return time.Duration(attempt) * time.Second
-		}))
 	return &ConnectionInvocationHandler{
 		connectionManager: bundle.ConnectionManager,
 		clusterService:    bundle.ClusterService,
 		logger:            bundle.Logger,
-		cb:                cbr,
 		smart:             !bundle.Config.Unisocket,
 	}
 }
 
 func (h *ConnectionInvocationHandler) Invoke(inv invocation.Invocation) (int64, error) {
-	groupID, err := h.cb.Try(func(ctx context.Context, attempt int) (interface{}, error) {
-		if h.smart {
-			groupID, err := h.invokeSmart(inv)
-			if err != nil {
-				if errors.Is(err, errPartitionOwnerNotAssigned) {
-					h.logger.Debug(func() string { return fmt.Sprintf("invoking non-smart since: %s", err.Error()) })
-					return h.invokeNonSmart(inv)
-				}
-				return int64(0), err
+	if h.smart {
+		groupID, err := h.invokeSmart(inv)
+		if err != nil {
+			if errors.Is(err, errPartitionOwnerNotAssigned) {
+				h.logger.Debug(func() string { return fmt.Sprintf("invoking non-smart since: %s", err.Error()) })
+				return h.invokeNonSmart(inv)
 			}
-			return groupID, err
-		} else {
-			return h.invokeNonSmart(inv)
+			return int64(0), err
 		}
-	})
-	return groupID.(int64), err
+		return groupID, nil
+	}
+	return h.invokeNonSmart(inv)
 }
 
 func (h *ConnectionInvocationHandler) invokeSmart(inv invocation.Invocation) (int64, error) {

--- a/internal/cluster/connection_manager.go
+++ b/internal/cluster/connection_manager.go
@@ -388,7 +388,7 @@ func (m *ConnectionManager) tryConnectCandidateCluster(ctx context.Context, clus
 		addr, err := m.connectCluster(ctx, cluster)
 		if err != nil {
 			m.logger.Debug(func() string {
-				return fmt.Sprintf("connectionManager: error connecting to cluster, attempt %d: %s", attempt+1, err.Error())
+				return fmt.Sprintf("cluster.ConnectionManager: error connecting to cluster, attempt %d: %s", attempt+1, err.Error())
 			})
 		}
 		return addr, err

--- a/internal/invocation/events.go
+++ b/internal/invocation/events.go
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package invocation
+
+const (
+	// EventGroupLost is dispatched if an invocation group is lost, e.g., a connection closed
+	EventGroupLost = "internal.invocation.grouplost"
+)
+
+type GroupLostEvent struct {
+	GroupID int64
+	Err     error
+}
+
+func NewGroupLost(groupID int64, err error) *GroupLostEvent {
+	return &GroupLostEvent{
+		GroupID: groupID,
+		Err:     err,
+	}
+}
+
+func (e *GroupLostEvent) EventName() string {
+	return EventGroupLost
+}

--- a/internal/invocation/invocation.go
+++ b/internal/invocation/invocation.go
@@ -48,6 +48,7 @@ type Invocation interface {
 	Close()
 	CanRetry(err error) bool
 	Deadline() time.Time
+	HasGroup(groupID int64) bool
 }
 
 type Impl struct {
@@ -125,12 +126,6 @@ func (i *Impl) Deadline() time.Time {
 	return i.deadline
 }
 
-/*
-func (i *Proxy) StoreSentConnection(conn interface{}) {
-	i.sentConnection.Store(conn)
-}
-*/
-
 // SetEventHandler sets the event handler for the invocation.
 // It should only be called at the site of creation.
 func (i *Impl) SetEventHandler(handler proto.ClientMessageHandler) {
@@ -160,6 +155,10 @@ func (i *Impl) MaybeCanRetry(err error) bool {
 	if errors.Is(err, hzerrors.ErrTargetDisconnected) {
 		return i.Request().Retryable || i.RedoOperation
 	}
+	return false
+}
+
+func (i *Impl) HasGroup(groupID int64) bool {
 	return false
 }
 

--- a/internal/invocation/invocation.go
+++ b/internal/invocation/invocation.go
@@ -48,7 +48,8 @@ type Invocation interface {
 	Close()
 	CanRetry(err error) bool
 	Deadline() time.Time
-	HasGroup(groupID int64) bool
+	Group() int64
+	SetGroup(id int64)
 }
 
 type Impl struct {
@@ -57,6 +58,7 @@ type Impl struct {
 	eventHandler  func(clientMessage *proto.ClientMessage)
 	request       *proto.ClientMessage
 	address       pubcluster.Address
+	group         int64
 	completed     int32
 	partitionID   int32
 	RedoOperation bool
@@ -158,8 +160,12 @@ func (i *Impl) MaybeCanRetry(err error) bool {
 	return false
 }
 
-func (i *Impl) HasGroup(groupID int64) bool {
-	return false
+func (i *Impl) Group() int64 {
+	return i.group
+}
+
+func (i *Impl) SetGroup(id int64) {
+	i.group = id
 }
 
 func (i *Impl) unwrapResponse(response *proto.ClientMessage) (*proto.ClientMessage, error) {

--- a/internal/invocation/invocation_service.go
+++ b/internal/invocation/invocation_service.go
@@ -65,7 +65,7 @@ func NewService(
 		responseCh:      make(chan *proto.ClientMessage),
 		removeCh:        make(chan int64),
 		doneCh:          make(chan struct{}),
-		groupLostCh:     make(chan *GroupLostEvent, 1),
+		groupLostCh:     make(chan *GroupLostEvent),
 		invocations:     map[int64]Invocation{},
 		handler:         handler,
 		eventDispatcher: eventDispacher,

--- a/internal/invocation/invocation_service.go
+++ b/internal/invocation/invocation_service.go
@@ -73,7 +73,9 @@ func NewService(
 		state:           ready,
 	}
 	s.eventDispatcher.Subscribe(EventGroupLost, serviceSubID, func(event event.Event) {
-		s.groupLostCh <- event.(*GroupLostEvent)
+		go func() {
+			s.groupLostCh <- event.(*GroupLostEvent)
+		}()
 	})
 	go s.processIncoming()
 	return s

--- a/internal/stats/stats_service_test.go
+++ b/internal/stats/stats_service_test.go
@@ -44,7 +44,7 @@ func TestNewService(t *testing.T) {
 	ed := event.NewDispatchService(lg)
 	okCh := make(chan struct{}, 1)
 	handler := Handler{okCh: okCh}
-	invService := invocation.NewService(handler, lg)
+	invService := invocation.NewService(handler, ed, lg)
 	config := hazelcast.Config{}
 	invFac := cluster.NewConnectionInvocationFactory(&config.Cluster)
 	srv := stats.NewService(invService, invFac, ed, lg, 100*time.Millisecond, "hz1")

--- a/set_it_test.go
+++ b/set_it_test.go
@@ -67,7 +67,11 @@ func TestSet_AddListener(t *testing.T) {
 			value := fmt.Sprintf("value-%d", i)
 			it.MustValue(s.Add(context.Background(), value))
 		}
-		it.Eventually(t, func() bool { return atomic.LoadInt32(&callCount) == targetCallCount })
+		it.Eventually(t, func() bool {
+			cc := atomic.LoadInt32(&callCount)
+			t.Logf("target: %d, actual: %d", targetCallCount, cc)
+			return cc == targetCallCount
+		})
 		atomic.StoreInt32(&callCount, 0)
 		if err = s.RemoveListener(context.Background(), subscriptionID); err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
- Closes invocations when the corresponding connection is disconnected. When a connection is disconnected, the connection publishes a `GroupLost` event which contains the connection ID (group ID). and the reason of disconnection. Invocation service subscribes to that event, and closes matching invocations. The `ConnectionClosed` event is not used for this purpose in order to avoid depending on `internal/cluster` for the `internal/invocation` package which would result in cyclic dependency.
- Changes user events to use the the global subscription ID.