### PR TITLE
Adds OrderedMembers and ConnectedToMember methods to the internal API

### DIFF
--- a/client_internals.go
+++ b/client_internals.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	pubcluster "github.com/hazelcast/hazelcast-go-client/cluster"
 	"github.com/hazelcast/hazelcast-go-client/internal/hzerrors"
 	"github.com/hazelcast/hazelcast-go-client/internal/proto"
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
@@ -93,6 +94,16 @@ func (ci *ClientInternal) Client() *Client {
 // It returns zero value of types.UUID{} if the cluster ID does not exist.
 func (ci *ClientInternal) ClusterID() types.UUID {
 	return ci.client.ic.ConnectionManager.ClusterID()
+}
+
+// OrderedMembers returns the most recent member list of the cluster.
+func (ci *ClientInternal) OrderedMembers() []pubcluster.MemberInfo {
+	return ci.ClusterService().OrderedMembers()
+}
+
+// ConnectedToMember returns true if there is a connection to the given member.
+func (ci *ClientInternal) ConnectedToMember(uuid types.UUID) bool {
+	return ci.ConnectionManager().GetConnectionForUUID(uuid) != nil
 }
 
 // EncodeData serializes the given value and returns a Data value.

--- a/client_internals_it_test.go
+++ b/client_internals_it_test.go
@@ -241,6 +241,9 @@ func TestClientInternal_OrderedMembers(t *testing.T) {
 	types.NewUUID()
 	assert.False(t, ci.ConnectedToMember(stopped.UUID))
 	for _, mem := range ci.OrderedMembers() {
+		if mem.UUID == stopped.UUID {
+			continue
+		}
 		assert.True(t, ci.ConnectedToMember(mem.UUID))
 	}
 }

--- a/client_internals_it_test.go
+++ b/client_internals_it_test.go
@@ -246,7 +246,7 @@ func TestClientInternal_OrderedMembers(t *testing.T) {
 }
 
 func TestClientInternal_ConnectedToMember(t *testing.T) {
-	tc := it.StartNewClusterWithOptions("ci-orderedmembers", 55701, 2)
+	tc := it.StartNewClusterWithOptions("ci-connected-to-member", 55701, 2)
 	ctx := context.Background()
 	client := it.MustClient(hz.StartNewClientWithConfig(ctx, tc.DefaultConfig()))
 	defer client.Shutdown(ctx)

--- a/client_internals_it_test.go
+++ b/client_internals_it_test.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -204,6 +205,58 @@ func TestClientInternal_ClusterID(t *testing.T) {
 	assert.Equal(t, types.UUID{}, ci.ClusterID())
 }
 
+func TestClientInternal_OrderedMembers(t *testing.T) {
+	// start a 1 member cluster
+	tc := it.StartNewClusterWithOptions("ci-orderedmembers", 55701, 1)
+	defer tc.Shutdown()
+	ctx := context.Background()
+	client := it.MustClient(hz.StartNewClientWithConfig(ctx, tc.DefaultConfig()))
+	defer client.Shutdown(ctx)
+	ci := hz.NewClientInternal(client)
+	targetUUIDs := tc.MemberUUIDs
+	assert.True(t, sameMembers(targetUUIDs, ci.OrderedMembers()))
+	// start another member
+	mem, err := tc.RC.StartMember(ctx, tc.ClusterID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	targetUUIDs = append(targetUUIDs, mem.UUID)
+	assert.True(t, sameMembers(targetUUIDs, ci.OrderedMembers()))
+	// start another member
+	mem, err = tc.RC.StartMember(ctx, tc.ClusterID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	targetUUIDs = append(targetUUIDs, mem.UUID)
+	assert.True(t, sameMembers(targetUUIDs, ci.OrderedMembers()))
+	// stop a member
+	stopped := ci.OrderedMembers()[0]
+	if _, err := tc.RC.ShutdownMember(ctx, tc.ClusterID, stopped.UUID.String()); err != nil {
+		t.Fatal(err)
+	}
+	targetUUIDs = targetUUIDs[1:]
+	it.Eventually(t, func() bool {
+		return sameMembers(targetUUIDs, ci.OrderedMembers())
+	})
+	types.NewUUID()
+	assert.False(t, ci.ConnectedToMember(stopped.UUID))
+	for _, mem := range ci.OrderedMembers() {
+		assert.True(t, ci.ConnectedToMember(mem.UUID))
+	}
+}
+
+func TestClientInternal_ConnectedToMember(t *testing.T) {
+	tc := it.StartNewClusterWithOptions("ci-orderedmembers", 55701, 2)
+	ctx := context.Background()
+	client := it.MustClient(hz.StartNewClientWithConfig(ctx, tc.DefaultConfig()))
+	defer client.Shutdown(ctx)
+	ci := hz.NewClientInternal(client)
+	tc.Shutdown()
+	it.Eventually(t, func() bool {
+		return len(filterConnectedMembers(ci)) == 0
+	})
+}
+
 func TestClientInternal_InvokeOnRandomTarget(t *testing.T) {
 	clientInternalTester(t, "ci-invoke-random", func(t *testing.T, ci *hz.ClientInternal) {
 		ctx := context.Background()
@@ -332,6 +385,25 @@ func clientInternalTester(t *testing.T, clusterName string, f func(t *testing.T,
 	defer client.Shutdown(ctx)
 	ci := hz.NewClientInternal(client)
 	f(t, ci)
+}
+
+func sameMembers(target []string, mems []cluster.MemberInfo) bool {
+	memUUIDs := make([]string, len(mems))
+	for i, mem := range mems {
+		memUUIDs[i] = mem.UUID.String()
+	}
+	return reflect.DeepEqual(target, memUUIDs)
+}
+
+func filterConnectedMembers(ci *hz.ClientInternal) []cluster.MemberInfo {
+	mems := ci.OrderedMembers()
+	var connected []cluster.MemberInfo
+	for _, mem := range mems {
+		if ci.ConnectedToMember(mem.UUID) {
+			connected = append(connected, mem)
+		}
+	}
+	return connected
 }
 
 const (


### PR DESCRIPTION
This PR adds the following new methods to `ClientInternal`:
* `OrderedMembers` which returns the most recent member list
* `ConnectedToMember` which returns true if there's a connection to the given member. This method is required, since the existence of a member in the member list doesn't mean there's a connection to it.