### PR TITLE
Fixes SQL driver tests to work with SSL

### DIFF
--- a/internal/it/sql.go
+++ b/internal/it/sql.go
@@ -18,14 +18,12 @@ package it
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"testing"
 
 	"go.uber.org/goleak"
 
 	hz "github.com/hazelcast/hazelcast-go-client"
-	"github.com/hazelcast/hazelcast-go-client/logger"
 	"github.com/hazelcast/hazelcast-go-client/serialization"
 )
 
@@ -53,15 +51,6 @@ func SQLTesterWithConfigBuilder(t *testing.T, configFn func(config *hz.Config), 
 		if configFn != nil {
 			configFn(&config)
 		}
-		if SSLEnabled() {
-			config.Cluster.Network.SSL.Enabled = true
-			config.Cluster.Network.SSL.SetTLSConfig(&tls.Config{InsecureSkipVerify: true})
-		}
-		logLevel := logger.WarnLevel
-		if TraceLoggingEnabled() {
-			logLevel = logger.TraceLevel
-		}
-		config.Logger.Level = logLevel
 		config.Cluster.Unisocket = !smart
 		ls := "smart"
 		if !smart {

--- a/internal/it/util.go
+++ b/internal/it/util.go
@@ -406,7 +406,7 @@ func getLoggerLevel() logger.Level {
 	if TraceLoggingEnabled() {
 		return logger.TraceLevel
 	}
-	return logger.WarnLevel
+	return logger.InfoLevel
 }
 
 func getDefaultClient(config *hz.Config) *hz.Client {

--- a/sql/driver/operators_it_test.go
+++ b/sql/driver/operators_it_test.go
@@ -48,9 +48,8 @@ type CompanyInfo struct {
 func TestNestedJSONQuery(t *testing.T) {
 	it.SkipIf(t, "hz < 5.1")
 	it.SQLTester(t, func(t *testing.T, client *hz.Client, config *hz.Config, m *hz.Map, mapName string) {
-		defer driver.SetSerializationConfig(nil)
 		const rowCount = 50
-		db := initDB(t, config)
+		db := initDB(config)
 		defer db.Close()
 		ms := createMappingStr(mapName, "bigint", "json")
 		it.Must(createMapping(t, db, ms))
@@ -70,8 +69,7 @@ func TestJSONOperators(t *testing.T) {
 	it.SkipIf(t, "hz < 5.1")
 	it.SQLTester(t, func(t *testing.T, client *hz.Client, config *hz.Config, m *hz.Map, mapName string) {
 		const rowCount = 50
-		defer driver.SetSerializationConfig(nil)
-		db := initDB(t, config)
+		db := initDB(config)
 		defer db.Close()
 		ms := createMappingStr(mapName, "bigint", "json")
 		it.Must(createMapping(t, db, ms))
@@ -101,13 +99,9 @@ func TestJSONOperators(t *testing.T) {
 	})
 }
 
-func initDB(t *testing.T, config *hz.Config) *sql.DB {
-	dsn := makeDSN(config)
-	sc := &serialization.Config{}
-	sc.SetGlobalSerializer(&it.PanicingGlobalSerializer{})
-	it.Must(driver.SetSerializationConfig(sc))
-	db := mustDB(sql.Open("hazelcast", dsn))
-	return db
+func initDB(config *hz.Config) *sql.DB {
+	config.Serialization.SetGlobalSerializer(&it.PanicingGlobalSerializer{})
+	return driver.Open(*config)
 }
 
 func populateMapWithEmployees(m *hz.Map, rowCount int) ([]employee, error) {


### PR DESCRIPTION
SQL driver tests didn't work with SSL, since some parts of those tests only used a DSN which doesn't support SSL options. Converted problematic tests to use `driver.Open` instead.