### PR TITLE
SQL Driver Context Cancellation

### DIFF
--- a/internal/it/sql.go
+++ b/internal/it/sql.go
@@ -28,7 +28,7 @@ import (
 var sqlTestCluster = NewSingletonTestCluster("sql", func() *TestCluster {
 	const clusterName = "sql-integration-test"
 	port := NextPort()
-	memberConfig := sqlXMLConfig(clusterName, "localhost", port)
+	memberConfig := SQLXMLConfig(clusterName, "localhost", port)
 	if SSLEnabled() {
 		memberConfig = sqlXMLSSLConfig(clusterName, "localhost", port)
 	}
@@ -79,7 +79,7 @@ func SQLTesterWithConfigBuilder(t *testing.T, configFn func(config *hz.Config), 
 	}
 }
 
-func SqlXMLConfig(clusterName, publicAddr string, port int) string {
+func SQLXMLConfig(clusterName, publicAddr string, port int) string {
 	return fmt.Sprintf(`
         <hazelcast xmlns="http://www.hazelcast.com/schema/config"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/internal/it/sql.go
+++ b/internal/it/sql.go
@@ -79,7 +79,7 @@ func SQLTesterWithConfigBuilder(t *testing.T, configFn func(config *hz.Config), 
 	}
 }
 
-func sqlXMLConfig(clusterName, publicAddr string, port int) string {
+func SqlXMLConfig(clusterName, publicAddr string, port int) string {
 	return fmt.Sprintf(`
         <hazelcast xmlns="http://www.hazelcast.com/schema/config"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/internal/sql/driver/sql_service.go
+++ b/internal/sql/driver/sql_service.go
@@ -117,9 +117,9 @@ func (s *SQLService) fetch(ctx context.Context, qid itypes.QueryID, conn *cluste
 	return page, nil
 }
 
-func (s *SQLService) closeQuery(qid itypes.QueryID, conn *cluster.Connection) error {
+func (s *SQLService) closeQuery(ctx context.Context, qid itypes.QueryID, conn *cluster.Connection) error {
 	req := codec.EncodeSqlCloseRequest(qid)
-	if _, err := s.invokeOnConnection(context.Background(), req, conn); err != nil {
+	if _, err := s.invokeOnConnection(ctx, req, conn); err != nil {
 		return fmt.Errorf("closing query: %w", err)
 	}
 	return nil

--- a/sql/driver/driver_it_test.go
+++ b/sql/driver/driver_it_test.go
@@ -590,7 +590,6 @@ func TestClusterShutdownWithContextCancel(t *testing.T) {
 		for rows.Next() {
 			// shutdown cluster after first page
 			tc.Shutdown()
-			// cancel context so that client does not block trying to connect to the cluster
 		}
 		close(finish)
 	}()

--- a/sql/driver/driver_it_test.go
+++ b/sql/driver/driver_it_test.go
@@ -584,7 +584,6 @@ func TestClusterShutdownWithContextCancel(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// shutdown the cluster
 	defer rows.Close()
 	finish := make(chan bool)
 	go func() {

--- a/sql/driver/driver_it_test.go
+++ b/sql/driver/driver_it_test.go
@@ -96,18 +96,6 @@ type RecordWithDateTime struct {
 	TimestampWithTimezoneValue *time.Time
 }
 
-func NewRecordWithDateTime(t *time.Time) *RecordWithDateTime {
-	dv := time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.Local)
-	tv := time.Date(0, 1, 1, t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), time.Local)
-	tsv := time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), time.Local)
-	return &RecordWithDateTime{
-		DateValue:                  &dv,
-		TimeValue:                  &tv,
-		TimestampValue:             &tsv,
-		TimestampWithTimezoneValue: t,
-	}
-}
-
 func (r RecordWithDateTime) FactoryID() int32 {
 	return factoryID
 }
@@ -573,8 +561,8 @@ func TestConcurrentQueries(t *testing.T) {
 	})
 }
 
-func TestClusterShutdownWithContextCancel(t *testing.T) {
-	tc := it.StartNewClusterWithConfig(1, it.SqlXMLConfig(t.Name(), "localhost", 60001), 60001)
+func TestClusterShutdownWithCancelOnFetchPage(t *testing.T) {
+	tc := it.StartNewClusterWithConfig(1, it.SQLXMLConfig(t.Name(), "localhost", 60001), 60001)
 	defer tc.Shutdown()
 	db := driver.Open(tc.DefaultConfig())
 	defer db.Close()

--- a/sql_it_test.go
+++ b/sql_it_test.go
@@ -491,7 +491,7 @@ func sqlStatementWithQueryTimeoutTest(t *testing.T) {
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			stmt := sql.NewStatement("select v from table(generate_stream(1))")
+			stmt := sql.NewStatement(tc.query)
 			stmt.SetQueryTimeout(3 * time.Second)
 			it.Must(stmt.SetCursorBufferSize(2))
 			it.SQLTester(t, func(t *testing.T, client *hz.Client, config *hz.Config, _ *hz.Map, _ string) {


### PR DESCRIPTION
Currently fetch calls on sql.driver does not respect context cancellation that is passed earlier with `db.QueryContext`.

This work introduces a test that fails on that situation, and fixes regarding it.