### PR TITLE
ClientInternals OrderedMembers and ConnectedToMember methods should not depend on test tag

### DIFF
--- a/client_internals.go
+++ b/client_internals.go
@@ -98,12 +98,12 @@ func (ci *ClientInternal) ClusterID() types.UUID {
 
 // OrderedMembers returns the most recent member list of the cluster.
 func (ci *ClientInternal) OrderedMembers() []pubcluster.MemberInfo {
-	return ci.ClusterService().OrderedMembers()
+	return ci.client.ic.ClusterService.OrderedMembers()
 }
 
 // ConnectedToMember returns true if there is a connection to the given member.
 func (ci *ClientInternal) ConnectedToMember(uuid types.UUID) bool {
-	return ci.ConnectionManager().GetConnectionForUUID(uuid) != nil
+	return ci.client.ic.ConnectionManager.GetConnectionForUUID(uuid) != nil
 }
 
 // EncodeData serializes the given value and returns a Data value.


### PR DESCRIPTION
`ClientInternals.ConnectionManager()` and `ClientInternals.ConnectedToMember()` are only built with `hazelcastinternaltest` tag. `ClientInternals.OrderedMembers()` and `ClientInternals.ConnectedToMembers()` methods should not depend on them.