### PR TITLE
fix test concurrency problem

### DIFF
--- a/internal/event/dispatch_service_test.go
+++ b/internal/event/dispatch_service_test.go
@@ -123,7 +123,7 @@ func TestDispatchServiceOrderIsGuaranteed(t *testing.T) {
 }
 
 func TestDispatchServiceAllPublishedAreHandledBeforeClose(t *testing.T) {
-	goroutineCount := 10000
+	goroutineCount := 10_000
 	dispatchCount := int32(0)
 	handler := func(event event.Event) {
 		atomic.AddInt32(&dispatchCount, 1)


### PR DESCRIPTION
It seems there is a race condition on TestClientEventHandlingOrder. This PR addresses this problem. Memory leak check is disabled until we find a healthy upper limit to test for.