### PR TITLE
[1.2.0] add "RemoveEntry" and "ContainsEntry" APIs to MultiMap [API-478]

### DIFF
--- a/examples/multimap/main.go
+++ b/examples/multimap/main.go
@@ -24,7 +24,6 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-
 	// Populate the map.
 	success, err := m.Put(ctx, "key", "value1")
 	if err != nil {
@@ -40,14 +39,18 @@ func main() {
 	if !success {
 		log.Fatal("multi-map put operation failed")
 	}
-
 	// Get both values under the same key.
 	values, err := m.Get(ctx, "key")
 	if err != nil {
 		log.Fatal(err)
 	}
-
 	// An interface slice contains the values.
 	// []interface {}{"value2", "value1"}
 	fmt.Printf("%#v", values)
+	// Check existence of an entry
+	ok, err := m.ContainsEntry(ctx, "key", "value1")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("entry found:%t", ok)
 }

--- a/multi_map_it_test.go
+++ b/multi_map_it_test.go
@@ -132,7 +132,7 @@ func TestMultiMap_RemoveEntry(t *testing.T) {
 		it.Must(m.PutAll(ctx, "key", targetValue, otherValue))
 		value := it.MustValue(m.Get(ctx, "key"))
 		assert.ElementsMatch(t, value, []interface{}{targetValue, otherValue})
-		// Remove only one of the values that corresponds to the key
+		// Remove only one of the values that corresponds to the key.
 		ok, err := m.RemoveEntry(ctx, "key", targetValue)
 		if err != nil {
 			t.Fatal(err)
@@ -140,7 +140,7 @@ func TestMultiMap_RemoveEntry(t *testing.T) {
 		assert.True(t, ok)
 		remaining := it.MustValue(m.Get(ctx, "key"))
 		assert.Equal(t, []interface{}{otherValue}, remaining)
-		// Call should have no effect, expect "false" return value
+		// Call should have no effect, expect it to return "false".
 		ok, err = m.RemoveEntry(ctx, "key", targetValue)
 		if err != nil {
 			t.Fatal(err)

--- a/proxy_multi_map.go
+++ b/proxy_multi_map.go
@@ -159,7 +159,7 @@ func (m *MultiMap) ContainsValue(ctx context.Context, value interface{}) (bool, 
 	}
 }
 
-// ContainsEntry returns true if the map contains an entry with the given key and value.
+// ContainsEntry returns true if the multi-map contains an entry with the given key and value.
 func (m *MultiMap) ContainsEntry(ctx context.Context, key interface{}, value interface{}) (bool, error) {
 	lid := extractLockID(ctx)
 	keyData, err := m.validateAndSerialize(key)
@@ -175,12 +175,12 @@ func (m *MultiMap) ContainsEntry(ctx context.Context, key interface{}, value int
 	if err != nil {
 		return false, err
 	}
-	return codec.DecodeMultiMapContainsKeyResponse(response), nil
+	return codec.DecodeMultiMapContainsEntryResponse(response), nil
 }
 
 // Delete removes the mapping for a key from this multi-map if it is present.
 // Unlike remove(object), this operation does not return the removed value, which avoids the serialization cost of
-// the returned value. If the removed value will not be used, a delete operation is preferred over a remove
+// the returned value. If the removed value will not be used, delete operation is preferred over remove
 // operation for better performance.
 func (m *MultiMap) Delete(ctx context.Context, key interface{}) error {
 	lid := extractLockID(ctx)
@@ -327,7 +327,7 @@ func (m *MultiMap) PutAll(ctx context.Context, key interface{}, values ...interf
 	return nil
 }
 
-// Remove deletes all the values  corresponding to the given key and returns it.
+// Remove deletes all the values corresponding to the given key and returns them as a slice.
 func (m *MultiMap) Remove(ctx context.Context, key interface{}) ([]interface{}, error) {
 	lid := extractLockID(ctx)
 	if keyData, err := m.validateAndSerialize(key); err != nil {
@@ -342,7 +342,7 @@ func (m *MultiMap) Remove(ctx context.Context, key interface{}) ([]interface{}, 
 	}
 }
 
-// RemoveEntry removes the specified value for the given key and returns true if call had an effect
+// RemoveEntry removes the specified value for the given key and returns true if call had an effect.
 func (m *MultiMap) RemoveEntry(ctx context.Context, key interface{}, value interface{}) (bool, error) {
 	lid := extractLockID(ctx)
 	keyData, err := m.validateAndSerialize(key)


### PR DESCRIPTION
add "RemoveEntry" and "ContainsEntry" APIs to MultiMap [API-478]

[API-478]: https://hazelcast.atlassian.net/browse/API-478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ