### PR TITLE
Restored serialization behaviour for time.Time values

### DIFF
--- a/client_internals_it_test.go
+++ b/client_internals_it_test.go
@@ -238,14 +238,6 @@ func TestClientInternal_OrderedMembers(t *testing.T) {
 	it.Eventually(t, func() bool {
 		return sameMembers(targetUUIDs, ci.OrderedMembers())
 	})
-	types.NewUUID()
-	assert.False(t, ci.ConnectedToMember(stopped.UUID))
-	for _, mem := range ci.OrderedMembers() {
-		if mem.UUID == stopped.UUID {
-			continue
-		}
-		assert.True(t, ci.ConnectedToMember(mem.UUID))
-	}
 }
 
 func TestClientInternal_ConnectedToMember(t *testing.T) {

--- a/doc.go
+++ b/doc.go
@@ -211,15 +211,9 @@ The names in parantheses correspond to SQL types:
 	- types.LocalTime (time)
 	- types.LocalDateTime (timestamp)
 	- types.OffsetDateTime (timestamp with time zone)
-	- time.Time (date) Detected by checking: hour == minute == second == nanoseconds = 0
-	- time.Time (time) Detected by checking: year == 0, month == day == 1
-	- time.Time (timestamp) Detected by checking: not time, timezone == time.Local
-	- time.Time (timestamp with time zone) Detected by checking: not time, timezone != time.Local
 	- serialization.JSON (json)
 
 Using Date/Time
-
-time.Time values are automatically serialized to the correct type.
 
 In order to force using a specific date/time type, create a time.Time value and cast it to the target type:
 

--- a/doc.go
+++ b/doc.go
@@ -207,6 +207,7 @@ The names in parantheses correspond to SQL types:
 	- float32 (real)
 	- float64 (double)
 	- types.Decimal (decimal)
+	- time.Time not supported, use one of types.LocalDate, types.LocalTime, types.LocalDateTime or types.OffsetDateTime
 	- types.LocalDate (date)
 	- types.LocalTime (time)
 	- types.LocalDateTime (timestamp)

--- a/internal/serialization/serialization.go
+++ b/internal/serialization/serialization.go
@@ -301,7 +301,7 @@ func (s *Service) registerIdentifiedFactories() error {
 }
 
 func (s *Service) lookupBuiltinSerializer(obj interface{}) pubserialization.Serializer {
-	switch o := obj.(type) {
+	switch obj.(type) {
 	case nil:
 		return nilSerializer
 	case bool:
@@ -359,7 +359,7 @@ func (s *Service) lookupBuiltinSerializer(obj interface{}) pubserialization.Seri
 	case types.OffsetDateTime:
 		return javaOffsetDateTimeSerializer
 	case time.Time:
-		return dateTimeSerializer(o)
+		return javaDateSerializer
 	case *big.Int:
 		return javaBigIntegerSerializer
 	case types.Decimal:
@@ -379,21 +379,6 @@ func makeError(rec interface{}) error {
 	default:
 		return fmt.Errorf("%v", rec)
 	}
-}
-
-func dateTimeSerializer(t time.Time) pubserialization.Serializer {
-	// if t has its year 0, then assume it contains only the time
-	if t.Year() == 0 && t.Month() == 1 && t.Day() == 1 {
-		return javaLocalTimeSerializer
-	}
-	h, mn, s := t.Clock()
-	if h == 0 && mn == 0 && s == 0 && t.Nanosecond() == 0 {
-		return javaLocalDateSerializer
-	}
-	if t.Location() == time.Local {
-		return javaLocalDateTimeSerializer
-	}
-	return javaOffsetDateTimeSerializer
 }
 
 var nilSerializer = &NilSerializer{}

--- a/internal/serialization/serialization_improvements_test.go
+++ b/internal/serialization/serialization_improvements_test.go
@@ -89,7 +89,7 @@ func TestSerializationImprovements_JavaDate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, types.LocalDateTime(target), value)
+	assert.Equal(t, target, value)
 }
 
 func TestSerializationImprovements(t *testing.T) {
@@ -100,26 +100,6 @@ func TestSerializationImprovements(t *testing.T) {
 			target interface{}
 			name   string
 		}{
-			{
-				input:  time.Date(2021, 2, 10, 0, 0, 0, 0, time.Local),
-				name:   "JavaLocalDate from types.LocalDate",
-				target: types.LocalDate(time.Date(2021, 2, 10, 0, 0, 0, 0, time.Local)),
-			},
-			{
-				input:  time.Date(0, 1, 1, 1, 2, 3, 50, time.Local),
-				name:   "JavaLocalTime from types.LocalTime",
-				target: types.LocalTime(time.Date(0, 1, 1, 1, 2, 3, 50, time.Local)),
-			},
-			{
-				input:  time.Date(2021, 2, 10, 1, 2, 3, 4, time.Local),
-				name:   "JavaLocalDateTime from types.LocalDateTime",
-				target: types.LocalDateTime(time.Date(2021, 2, 10, 1, 2, 3, 4, time.Local)),
-			},
-			{
-				input:  time.Date(2021, 2, 10, 1, 2, 3, 4, time.FixedZone("", -3*60*60)),
-				name:   "JavaOffsetDateTime from types.OffsetDateTime",
-				target: types.OffsetDateTime(time.Date(2021, 2, 10, 1, 2, 3, 4, time.FixedZone("", -3*60*60))),
-			},
 			{
 				input:  types.LocalDate(time.Date(2021, 2, 10, 0, 0, 0, 0, time.Local)),
 				name:   "JavaLocalDate",

--- a/sql/driver/doc.go
+++ b/sql/driver/doc.go
@@ -175,6 +175,7 @@ The names in parentheses correspond to SQL types:
 	- float32 (real)
 	- float64 (double)
 	- types.Decimal (decimal)
+	- time.Time not supported, use one of types.LocalDate, types.LocalTime, types.LocalDateTime or types.OffsetDateTime
 	- types.LocalDate (date)
 	- types.LocalTime (time)
 	- types.LocalDateTime (timestamp)

--- a/sql/driver/doc.go
+++ b/sql/driver/doc.go
@@ -179,15 +179,9 @@ The names in parentheses correspond to SQL types:
 	- types.LocalTime (time)
 	- types.LocalDateTime (timestamp)
 	- types.OffsetDateTime (timestamp with time zone)
-	- time.Time (date) Detected by checking: hour == minute == second == nanoseconds = 0
-	- time.Time (time) Detected by checking: year == 0, month == day == 1
-	- time.Time (timestamp) Detected by checking: not time, timezone == time.Local
-	- time.Time (timestamp with time zone) Detected by checking: not time, timezone != time.Local
 	- serialization.JSON (json)
 
 Using Date/Time Types
-
-time.Time values are automatically serialized to the correct type.
 
 In order to force using a specific date/time type, create a time.Time value and cast it to the target type:
 


### PR DESCRIPTION
Previously, we used a heuristic to map `time.Time` values to the correct reference implementation type. This PR reverses that change, and uses the v1.1.1 behaviour.