### PR TITLE
Refactor Event Handling Order Test with correct assumptions [API-1221]

### DIFF
--- a/client_it_test.go
+++ b/client_it_test.go
@@ -206,11 +206,14 @@ func TestClientEventHandlingOrder(t *testing.T) {
 			// event journal to keep track of order of the published events
 			journal = make([]*hz.EntryNotified, 0, eventCount)
 			// wait for all events to be processed
-			wg sync.WaitGroup
+			wg  sync.WaitGroup
+			mut sync.Mutex
 		)
 		wg.Add(eventCount)
 		handler := func(event *hz.EntryNotified) {
+			mut.Lock()
 			journal = append(journal, event)
+			mut.Unlock()
 			wg.Done()
 		}
 		it.MustValue(m.AddEntryListener(ctx, lc, handler))

--- a/client_it_test.go
+++ b/client_it_test.go
@@ -207,9 +207,9 @@ func TestClientEventHandlingOrder(t *testing.T) {
 	// Create custom cluster, and client from it
 	cls := it.StartNewClusterWithOptions("event-order-test-cluster", 15701, it.MemberCount())
 	defer cls.Shutdown()
-	cnfg := cls.DefaultConfig()
+	cfg := cls.DefaultConfig()
 	ctx := context.Background()
-	c := it.MustValue(hz.StartNewClientWithConfig(ctx, cnfg)).(*hz.Client)
+	c := it.MustValue(hz.StartNewClientWithConfig(ctx, cfg)).(*hz.Client)
 	defer c.Shutdown(ctx)
 	// Create test map
 	m := it.MustValue(c.GetMap(ctx, "my-map")).(*hz.Map)
@@ -236,7 +236,7 @@ func TestClientEventHandlingOrder(t *testing.T) {
 		it.MustValue(m.Remove(ctx, "sameKey"))
 	}
 	wg.Wait()
-	assert.Equal(t, 0, len(journal)%2)
+	assert.Equal(t, eventCount, len(journal))
 	for i := 0; i < eventCount; i += 2 {
 		assert.Equal(t, hz.EntryAdded, journal[i].EventType)
 		assert.Equal(t, hz.EntryRemoved, journal[i+1].EventType)

--- a/client_it_test.go
+++ b/client_it_test.go
@@ -207,9 +207,9 @@ func TestClientEventHandlingOrder(t *testing.T) {
 	// Create custom cluster, and client from it
 	cls := it.StartNewClusterWithOptions("event-order-test-cluster", 15701, it.MemberCount())
 	defer cls.Shutdown()
-	conf := cls.DefaultConfig()
+	cnfg := cls.DefaultConfig()
 	ctx := context.Background()
-	c := it.MustValue(hz.StartNewClientWithConfig(ctx, conf)).(*hz.Client)
+	c := it.MustValue(hz.StartNewClientWithConfig(ctx, cnfg)).(*hz.Client)
 	defer c.Shutdown(ctx)
 	// Create test map
 	m := it.MustValue(c.GetMap(ctx, "my-map")).(*hz.Map)
@@ -240,9 +240,9 @@ func TestClientEventHandlingOrder(t *testing.T) {
 	for i := 0; i < eventCount; i += 2 {
 		assert.Equal(t, hz.EntryAdded, journal[i].EventType)
 		assert.Equal(t, hz.EntryRemoved, journal[i+1].EventType)
-		value := i / 2
-		assert.Equal(t, int64(value), journal[i].Value)
-		assert.Equal(t, int64(value), journal[i+1].OldValue)
+		v := i / 2
+		assert.Equal(t, int64(v), journal[i].Value)
+		assert.Equal(t, int64(v), journal[i+1].OldValue)
 	}
 }
 


### PR DESCRIPTION
`TestClientEventHandlingOrder` test case is written with an incorrect assumption, resulting it to fail time to time.

Previous assumption: Map entry events received by client are ordered based on partitionID that entries belong.
Current(fix) assumption: Map entry events received by client are ordered based on entry key.

This fix, addresses this assumption change by refactoring mentioned test. 

