### PR TITLE
Fix all partitions being assigned to one node

### DIFF
--- a/internal/cluster/partition_service.go
+++ b/internal/cluster/partition_service.go
@@ -118,12 +118,10 @@ func (p *partitionTable) Update(pairs []proto.Pair, version int32, connectionID 
 	}
 	newPartitions := map[int32]types.UUID{}
 	for _, pair := range pairs {
-		uuids := pair.Key.([]types.UUID)
+		uuid := pair.Key.(types.UUID)
 		ids := pair.Value.([]int32)
-		for _, uuid := range uuids {
-			for _, id := range ids {
-				newPartitions[id] = uuid
-			}
+		for _, id := range ids {
+			newPartitions[id] = uuid
 		}
 	}
 	if reflect.DeepEqual(p.partitions, newPartitions) {

--- a/internal/proto/codec/builtin.go
+++ b/internal/proto/codec/builtin.go
@@ -632,7 +632,11 @@ func DecodeListMultiFrameForData(frameIterator *proto.ForwardFrameIterator) []is
 }
 
 func DecodeListMultiFrameWithListInteger(frameIterator *proto.ForwardFrameIterator) [][]int32 {
-	result := make([][]int32, 0)
+	var result [][]int32
+	DecodeListMultiFrame(frameIterator, func(fi *proto.ForwardFrameIterator) {
+		result = append(result, DecodeListInteger(fi))
+	})
+	return result
 	frameIterator.Next()
 	for !CodecUtil.NextFrameIsDataStructureEndFrame(frameIterator) {
 		result = append(result, DecodeListInteger(frameIterator))

--- a/internal/proto/codec/builtin.go
+++ b/internal/proto/codec/builtin.go
@@ -366,7 +366,7 @@ func DecodeEntryListUUIDListInteger(frameIterator *proto.ForwardFrameIterator) [
 	keySize := len(keys)
 	result := make([]proto.Pair, keySize)
 	for i := 0; i < keySize; i++ {
-		result[i] = proto.NewPair(keys, values)
+		result[i] = proto.NewPair(keys[i], values[i])
 	}
 	return result
 }
@@ -631,11 +631,11 @@ func DecodeListMultiFrameForData(frameIterator *proto.ForwardFrameIterator) []is
 	return result
 }
 
-func DecodeListMultiFrameWithListInteger(frameIterator *proto.ForwardFrameIterator) []int32 {
-	result := make([]int32, 0)
+func DecodeListMultiFrameWithListInteger(frameIterator *proto.ForwardFrameIterator) [][]int32 {
+	result := make([][]int32, 0)
 	frameIterator.Next()
 	for !CodecUtil.NextFrameIsDataStructureEndFrame(frameIterator) {
-		result = append(result, DecodeListInteger(frameIterator)...)
+		result = append(result, DecodeListInteger(frameIterator))
 	}
 	frameIterator.Next()
 	return result

--- a/internal/proto/codec/builtin.go
+++ b/internal/proto/codec/builtin.go
@@ -637,12 +637,6 @@ func DecodeListMultiFrameWithListInteger(frameIterator *proto.ForwardFrameIterat
 		result = append(result, DecodeListInteger(fi))
 	})
 	return result
-	frameIterator.Next()
-	for !CodecUtil.NextFrameIsDataStructureEndFrame(frameIterator) {
-		result = append(result, DecodeListInteger(frameIterator))
-	}
-	frameIterator.Next()
-	return result
 }
 
 func DecodeListMultiFrameForMemberInfo(frameIterator *proto.ForwardFrameIterator) []pubcluster.MemberInfo {

--- a/internal/proto/codec/builtin_test.go
+++ b/internal/proto/codec/builtin_test.go
@@ -586,8 +586,28 @@ func TestEntryListUUIDListIntegerCodec_Decode(t *testing.T) {
 
 	// then
 	assert.Equal(t, len(result), 1)
-	assert.Equal(t, result[0].Key.([]types.UUID)[0].String(), key.String())
+	assert.Equal(t, result[0].Key.(types.UUID).String(), key.String())
 	assert.EqualValues(t, result[0].Value.([]int32), value)
+}
+
+func TestEntryListUUIDListIntegerCodec_Decode_Many(t *testing.T) {
+	// given
+	clientMessage := proto.NewClientMessageForEncode()
+	entries := []proto.Pair{
+		{Key: types.NewUUID(), Value: []int32{1, 2, 3}},
+		{Key: types.NewUUID(), Value: []int32{4, 5, 6}},
+	}
+	EncodeEntryListUUIDListInteger(clientMessage, entries)
+
+	// when
+	result := DecodeEntryListUUIDListInteger(clientMessage.FrameIterator())
+
+	// then
+	assert.Equal(t, len(result), 2)
+	assert.Equal(t, result[0].Key.(types.UUID).String(), entries[0].Key.(types.UUID).String())
+	assert.EqualValues(t, result[0].Value.([]int32), entries[0].Value)
+	assert.Equal(t, result[1].Key.(types.UUID).String(), entries[1].Key.(types.UUID).String())
+	assert.EqualValues(t, result[1].Value.([]int32), entries[1].Value)
 }
 
 func TestLongArrayCodec_Encode(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/hazelcast/hazelcast-go-client/issues/774

### Before:
3-node cluster, showing uneven activity by go-client:
<img width="867" alt="image" src="https://user-images.githubusercontent.com/1817604/166611944-8b68ab4c-8b8b-48b3-898b-8f874d6ec265.png">

3-node cluster, showing uneven Network and CPU utilization:
<img width="936" alt="image" src="https://user-images.githubusercontent.com/1817604/166612501-83876454-646e-40ce-9507-58745cf65793.png">


### After:
3-node cluster, showing even activity by go-client:
<img width="866" alt="image" src="https://user-images.githubusercontent.com/1817604/166612742-879b3173-5842-4af4-94be-cad6c2cc1426.png">

3-node cluster, showing even Network and CPU utilization:
<img width="938" alt="image" src="https://user-images.githubusercontent.com/1817604/166612474-53cfcb1c-4bcf-4f7f-8a3e-69cd1d5e3919.png">

Summary of root cause:
1. `DecodeListMultiFrameWithListInteger()` returns a single slice of same partitions for all nodes, instead of a slice of slices one for each node
2. `DecodeEntryListUUIDListInteger()` returns a n:m mapping of all uuids to all partitions, it should be a 1:k mapping of node to just its partitions.
3. `partitionTable.Update()` always assigns the last uuid in the pairs to all partitions, it should assign the correct node uuid to each partition