### PR TITLE
Implement CheckNamedValue for Conn

### DIFF
--- a/internal/it/map.go
+++ b/internal/it/map.go
@@ -18,6 +18,7 @@ package it
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"go.uber.org/goleak"
@@ -87,4 +88,16 @@ func GetClientMapWithConfig(mapName string, config *hz.Config) (*hz.Client, *hz.
 	} else {
 		return client, m
 	}
+}
+
+func MapSetOnServer(clusterID string, mapName string, key, value string) *Response {
+	script := fmt.Sprintf(`
+		var map = instance_0.getMap("%s");
+        map.set(%s, %s);
+	`, mapName, key, value)
+	resp, err := rc.ExecuteOnController(context.Background(), clusterID, script, Lang_JAVASCRIPT)
+	if err != nil {
+		panic(fmt.Errorf("executing on controller: %w", err))
+	}
+	return resp
 }

--- a/internal/it/serialization.go
+++ b/internal/it/serialization.go
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package it
+
+import (
+	"testing"
+
+	"github.com/hazelcast/hazelcast-go-client"
+)
+
+func SerializationTester(t *testing.T, f func(t *testing.T, config hazelcast.Config, clusterID, mapName string)) {
+	ensureRemoteController(true)
+	mapName := NewUniqueObjectName("map")
+	f(t, defaultTestCluster.DefaultConfig(), defaultTestCluster.ClusterID, mapName)
+}

--- a/internal/serialization/big_int.go
+++ b/internal/serialization/big_int.go
@@ -43,6 +43,9 @@ func NewBigInt(b *big.Int) BigInt {
 // GoBigInt returns a big.Int from this BigInt
 func (b BigInt) GoBigInt() *big.Int {
 	bb := new(big.Int)
+	if len(b.mag) == 0 {
+		return bb
+	}
 	bb.SetBits(int32ArrToWords(b.mag))
 	if b.signum < 0 {
 		bb.Neg(bb)

--- a/internal/serialization/default_serializer.go
+++ b/internal/serialization/default_serializer.go
@@ -503,10 +503,6 @@ func (JavaArrayListSerializer) Read(input serialization.DataInput) interface{} {
 
 func (JavaArrayListSerializer) Write(o serialization.DataOutput, i interface{}) {
 	v := i.([]interface{})
-	if v == nil {
-		o.WriteInt32(nilArrayLength)
-		return
-	}
 	length := len(v)
 	o.WriteInt32(int32(length))
 	for j := 0; j < length; j++ {

--- a/internal/serialization/default_serializer.go
+++ b/internal/serialization/default_serializer.go
@@ -467,6 +467,25 @@ func (JavaLinkedListSerializer) Write(output serialization.DataOutput, i interfa
 	// no-op
 }
 
+type JavaArraySerializer struct{}
+
+func (JavaArraySerializer) ID() int32 {
+	return TypeJavaArray
+}
+
+func (JavaArraySerializer) Read(input serialization.DataInput) interface{} {
+	count := int(input.ReadInt32())
+	res := make([]interface{}, count)
+	for i := 0; i < count; i++ {
+		res[i] = input.ReadObject()
+	}
+	return res
+}
+
+func (JavaArraySerializer) Write(output serialization.DataOutput, i interface{}) {
+	// no-op
+}
+
 type JavaArrayListSerializer struct{}
 
 func (JavaArrayListSerializer) ID() int32 {
@@ -482,8 +501,17 @@ func (JavaArrayListSerializer) Read(input serialization.DataInput) interface{} {
 	return res
 }
 
-func (JavaArrayListSerializer) Write(output serialization.DataOutput, i interface{}) {
-	// no-op
+func (JavaArrayListSerializer) Write(o serialization.DataOutput, i interface{}) {
+	v := i.([]interface{})
+	length := len(v)
+	if length == 0 {
+		o.WriteInt32(nilArrayLength)
+		return
+	}
+	o.WriteInt32(int32(length))
+	for j := 0; j < length; j++ {
+		o.WriteObject(v[j])
+	}
 }
 
 type JavaLocalDateSerializer struct{}
@@ -514,32 +542,32 @@ func (JavaLocalTimeSerializer) Write(output serialization.DataOutput, i interfac
 	WriteTime(output, i.(time.Time))
 }
 
-type TypeJavaLocalDateTimeSerializer struct{}
+type JavaLocalDateTimeSerializer struct{}
 
-func (TypeJavaLocalDateTimeSerializer) ID() int32 {
+func (JavaLocalDateTimeSerializer) ID() int32 {
 	return TypeJavaLocalDateTime
 }
 
-func (TypeJavaLocalDateTimeSerializer) Read(input serialization.DataInput) interface{} {
+func (JavaLocalDateTimeSerializer) Read(input serialization.DataInput) interface{} {
 	return ReadTimestamp(input)
 }
 
-func (TypeJavaLocalDateTimeSerializer) Write(output serialization.DataOutput, i interface{}) {
+func (JavaLocalDateTimeSerializer) Write(output serialization.DataOutput, i interface{}) {
 	t := i.(time.Time)
 	WriteTimestamp(output, t)
 }
 
-type TypeJavaOffsetDateTimeSerializer struct{}
+type JavaOffsetDateTimeSerializer struct{}
 
-func (TypeJavaOffsetDateTimeSerializer) ID() int32 {
+func (JavaOffsetDateTimeSerializer) ID() int32 {
 	return TypeJavaOffsetDateTime
 }
 
-func (TypeJavaOffsetDateTimeSerializer) Read(input serialization.DataInput) interface{} {
+func (JavaOffsetDateTimeSerializer) Read(input serialization.DataInput) interface{} {
 	return ReadTimestampWithTimezone(input)
 }
 
-func (TypeJavaOffsetDateTimeSerializer) Write(output serialization.DataOutput, i interface{}) {
+func (JavaOffsetDateTimeSerializer) Write(output serialization.DataOutput, i interface{}) {
 	t := i.(time.Time)
 	WriteTimestampWithTimezone(output, t)
 }

--- a/internal/serialization/default_serializer.go
+++ b/internal/serialization/default_serializer.go
@@ -503,11 +503,11 @@ func (JavaArrayListSerializer) Read(input serialization.DataInput) interface{} {
 
 func (JavaArrayListSerializer) Write(o serialization.DataOutput, i interface{}) {
 	v := i.([]interface{})
-	length := len(v)
-	if length == 0 {
+	if v == nil {
 		o.WriteInt32(nilArrayLength)
 		return
 	}
+	length := len(v)
 	o.WriteInt32(int32(length))
 	for j := 0; j < length; j++ {
 		o.WriteObject(v[j])

--- a/internal/serialization/object_data.go
+++ b/internal/serialization/object_data.go
@@ -771,6 +771,9 @@ func WriteTimestampWithTimezone(o serialization.DataOutput, t time.Time) {
 }
 
 func WriteBigInt(o serialization.DataOutput, b *big.Int) {
+	if b == nil {
+		b = new(big.Int)
+	}
 	o.WriteByteArray(BigIntToJavaBytes(b))
 }
 

--- a/internal/serialization/serialization.go
+++ b/internal/serialization/serialization.go
@@ -205,10 +205,16 @@ func (s *Service) lookupBuiltinDeserializer(typeID int32) pubserialization.Seria
 		return javaDateSerializer
 	case TypeJavaBigInteger:
 		return javaBigIntegerSerializer
+	case TypeJavaDecimal:
+		return javaDecimalSerializer
 	case TypeJSONSerialization:
 		return jsonSerializer
+	case TypeJavaArray:
+		return javaArraySerializer
 	case TypeJavaArrayList:
 		return javaArrayListSerializer
+	case TypeJavaLinkedList:
+		return javaLinkedListSerializer
 	case TypeJavaLocalDate:
 		return javaLocalDateSerializer
 	case TypeJavaLocalTime:
@@ -217,6 +223,8 @@ func (s *Service) lookupBuiltinDeserializer(typeID int32) pubserialization.Seria
 		return javaLocalDateTimeSerializer
 	case TypeJavaOffsetDateTime:
 		return javaOffsetDateTimeSerializer
+	case TypeJavaClass:
+		return javaClassSerializer
 	case TypeGobSerialization:
 		return gobSerializer
 	}
@@ -338,6 +346,8 @@ func (s *Service) lookupBuiltinSerializer(obj interface{}) pubserialization.Seri
 		return float32ArraySerializer
 	case []float64:
 		return float64ArraySerializer
+	case []interface{}:
+		return javaArrayListSerializer
 	case types.UUID:
 		return uuidSerializer
 	case time.Time:
@@ -404,9 +414,12 @@ var jsonSerializer = &JSONValueSerializer{}
 var javaDateSerializer = &JavaDateSerializer{}
 var javaBigIntegerSerializer = &JavaBigIntegerSerializer{}
 var javaDecimalSerializer = &JavaDecimalSerializer{}
+var javaClassSerializer = &JavaClassSerializer{}
+var javaArraySerializer = &JavaArraySerializer{}
 var javaArrayListSerializer = &JavaArrayListSerializer{}
+var javaLinkedListSerializer = &JavaLinkedListSerializer{}
 var javaLocalDateSerializer = &JavaLocalDateSerializer{}
 var javaLocalTimeSerializer = &JavaLocalTimeSerializer{}
-var javaLocalDateTimeSerializer = &TypeJavaLocalDateTimeSerializer{}
-var javaOffsetDateTimeSerializer = &TypeJavaOffsetDateTimeSerializer{}
+var javaLocalDateTimeSerializer = &JavaLocalDateTimeSerializer{}
+var javaOffsetDateTimeSerializer = &JavaOffsetDateTimeSerializer{}
 var gobSerializer = &GobSerializer{}

--- a/internal/serialization/serialization_consts.go
+++ b/internal/serialization/serialization_consts.go
@@ -43,6 +43,7 @@ const (
 	TypeJavaDate           = -25
 	TypeJavaBigInteger     = -26
 	TypeJavaDecimal        = -27
+	TypeJavaArray          = -28
 	TypeJavaArrayList      = -29
 	TypeJavaLinkedList     = -30
 	TypeJavaLocalDate      = -51

--- a/internal/serialization/serialization_improvements_test.go
+++ b/internal/serialization/serialization_improvements_test.go
@@ -94,6 +94,7 @@ func TestSerializationImprovements_JavaDate(t *testing.T) {
 
 func TestSerializationImprovements(t *testing.T) {
 	serializationImprovementsTester(func(ss *iserialization.Service) {
+		var dec types.Decimal
 		testCases := []struct {
 			input  interface{}
 			target interface{}
@@ -120,9 +121,29 @@ func TestSerializationImprovements(t *testing.T) {
 				target: time.Date(2021, 2, 10, 1, 2, 3, 4, time.FixedZone("", -3*60*60)),
 			},
 			{
+				input:  []interface{}{"foo", int64(22)},
+				name:   "JavaArrayList",
+				target: []interface{}{"foo", int64(22)},
+			},
+			{
 				input:  big.NewInt(-10_000_000),
 				name:   "JavaBigInteger",
 				target: big.NewInt(-10_000_000),
+			},
+			{
+				input:  (*big.Int)(nil),
+				name:   "JavaBigInteger-nil",
+				target: new(big.Int),
+			},
+			{
+				input:  types.NewDecimal(big.NewInt(111_111_111), 222_222_222),
+				name:   "JavaBigDecimal",
+				target: types.NewDecimal(big.NewInt(111_111_111), 222_222_222),
+			},
+			{
+				input:  dec,
+				name:   "JavaBigDecimal-nil",
+				target: types.NewDecimal(new(big.Int), 0),
 			},
 		}
 		for _, tc := range testCases {
@@ -140,10 +161,9 @@ func TestSerializationImprovements(t *testing.T) {
 					if !tt.Equal(ii) {
 						t.Fatalf("%s != %s", tt.String(), ii.String())
 					}
-				} else {
-					assert.Equal(t, tc.target, tc.input)
+					return
 				}
-
+				assert.Equal(t, tc.target, value)
 			})
 		}
 

--- a/internal/serialization/serialization_improvements_test.go
+++ b/internal/serialization/serialization_improvements_test.go
@@ -126,6 +126,11 @@ func TestSerializationImprovements(t *testing.T) {
 				target: []interface{}{"foo", int64(22)},
 			},
 			{
+				input:  []interface{}{},
+				name:   "JavaArrayList-empty",
+				target: []interface{}{},
+			},
+			{
 				input:  big.NewInt(-10_000_000),
 				name:   "JavaBigInteger",
 				target: big.NewInt(-10_000_000),

--- a/internal/serialization/server_it_test.go
+++ b/internal/serialization/server_it_test.go
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package serialization_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/hazelcast/hazelcast-go-client"
+	"github.com/hazelcast/hazelcast-go-client/internal/it"
+)
+
+func TestServer(t *testing.T) {
+	testCases := []struct {
+		name   string
+		input  string
+		target interface{}
+	}{
+		{
+			name:   "array",
+			input:  `Java.to(["foo", 38], "java.lang.Object[]")`,
+			target: []interface{}{"foo", int32(38)},
+		},
+		{
+			name:   "linked-list",
+			input:  `new java.util.LinkedList(java.util.Arrays.asList("foo", 38))`,
+			target: []interface{}{"foo", int32(38)},
+		},
+		{
+			name:   "class",
+			input:  `java.lang.String.class`,
+			target: "java.lang.String",
+		},
+	}
+	it.SerializationTester(t, func(t *testing.T, config hazelcast.Config, clusterID, mapName string) {
+		ctx := context.Background()
+		client := it.MustClient(hazelcast.StartNewClientWithConfig(ctx, config))
+		m := it.MustValue(client.GetMap(ctx, mapName)).(*hazelcast.Map)
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				key := fmt.Sprintf(`"%s"`, tc.name)
+				res := it.MapSetOnServer(clusterID, mapName, key, tc.input)
+				if !res.GetSuccess() {
+					t.Fatalf("could not set: %s, %s", key, res.GetMessage())
+				}
+				v := it.MustValue(m.Get(ctx, tc.name))
+				assert.Equal(t, tc.target, v)
+			})
+		}
+	})
+}

--- a/internal/serialization/server_it_test.go
+++ b/internal/serialization/server_it_test.go
@@ -44,6 +44,11 @@ func TestServer(t *testing.T) {
 			target: []interface{}{"foo", int32(38)},
 		},
 		{
+			name:   "linked-list-empty",
+			input:  `new java.util.LinkedList()`,
+			target: []interface{}{},
+		},
+		{
 			name:   "class",
 			input:  `java.lang.String.class`,
 			target: "java.lang.String",

--- a/internal/sql/driver/conn.go
+++ b/internal/sql/driver/conn.go
@@ -21,7 +21,9 @@ import (
 	"database/sql/driver"
 	"fmt"
 
+	"github.com/hazelcast/hazelcast-go-client/internal/check"
 	"github.com/hazelcast/hazelcast-go-client/internal/client"
+	ihzerrors "github.com/hazelcast/hazelcast-go-client/internal/hzerrors"
 )
 
 var (
@@ -31,6 +33,13 @@ var (
 type Conn struct {
 	ic *client.Client
 	ss *SQLService
+}
+
+func (c *Conn) CheckNamedValue(v *driver.NamedValue) error {
+	if check.Nil(v.Value) {
+		return ihzerrors.NewIllegalArgumentError("nil arg is not allowed", nil)
+	}
+	return nil
 }
 
 func newConn(name string) (*Conn, error) {


### PR DESCRIPTION
This PR implements `CheckNamedValue` on `driver.Conn` so any value supported by Hazelcast is supported (in contrast with the limited set of types database/sql provides).