### PR TITLE
Update staticcheck version

### DIFF
--- a/.github/workflows/test-all-32bits.yaml
+++ b/.github/workflows/test-all-32bits.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: "Install Go tools"
         run: |
           go get -u golang.org/x/tools/...
-          go get honnef.co/go/tools/cmd/staticcheck@latest
+          go get honnef.co/go/tools/cmd/staticcheck@v0.2.2
 
       - name: "Run Checkers"
         run: |

--- a/.github/workflows/test-all.yaml
+++ b/.github/workflows/test-all.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: "Install Go tools"
         run: |
           go get -u golang.org/x/tools/...
-          go get honnef.co/go/tools/cmd/staticcheck@latest
+          go get honnef.co/go/tools/cmd/staticcheck@v0.2.2
 
       - name: "Run Checkers"
         run: |


### PR DESCRIPTION
Update staticcheck version to comply with go v1.15. Used checkout the "latest" version, however now that one requires go 1.17 and we want to stay at the minimal supported version on actions which is 1.15 for us.