### PR TITLE
Prevent panic when queries run concurrently

### DIFF
--- a/internal/sql/driver/conn.go
+++ b/internal/sql/driver/conn.go
@@ -61,7 +61,7 @@ func (c *Conn) Prepare(query string) (driver.Stmt, error) {
 }
 
 func (c *Conn) Close() error {
-	return c.ic.Shutdown(context.Background())
+	return nil
 }
 
 func (c Conn) Begin() (driver.Tx, error) {

--- a/internal/sql/driver/connector.go
+++ b/internal/sql/driver/connector.go
@@ -52,6 +52,15 @@ func (c *Connector) Connect(ctx context.Context) (driver.Conn, error) {
 	return c.conn, nil
 }
 
+func (c *Connector) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.conn != nil {
+		return c.conn.ic.Shutdown(context.Background())
+	}
+	return nil
+}
+
 func (c Connector) Driver() driver.Driver {
 	return c.drv
 }


### PR DESCRIPTION
Moved client shutdown code to db close, instead of conn close to prevent a panic when queries run concurrently.