### PR TITLE
[TRIVIAL] Make ClientType and ClientVersion variables

### DIFF
--- a/client.go
+++ b/client.go
@@ -35,7 +35,8 @@ import (
 )
 
 const (
-	ClientVersion = internal.ClientVersion
+	// ClientVersion is the semantic versioning compatible client version.
+	ClientVersion = internal.CurrentClientVersion
 )
 
 // StartNewClient creates and starts a new client with the default configuration.

--- a/client_it_test.go
+++ b/client_it_test.go
@@ -668,7 +668,7 @@ func TestClientFixConnection(t *testing.T) {
 
 func TestClientVersion(t *testing.T) {
 	// adding this test here, so there's no "unused lint warning.
-	assert.Equal(t, "1.2.0", hz.ClientVersion)
+	assert.Equal(t, "1.3.0", hz.ClientVersion)
 }
 
 func TestInvocationTimeout(t *testing.T) {

--- a/internal/common.go
+++ b/internal/common.go
@@ -18,8 +18,9 @@ package internal
 
 const (
 	// ClientType is used in the Management
-	ClientType         = "GOO"
 	AggregateFactoryID = -29
 	// ClientVersion should be manually set
 	ClientVersion = "1.2.0"
 )
+
+var ClientType = "GOO"

--- a/internal/common.go
+++ b/internal/common.go
@@ -17,10 +17,14 @@
 package internal
 
 const (
-	// ClientType is used in the Management
 	AggregateFactoryID = -29
-	// ClientVersion should be manually set
-	ClientVersion = "1.2.0"
+	// CurrentClientVersion should be manually set
+	CurrentClientVersion = "1.3.0"
 )
 
+// ClientType is used in the Management Center
 var ClientType = "GOO"
+
+// ClientVersion is the effective client version.
+// It is sent to the member during authentication.
+var ClientVersion = CurrentClientVersion


### PR DESCRIPTION
This PR makes `internal.ClientType` a variable, so it can be changed by a build flag.such as:
```
go build -v -ldflags="-X 'github.com/hazelcast/hazelcast-go-client/internal.ClientType=CLC' -X 'github.com/hazelcast/hazelcast-go-client/internal.ClientVersion=1.0.0-beta1'"

```