### PR TITLE
[1.2.0] [EASY] Respect the context in query result after the first page.

### DIFF
--- a/internal/sql/driver/result.go
+++ b/internal/sql/driver/result.go
@@ -66,7 +66,7 @@ func NewQueryResult(ctx context.Context, qid sql.QueryID, md sql.RowMetadata, pa
 		select {
 		case <-ctx.Done():
 			// ignoring the error here, since there is nothing to do on error.
-			//_ = qr.Close()
+			_ = qr.Close()
 		case <-doneCh:
 			return
 		}

--- a/internal/sql/driver/result.go
+++ b/internal/sql/driver/result.go
@@ -61,11 +61,12 @@ func NewQueryResult(ctx context.Context, qid sql.QueryID, md sql.RowMetadata, pa
 		cursorBufferSize: cbs,
 		index:            0,
 	}
+	// the following goroutine cancels the query when the context is canceled.
 	go func() {
 		select {
 		case <-ctx.Done():
 			// ignoring the error here, since there is nothing to do on error.
-			_ = qr.Close()
+			//_ = qr.Close()
 		case <-doneCh:
 			return
 		}

--- a/internal/sql/driver/sql_service.go
+++ b/internal/sql/driver/sql_service.go
@@ -94,9 +94,9 @@ func (s *SQLService) QuerySQL(ctx context.Context, query string, params []driver
 	return resp.(*QueryResult), nil
 }
 
-func (s *SQLService) fetch(qid isql.QueryID, conn *cluster.Connection, cbs int32) (*isql.Page, error) {
+func (s *SQLService) fetch(ctx context.Context, qid isql.QueryID, conn *cluster.Connection, cbs int32) (*isql.Page, error) {
 	req := codec.EncodeSqlFetchRequest(qid, cbs)
-	resp, err := s.invokeOnConnection(context.Background(), req, conn)
+	resp, err := s.invokeOnConnection(ctx, req, conn)
 	if err != nil {
 		return nil, err
 	}
@@ -141,7 +141,7 @@ func (s *SQLService) executeSQL(ctx context.Context, query string, resultType by
 		return &ExecResult{UpdateCount: updateCount}, nil
 	}
 	md := isql.RowMetadata{Columns: metadata}
-	return NewQueryResult(qid, md, page, s, conn, cursorBufferSize)
+	return NewQueryResult(ctx, qid, md, page, s, conn, cursorBufferSize)
 }
 
 func (s *SQLService) serializeParams(params []driver.Value) ([]*iserialization.Data, error) {

--- a/sql/driver/driver_it_test.go
+++ b/sql/driver/driver_it_test.go
@@ -460,6 +460,35 @@ func TestSetSSLConfig(t *testing.T) {
 	}
 }
 
+func TestContextCancelAfterFirstPage(t *testing.T) {
+	/*
+		This test ensures context cancellation works for results after the first page (fetch operation).
+		generate_stream function generates N rows per second. Since the context times out after 1100 ms, it should be canceled right after getting the first number.
+	*/
+	it.SkipIf(t, "hz < 5.0")
+	it.SQLTester(t, func(t *testing.T, client *hz.Client, config *hz.Config, m *hz.Map, mapName string) {
+		db := driver.Open(*config)
+		defer db.Close()
+		ctx, cancel := context.WithTimeout(context.Background(), 1100*time.Millisecond)
+		defer cancel()
+		tic := time.Now()
+		rows, err := db.QueryContext(ctx, "select * from table(generate_stream(1))")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			// do nothing
+		}
+		toc := time.Now()
+		took := toc.Sub(tic).Milliseconds()
+		if took >= 2000 {
+			// the time should be less than 200 milliseconds (two pages of results), which proves that the query is canceled after the first page.
+			t.Fatalf("the passed time should take less than 2000 milliseconds, but it is: %d", took)
+		}
+	})
+}
+
 func TestConcurrentQueries(t *testing.T) {
 	it.SkipIf(t, "hz < 5.0")
 	it.SQLTester(t, func(t *testing.T, client *hz.Client, config *hz.Config, m *hz.Map, mapName string) {

--- a/sql/driver/driver_it_test.go
+++ b/sql/driver/driver_it_test.go
@@ -469,7 +469,7 @@ func TestContextCancelAfterFirstPage(t *testing.T) {
 	it.SQLTester(t, func(t *testing.T, client *hz.Client, config *hz.Config, m *hz.Map, mapName string) {
 		db := driver.Open(*config)
 		defer db.Close()
-		ctx, cancel := context.WithTimeout(context.Background(), 1100*time.Millisecond)
+		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		tic := time.Now()
 		rows, err := db.QueryContext(ctx, "select * from table(generate_stream(1))")
@@ -478,12 +478,12 @@ func TestContextCancelAfterFirstPage(t *testing.T) {
 		}
 		defer rows.Close()
 		for rows.Next() {
-			// do nothing
+			cancel()
 		}
 		toc := time.Now()
 		took := toc.Sub(tic).Milliseconds()
 		if took >= 2000 {
-			// the time should be less than 200 milliseconds (two pages of results), which proves that the query is canceled after the first page.
+			// the time should be less than 2000 milliseconds (two pages of results), which proves that the query is canceled after the first page.
 			t.Fatalf("the passed time should take less than 2000 milliseconds, but it is: %d", took)
 		}
 	})


### PR DESCRIPTION
When iterating over the pages of results, the context is not respected after the initial page. As reported by @utku-caglayan,  that's especially problematic in streaming use case, when there is no new row in the stream.

This PR fixes that by updating `QueryResult` constructor to spawn a goroutine which cancels the query when the context is canceled.