### PR TITLE
[1.2.0] Fix SSL mode for some tests

### DIFF
--- a/client_internals_it_test.go
+++ b/client_internals_it_test.go
@@ -91,6 +91,9 @@ func testListenersAfterClientDisconnected(t *testing.T, memberHost string, clien
 	const heartBeatSec = 6
 	// launch the cluster
 	memberConfig := listenersAfterClientDisconnectedXMLConfig(t.Name(), memberHost, port, heartBeatSec)
+	if it.SSLEnabled() {
+		memberConfig = listenersAfterClientDisconnectedXMLSSLConfig(t.Name(), memberHost, port, heartBeatSec)
+	}
 	tc := it.StartNewClusterWithConfig(1, memberConfig, port)
 	// create and start the client
 	config := tc.DefaultConfig()

--- a/client_it_test.go
+++ b/client_it_test.go
@@ -642,7 +642,7 @@ func TestClientFixConnection(t *testing.T) {
 	port := 20701 + id*10
 	cls := it.StartNewClusterWithOptions(clusterName, int(port), memberCount)
 	defer cls.Shutdown()
-	config := hz.Config{}
+	config := cls.DefaultConfig()
 	config.Cluster.Network.SetAddresses(fmt.Sprintf("localhost:%d", port+1))
 	config.Cluster.Name = clusterName
 	config.AddMembershipListener(func(event cluster.MembershipStateChanged) {

--- a/client_it_test.go
+++ b/client_it_test.go
@@ -863,3 +863,32 @@ func listenersAfterClientDisconnectedXMLConfig(clusterName, publicAddr string, p
         </hazelcast>
 	`, clusterName, publicAddr, port, heartBeatSec)
 }
+
+func listenersAfterClientDisconnectedXMLSSLConfig(clusterName, publicAddr string, port, heartBeatSec int) string {
+	return fmt.Sprintf(`
+        <hazelcast xmlns="http://www.hazelcast.com/schema/config"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://www.hazelcast.com/schema/config
+            http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd">
+            <cluster-name>%s</cluster-name>
+            <network>
+				<public-address>%s</public-address>
+				<port>%d</port>
+				<ssl enabled="true">
+					<factory-class-name>
+						com.hazelcast.nio.ssl.ClasspathSSLContextFactory
+					</factory-class-name>
+					<properties>
+						<property name="keyStore">com/hazelcast/nio/ssl-mutual-auth/server1.keystore</property>
+						<property name="keyStorePassword">password</property>
+						<property name="keyManagerAlgorithm">SunX509</property>
+						<property name="protocol">TLSv1.2</property>
+					</properties>
+				</ssl>
+            </network>
+			<properties>
+				<property name="hazelcast.heartbeat.interval.seconds">%d</property>
+			</properties>
+        </hazelcast>
+	`, clusterName, publicAddr, port, heartBeatSec)
+}

--- a/internal/it/serialization.go
+++ b/internal/it/serialization.go
@@ -25,8 +25,5 @@ import (
 func SerializationTester(t *testing.T, f func(t *testing.T, config hazelcast.Config, clusterID, mapName string)) {
 	ensureRemoteController(true)
 	mapName := NewUniqueObjectName("map")
-	config := defaultTestCluster.DefaultConfig()
-	// SSL is never used with serialization tests.
-	config.Cluster.Network.SSL.Enabled = false
 	f(t, defaultTestCluster.DefaultConfig(), defaultTestCluster.ClusterID, mapName)
 }

--- a/internal/it/serialization.go
+++ b/internal/it/serialization.go
@@ -25,5 +25,8 @@ import (
 func SerializationTester(t *testing.T, f func(t *testing.T, config hazelcast.Config, clusterID, mapName string)) {
 	ensureRemoteController(true)
 	mapName := NewUniqueObjectName("map")
+	config := defaultTestCluster.DefaultConfig()
+	// SSL is never used with serialization tests.
+	config.Cluster.Network.SSL.Enabled = false
 	f(t, defaultTestCluster.DefaultConfig(), defaultTestCluster.ClusterID, mapName)
 }

--- a/sql/driver/driver_it_test.go
+++ b/sql/driver/driver_it_test.go
@@ -18,6 +18,7 @@ package driver_test
 
 import (
 	"context"
+	"crypto/tls"
 	"database/sql"
 	"fmt"
 	"math/big"
@@ -507,6 +508,14 @@ func testSQLQuery(t *testing.T, ctx context.Context, keyFmt, valueFmt string, ke
 			t.Fatal(err)
 		}
 		defer driver.SetSerializationConfig(nil)
+		if it.SSLEnabled() {
+			sslc := &cluster.SSLConfig{Enabled: true}
+			sslc.SetTLSConfig(&tls.Config{InsecureSkipVerify: true})
+			if err := driver.SetSSLConfig(sslc); err != nil {
+				t.Fatal(err)
+			}
+			defer driver.SetSSLConfig(nil)
+		}
 		db := mustDB(sql.Open("hazelcast", dsn))
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
SSL mode (turned on by `ENABLE_SSL=1`) didn't work for some of the tests. Fixed the tests so all tests work with the SSL Mode:

```
HZ_VERSION=5.0 ENABLE_SSL=1 make test-all
```