### PR TITLE
[1.2.0] Prevent panic in listener handlers if member not found

### DIFF
--- a/events.go
+++ b/events.go
@@ -62,6 +62,8 @@ const (
 )
 
 // EntryNotified contains information about an entry event.
+// Member may have the zero value of cluster.MemberInfo if the member is not known at the time the corresponding callback runs.
+// You can check that situation by checking whether Member.UUID is the default UUID.
 type EntryNotified struct {
 	MergingValue            interface{}
 	Key                     interface{}
@@ -157,6 +159,8 @@ func newLifecycleStateChanged(state LifecycleState) *LifecycleStateChanged {
 }
 
 // MessagePublished contains information about a message published event.
+// Member may have the zero value of cluster.MemberInfo if the member is not known at the time the corresponding callback runs.
+// You can check that situation by checking whether Member.UUID is the default UUID.
 type MessagePublished struct {
 	PublishTime time.Time
 	Value       interface{}
@@ -191,6 +195,8 @@ const (
 type QueueItemNotifiedHandler func(event *QueueItemNotified)
 
 // QueueItemNotified contains information about an item notified event.
+// Member may have the zero value of cluster.MemberInfo if the member is not known at the time the corresponding callback runs.
+// You can check that situation by checking whether Member.UUID is the default UUID.
 type QueueItemNotified struct {
 	Value     interface{}
 	QueueName string
@@ -215,6 +221,8 @@ func newQueueItemNotified(name string, value interface{}, member cluster.MemberI
 type ListItemNotifiedHandler func(event *ListItemNotified)
 
 // ListItemNotified describes the List item event.
+// Member may have the zero value of cluster.MemberInfo if the member is not known at the time the corresponding callback runs.
+// You can check that situation by checking whether Member.UUID is the default UUID.
 type ListItemNotified struct {
 	Value     interface{}
 	ListName  string
@@ -240,6 +248,8 @@ func newListItemNotified(name string, value interface{}, member cluster.MemberIn
 type SetItemNotifiedHandler func(event *SetItemNotified)
 
 // SetItemNotified contains information about an item notified event.
+// Member may have the zero value of cluster.MemberInfo if the member is not known at the time the corresponding callback runs.
+// You can check that situation by checking whether Member.UUID is the default UUID.
 type SetItemNotified struct {
 	Value     interface{}
 	SetName   string

--- a/internal/serialization/class_definition_writer.go
+++ b/internal/serialization/class_definition_writer.go
@@ -138,6 +138,10 @@ func (cdw *ClassDefinitionWriter) WritePortableArray(fieldName string, portables
 	}
 }
 
+func (cdw *ClassDefinitionWriter) GetRawDataOutput() serialization.DataOutput {
+	return &EmptyObjectDataOutput{}
+}
+
 func (cdw *ClassDefinitionWriter) registerAndGet() (*serialization.ClassDefinition, error) {
 	return cdw.classDefinition, cdw.portableContext.RegisterClassDefinition(cdw.classDefinition)
 }

--- a/internal/serialization/default_portable_reader.go
+++ b/internal/serialization/default_portable_reader.go
@@ -29,6 +29,7 @@ type DefaultPortableReader struct {
 	classDefinition *serialization.ClassDefinition
 	offset          int32
 	finalPos        int32
+	raw             bool
 }
 
 func NewDefaultPortableReader(serializer *PortableSerializer, input serialization.DataInput,
@@ -92,6 +93,9 @@ func TypeByID(fieldType serialization.FieldDefinitionType) string {
 }
 
 func (pr *DefaultPortableReader) positionByField(fieldName string, fieldType serialization.FieldDefinitionType) int32 {
+	if pr.raw {
+		panic(ihzerrors.NewSerializationError("cannot read Portable fields after getRawDataInput() is called", nil))
+	}
 	field, ok := pr.classDefinition.Fields[fieldName]
 	if !ok {
 		panic(ihzerrors.NewSerializationError(fmt.Sprintf("unknown field: %s", fieldName), nil))
@@ -307,6 +311,17 @@ func (pr *DefaultPortableReader) readPortableArray(fieldName string) []serializa
 	}
 	pr.input.SetPosition(backupPos)
 	return portables
+}
+
+func (pr *DefaultPortableReader) GetRawDataInput() serialization.DataInput {
+	if !pr.raw {
+		off := pr.offset + pr.classDefinition.FieldCount()*Int32SizeInBytes
+		pr.input.SetPosition(off)
+		pos := pr.input.ReadInt32()
+		pr.input.SetPosition(pos)
+		pr.raw = true
+	}
+	return pr.input
 }
 
 func (pr *DefaultPortableReader) End() {

--- a/internal/serialization/default_portable_writer.go
+++ b/internal/serialization/default_portable_writer.go
@@ -29,6 +29,7 @@ type DefaultPortableWriter struct {
 	classDefinition *serialization.ClassDefinition
 	begin           int32
 	offset          int32
+	raw             bool
 }
 
 func NewDefaultPortableWriter(serializer *PortableSerializer, output *PositionalObjectDataOutput,
@@ -39,7 +40,7 @@ func NewDefaultPortableWriter(serializer *PortableSerializer, output *Positional
 	offset := output.Position()
 	fieldIndexesLength := (len(classDefinition.Fields) + 1) * Int32SizeInBytes
 	output.WriteZeroBytes(fieldIndexesLength)
-	return &DefaultPortableWriter{serializer, output, classDefinition, begin, offset}
+	return &DefaultPortableWriter{serializer, output, classDefinition, begin, offset, false}
 }
 
 func (pw *DefaultPortableWriter) WriteByte(fieldName string, value byte) {
@@ -182,6 +183,9 @@ func (pw *DefaultPortableWriter) WritePortableArray(fieldName string, portableAr
 }
 
 func (pw *DefaultPortableWriter) setPosition(fieldName string, fieldType int32) {
+	if pw.raw {
+		panic(ihzerrors.NewSerializationError("cannot write Portable fields after getRawDataOutput() is called", nil))
+	}
 	field, ok := pw.classDefinition.Fields[fieldName]
 	if !ok {
 		panic(ihzerrors.NewSerializationError(fmt.Sprintf("unknown field: %s", fieldName), nil))
@@ -192,6 +196,16 @@ func (pw *DefaultPortableWriter) setPosition(fieldName string, fieldType int32) 
 	pw.output.WriteInt16(int16(len(runes)))
 	pw.output.writeStringBytes(runes)
 	pw.output.WriteByte(byte(fieldType))
+}
+
+func (pw *DefaultPortableWriter) GetRawDataOutput() serialization.DataOutput {
+	if !pw.raw {
+		pos := pw.output.Position()
+		index := pw.classDefinition.FieldCount()
+		pw.output.PWriteInt32(pw.offset+index*Int32SizeInBytes, pos)
+		pw.raw = true
+	}
+	return pw.output.ObjectDataOutput
 }
 
 func (pw *DefaultPortableWriter) End() {

--- a/internal/serialization/object_data.go
+++ b/internal/serialization/object_data.go
@@ -329,6 +329,12 @@ func (i *ObjectDataInput) Position() int32 {
 }
 
 func (i *ObjectDataInput) SetPosition(pos int32) {
+	if pos < 0 {
+		panic(ihzerrors.NewIllegalArgumentError(fmt.Sprintf("negative pos: %v", i.position), nil))
+	}
+	if len(i.buffer) < int(pos) {
+		panic(ihzerrors.NewEOFError(fmt.Sprintf("pos %v is out of range", pos)))
+	}
 	i.position = pos
 }
 
@@ -681,3 +687,55 @@ func (p *PositionalObjectDataOutput) PWriteFloat64(pos int32, v float64) {
 func byteSliceToString(buf []byte) string {
 	return *(*string)(unsafe.Pointer(&buf))
 }
+
+// EmptyObjectDataOutput implements no-op serialization.DataOutput.
+type EmptyObjectDataOutput struct {
+}
+
+func (e *EmptyObjectDataOutput) Position() int32 {
+	return 0
+}
+
+func (e *EmptyObjectDataOutput) SetPosition(int32) {}
+
+func (e *EmptyObjectDataOutput) WriteByte(byte) {}
+
+func (e *EmptyObjectDataOutput) WriteBool(bool) {}
+
+func (e *EmptyObjectDataOutput) WriteUInt16(uint16) {}
+
+func (e *EmptyObjectDataOutput) WriteInt16(int16) {}
+
+func (e *EmptyObjectDataOutput) WriteInt32(int32) {}
+
+func (e *EmptyObjectDataOutput) WriteInt64(int64) {}
+
+func (e *EmptyObjectDataOutput) WriteFloat32(float32) {}
+
+func (e *EmptyObjectDataOutput) WriteFloat64(float64) {}
+
+func (e *EmptyObjectDataOutput) WriteString(string) {}
+
+func (e *EmptyObjectDataOutput) WriteObject(interface{}) {}
+
+func (e *EmptyObjectDataOutput) WriteByteArray([]byte) {}
+
+func (e *EmptyObjectDataOutput) WriteBoolArray([]bool) {}
+
+func (e *EmptyObjectDataOutput) WriteUInt16Array([]uint16) {}
+
+func (e *EmptyObjectDataOutput) WriteInt16Array([]int16) {}
+
+func (e *EmptyObjectDataOutput) WriteInt32Array([]int32) {}
+
+func (e *EmptyObjectDataOutput) WriteInt64Array([]int64) {}
+
+func (e *EmptyObjectDataOutput) WriteFloat32Array([]float32) {}
+
+func (e *EmptyObjectDataOutput) WriteFloat64Array([]float64) {}
+
+func (e *EmptyObjectDataOutput) WriteStringArray([]string) {}
+
+func (e *EmptyObjectDataOutput) WriteStringBytes(string) {}
+
+func (e *EmptyObjectDataOutput) WriteZeroBytes(int) {}

--- a/proxy.go
+++ b/proxy.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/hazelcast/hazelcast-go-client/aggregate"
+	pubcluster "github.com/hazelcast/hazelcast-go-client/cluster"
 	"github.com/hazelcast/hazelcast-go-client/internal/cb"
 	"github.com/hazelcast/hazelcast-go-client/internal/check"
 	"github.com/hazelcast/hazelcast-go-client/internal/cluster"
@@ -397,8 +398,12 @@ func (p *proxy) makeEntryNotifiedListenerHandler(handler EntryNotifiedHandler) e
 			p.logger.Errorf("error at AddEntryListener: %w", err)
 			return
 		}
-		member := p.clusterService.GetMemberByUUID(binUUID)
-		handler(newEntryNotifiedEvent(p.name, *member, key, value, oldValue, mergingValue, int(affectedEntries), EntryEventType(binEventType)))
+		// prevent panic if member not found
+		var member pubcluster.MemberInfo
+		if m := p.clusterService.GetMemberByUUID(binUUID); m != nil {
+			member = *m
+		}
+		handler(newEntryNotifiedEvent(p.name, member, key, value, oldValue, mergingValue, int(affectedEntries), EntryEventType(binEventType)))
 	}
 }
 

--- a/serialization/api.go
+++ b/serialization/api.go
@@ -168,7 +168,6 @@ type DataOutput interface {
 // Example usage:
 //  field1 = input.ReadString()
 //  field2 = input.ReadString()
-//  return input.Error()
 type DataInput interface {
 	// Position returns the head position in the byte array.
 	Position() int32
@@ -318,6 +317,12 @@ type PortableWriter interface {
 
 	// WritePortableArray writes a []Portable with fieldName.
 	WritePortableArray(fieldName string, value []Portable)
+
+	// GetRawDataOutput returns raw DataOutput to write unnamed fields like
+	// IdentifiedDataSerializable does. All unnamed fields must be written after
+	// portable fields. Attempts to write named fields after GetRawDataOutput is
+	// called will panic.
+	GetRawDataOutput() DataOutput
 }
 
 // PortableReader provides a mean of reading portable fields from a binary in form of go primitives
@@ -406,4 +411,10 @@ type PortableReader interface {
 	// ReadPortableArray takes fieldName Name of the field and returns the []Portable value read.
 	// It returns nil if an error is set previously.
 	ReadPortableArray(fieldName string) []Portable
+
+	// GetRawDataInput returns raw DataInput to read unnamed fields like
+	// IdentifiedDataSerializable does. All unnamed fields must be read after
+	// portable fields. Attempts to read named fields after GetRawDataInput is
+	// called will panic.
+	GetRawDataInput() DataInput
 }

--- a/serialization/class_definition.go
+++ b/serialization/class_definition.go
@@ -85,11 +85,11 @@ func (cd *ClassDefinition) AddPortableField(fieldName string, def *ClassDefiniti
 	if def.ClassID == 0 {
 		return ihzerrors.NewIllegalArgumentError("portable class ID cannot be zero", nil)
 	}
-	return cd.AddField(newFieldDefinition(int32(len(cd.Fields)), fieldName, TypePortable, def.FactoryID, def.ClassID, cd.Version))
+	return cd.AddField(newFieldDefinition(cd.FieldCount(), fieldName, TypePortable, def.FactoryID, def.ClassID, cd.Version))
 }
 
 func (cd *ClassDefinition) addNewFieldDefinition(fieldName string, fieldType FieldDefinitionType) error {
-	return cd.AddField(newFieldDefinition(int32(len(cd.Fields)), fieldName, fieldType, 0, 0, cd.Version))
+	return cd.AddField(newFieldDefinition(cd.FieldCount(), fieldName, fieldType, 0, 0, cd.Version))
 }
 
 func (cd *ClassDefinition) AddByteArrayField(fieldName string) error {
@@ -128,11 +128,15 @@ func (cd *ClassDefinition) AddPortableArrayField(fieldName string, def *ClassDef
 	if def.ClassID == 0 {
 		return ihzerrors.NewIllegalArgumentError("portable class ID cannot be zero", nil)
 	}
-	return cd.AddField(newFieldDefinition(int32(len(cd.Fields)), fieldName, TypePortableArray, def.FactoryID, def.ClassID, cd.Version))
+	return cd.AddField(newFieldDefinition(cd.FieldCount(), fieldName, TypePortableArray, def.FactoryID, def.ClassID, cd.Version))
 }
 
 func (cd *ClassDefinition) AddStringArrayField(fieldName string) error {
 	return cd.addNewFieldDefinition(fieldName, TypeStringArray)
+}
+
+func (cd *ClassDefinition) FieldCount() int32 {
+	return int32(len(cd.Fields))
 }
 
 type FieldDefinitionType int32


### PR DESCRIPTION
`clusterService.GetMemberByUUID` may return `nil` if there is no member for the given UUID. In that case, the handler for the listener is called with the zero value of `cluster.MemberInfo`.