### PR TITLE
[1.2.0] [EASY] Set TTL return [API-1081]

### DIFF
--- a/map_it_test.go
+++ b/map_it_test.go
@@ -1060,7 +1060,7 @@ func TestMap_SetTTL(t *testing.T) {
 func TestMap_SetTTLAffected(t *testing.T) {
 	it.MapTester(t, func(t *testing.T, m *hz.Map) {
 		ctx := context.Background()
-		testcases := []struct {
+		testCases := []struct {
 			key        string
 			isEffected bool
 			expectErr  bool
@@ -1083,10 +1083,10 @@ func TestMap_SetTTLAffected(t *testing.T) {
 		_ = it.MustValue(m.Put(ctx, "happy path", "someValue"))
 		_ = it.MustValue(m.PutWithTTL(ctx, "setTTL on already expired key", "someValue", time.Millisecond))
 		time.Sleep(time.Millisecond)
-		for _, test := range testcases {
-			effected, err := m.SetTTLAffected(ctx, test.key, time.Second)
-			assert.Equal(t, test.expectErr, err != nil)
-			assert.Equal(t, test.isEffected, effected)
+		for _, tc := range testCases {
+			affected, err := m.SetTTLAffected(ctx, tc.key, time.Second)
+			assert.Equal(t, tc.expectErr, err != nil)
+			assert.Equal(t, tc.isEffected, affected)
 		}
 	})
 }

--- a/map_it_test.go
+++ b/map_it_test.go
@@ -1057,7 +1057,7 @@ func TestMap_SetTTL(t *testing.T) {
 	})
 }
 
-func TestMap_SetTTLEffected(t *testing.T) {
+func TestMap_SetTTLAffected(t *testing.T) {
 	it.MapTester(t, func(t *testing.T, m *hz.Map) {
 		ctx := context.Background()
 		testcases := []struct {
@@ -1084,7 +1084,7 @@ func TestMap_SetTTLEffected(t *testing.T) {
 		_ = it.MustValue(m.PutWithTTL(ctx, "setTTL on already expired key", "someValue", time.Millisecond))
 		time.Sleep(time.Millisecond)
 		for _, test := range testcases {
-			effected, err := m.SetTTLEffected(ctx, test.key, time.Second)
+			effected, err := m.SetTTLAffected(ctx, test.key, time.Second)
 			assert.Equal(t, test.expectErr, err != nil)
 			assert.Equal(t, test.isEffected, effected)
 		}

--- a/map_it_test.go
+++ b/map_it_test.go
@@ -1065,23 +1065,26 @@ func TestMap_SetTTLAffected(t *testing.T) {
 			isEffected    bool
 			errorExpected bool
 		}{
+			// happy path
 			{
-				key:        "happy path",
+				key:        "k1",
 				isEffected: true,
 			},
+			// setTTL on non-existing key
 			{
-				key:           "setTTL on non-existing key",
+				key:           "k2",
 				isEffected:    false,
 				errorExpected: false,
 			},
+			// setTTL on already expired key
 			{
-				key:           "setTTL on already expired key",
+				key:           "k3",
 				isEffected:    false,
 				errorExpected: false,
 			},
 		}
-		_ = it.MustValue(m.Put(ctx, "happy path", "someValue"))
-		_ = it.MustValue(m.PutWithTTL(ctx, "setTTL on already expired key", "someValue", time.Millisecond))
+		_ = it.MustValue(m.Put(ctx, "k1", "someValue"))
+		_ = it.MustValue(m.PutWithTTL(ctx, "k3", "someValue", time.Millisecond))
 		time.Sleep(time.Millisecond)
 		for _, tc := range testCases {
 			affected, err := m.SetTTLAffected(ctx, tc.key, time.Second)

--- a/map_it_test.go
+++ b/map_it_test.go
@@ -1047,7 +1047,7 @@ func TestMap_SetTTL(t *testing.T) {
 		ctx := context.Background()
 		targetValue := "value"
 		it.Must(m.Set(ctx, "key", targetValue))
-		if err := m.SetTTL(ctx, "key", 2*time.Second); err != nil {
+		if err := m.SetTTL(ctx, "key", 20*time.Second); err != nil {
 			t.Fatal(err)
 		}
 		assert.Equal(t, targetValue, it.MustValue(m.Get(ctx, "key")))
@@ -1061,23 +1061,23 @@ func TestMap_SetTTLAffected(t *testing.T) {
 	it.MapTester(t, func(t *testing.T, m *hz.Map) {
 		ctx := context.Background()
 		testCases := []struct {
-			key        string
-			isEffected bool
-			expectErr  bool
+			key           string
+			isEffected    bool
+			errorExpected bool
 		}{
 			{
 				key:        "happy path",
 				isEffected: true,
 			},
 			{
-				key:        "setTTL on non-existing key",
-				isEffected: false,
-				expectErr:  false,
+				key:           "setTTL on non-existing key",
+				isEffected:    false,
+				errorExpected: false,
 			},
 			{
-				key:        "setTTL on already expired key",
-				isEffected: false,
-				expectErr:  false,
+				key:           "setTTL on already expired key",
+				isEffected:    false,
+				errorExpected: false,
 			},
 		}
 		_ = it.MustValue(m.Put(ctx, "happy path", "someValue"))
@@ -1085,7 +1085,7 @@ func TestMap_SetTTLAffected(t *testing.T) {
 		time.Sleep(time.Millisecond)
 		for _, tc := range testCases {
 			affected, err := m.SetTTLAffected(ctx, tc.key, time.Second)
-			assert.Equal(t, tc.expectErr, err != nil)
+			assert.Equal(t, tc.errorExpected, err != nil)
 			assert.Equal(t, tc.isEffected, affected)
 		}
 	})

--- a/proxy_map.go
+++ b/proxy_map.go
@@ -830,11 +830,11 @@ func (m *Map) SetTTL(ctx context.Context, key interface{}, ttl time.Duration) er
 	}
 }
 
-// SetTTLEffected updates the TTL value of the entry specified by the given key with a new TTL value.
+// SetTTLAffected updates the TTL value of the entry specified by the given key with a new TTL value.
 // Given TTL (maximum time in seconds for this entry to stay in the map) is used.
 // Returns true if entry is affected.
 // Set ttl to 0 for infinite timeout.
-func (m *Map) SetTTLEffected(ctx context.Context, key interface{}, ttl time.Duration) (bool, error) {
+func (m *Map) SetTTLAffected(ctx context.Context, key interface{}, ttl time.Duration) (bool, error) {
 	keyData, err := m.validateAndSerialize(key)
 	if err != nil {
 		return false, err

--- a/proxy_map.go
+++ b/proxy_map.go
@@ -830,6 +830,23 @@ func (m *Map) SetTTL(ctx context.Context, key interface{}, ttl time.Duration) er
 	}
 }
 
+// SetTTLEffected updates the TTL value of the entry specified by the given key with a new TTL value.
+// Given TTL (maximum time in seconds for this entry to stay in the map) is used.
+// Returns true if entry is affected.
+// Set ttl to 0 for infinite timeout.
+func (m *Map) SetTTLEffected(ctx context.Context, key interface{}, ttl time.Duration) (bool, error) {
+	keyData, err := m.validateAndSerialize(key)
+	if err != nil {
+		return false, err
+	}
+	request := codec.EncodeMapSetTtlRequest(m.name, keyData, ttl.Milliseconds())
+	resp, err := m.invokeOnKey(ctx, request, keyData)
+	if err != nil {
+		return false, err
+	}
+	return codec.DecodeMapSetTtlResponse(resp), nil
+}
+
 // SetWithTTL sets the value for the given key.
 // Given TTL (maximum time in seconds for this entry to stay in the map) is used.
 // Set ttl to 0 for infinite timeout.


### PR DESCRIPTION
Fixes #701

This work introduces "SetTTLAffected" functionality to "Map" API. We are introducing this to let users access to the boolean response of the server. We did not want to break the existing api, hence this is created as a new function.