### PR TITLE
Conflict with documentation on methods which use `connectToObject` [API-1180]

### DIFF
--- a/multi_map_it_test.go
+++ b/multi_map_it_test.go
@@ -619,3 +619,27 @@ func TestMultiMap_MultiMapEntryListener(t *testing.T) {
 		}
 	})
 }
+
+func TestMultiMap_GetObservation(t *testing.T) {
+	it.MultiMapTester(t, func(t *testing.T, m *hz.MultiMap) {
+		ctx := context.Background()
+		// make sure that underlying multi-map is empty
+		assert.EqualValues(t, 0, it.MustValue(m.Size(ctx)))
+		targetValues := map[string][]interface{}{
+			// represent nil return value
+			"nil": nil,
+			// represent return object with zero length and capacity
+			"object": make([]interface{}, 0),
+		}
+		// represent dummy non-existing key
+		nonExistingKey := "dummyKey"
+		// try to get non-existing key values
+		getResult := it.MustValue(m.Get(ctx, nonExistingKey))
+		// line below supposed to be wrong assertion, because according to doc it should return nil
+		nilResult := assert.NotEqual(t, targetValues["nil"], getResult)
+		// line below should not be correct according to documentation
+		objResult := assert.Equal(t, targetValues["object"], getResult)
+		// proves there is conflict according to documentation
+		assert.Equal(t, nilResult, objResult)
+	})
+}

--- a/multi_map_it_test.go
+++ b/multi_map_it_test.go
@@ -635,9 +635,11 @@ func TestMultiMap_GetObservation(t *testing.T) {
 		nonExistingKey := "dummyKey"
 		// try to get non-existing key values
 		getResult := it.MustValue(m.Get(ctx, nonExistingKey))
-		// line below supposed to be wrong assertion, because according to doc it should return nil
+		// line below supposed to be correct assertion but asserting NotEqual make no sense
+		// for the sake of continuity (not fail), asserted with NotEqual
 		nilResult := assert.NotEqual(t, targetValues["nil"], getResult)
 		// line below should not be correct according to documentation
+		// But it does not fail because actual implementation return object
 		objResult := assert.Equal(t, targetValues["object"], getResult)
 		// proves there is conflict according to documentation
 		assert.Equal(t, nilResult, objResult)


### PR DESCRIPTION
According to documentation;
- `m.Get(...)` should return `nil`, if the given key does not exist on the multi-map.
-  But actual implementation is different, because of underling implementation of [convertToObjects](https://github.com/hazelcast/hazelcast-go-client/blob/b0d78a4eb0a1996271bdefb7a794e43bee65f5b1/proxy.go#L308). It creates a slice as `decodedValues := make([]interface{}, len(values))`, even if given `values` is zero, it creates an object and end up becoming non-nil. 