### PR TITLE
Go Compact part1 [API-1306] (#782)

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -209,7 +209,7 @@ func TestMarshalDefaultConfig(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	target := `{"Logger":{},"Failover":{},"Serialization":{},"Cluster":{"Security":{"Credentials":{}},"Cloud":{},"Network":{"SSL":{},"PortRange":{}},"ConnectionStrategy":{"Retry":{}},"Discovery":{}},"Stats":{}}`
+	target := `{"Logger":{},"Failover":{},"Serialization":{"Compact":{}},"Cluster":{"Security":{"Credentials":{}},"Cloud":{},"Network":{"SSL":{},"PortRange":{}},"ConnectionStrategy":{"Retry":{}},"Discovery":{}},"Stats":{}}`
 	assertStringEquivalent(t, target, string(b))
 }
 

--- a/internal/serialization/compact_serializer.go
+++ b/internal/serialization/compact_serializer.go
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package serialization
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/hazelcast/hazelcast-go-client/internal/hzerrors"
+	pubserialization "github.com/hazelcast/hazelcast-go-client/serialization"
+)
+
+type CompactStreamSerializer struct {
+	typeToSchema         map[reflect.Type]Schema
+	typeToSerializer     map[reflect.Type]pubserialization.CompactSerializer
+	typeNameToSerializer map[string]pubserialization.CompactSerializer
+	ss                   *SchemaService
+	fingerprint          RabinFingerPrint
+}
+
+func NewCompactStreamSerializer(cfg pubserialization.CompactConfig) *CompactStreamSerializer {
+	typeToSerializer := make(map[reflect.Type]pubserialization.CompactSerializer)
+	typeNameToSerializer := make(map[string]pubserialization.CompactSerializer)
+	for typeName, serializer := range cfg.Serializers() {
+		typeNameToSerializer[typeName] = serializer
+		typeToSerializer[serializer.Type()] = serializer
+	}
+	return &CompactStreamSerializer{
+		ss:                   NewSchemaService(),
+		typeToSchema:         make(map[reflect.Type]Schema),
+		typeToSerializer:     typeToSerializer,
+		typeNameToSerializer: typeNameToSerializer,
+		fingerprint:          NewRabinFingerPrint(),
+	}
+}
+
+func (CompactStreamSerializer) ID() int32 {
+	return TypeCompact
+}
+
+func (c CompactStreamSerializer) Read(input pubserialization.DataInput) interface{} {
+	schema := c.getOrReadSchema(input)
+	typeName := schema.TypeName()
+	serializer, ok := c.typeNameToSerializer[typeName]
+	if !ok {
+		panic(fmt.Sprintf("no compact serializer found for type: %s", typeName))
+	}
+	reader := NewDefaultCompactReader(c, input.(*ObjectDataInput), schema)
+	return serializer.Read(reader)
+}
+
+func (c CompactStreamSerializer) Write(output pubserialization.DataOutput, object interface{}) {
+	t := reflect.TypeOf(object)
+	serializer := c.typeToSerializer[t]
+	schema, ok := c.typeToSchema[t]
+	if !ok {
+		sw := NewSchemaWriter(serializer.TypeName())
+		serializer.Write(sw, object)
+		schema = sw.Build(c.fingerprint)
+		c.ss.PutLocal(schema)
+		c.typeToSchema[t] = schema
+	}
+	output.WriteInt64(schema.ID())
+	w := NewDefaultCompactWriter(c, output.(*PositionalObjectDataOutput), schema)
+	serializer.Write(w, object)
+	w.End()
+}
+
+func (c CompactStreamSerializer) IsRegisteredAsCompact(t reflect.Type) bool {
+	_, ok := c.typeToSerializer[t]
+	return ok
+}
+
+func (c CompactStreamSerializer) getOrReadSchema(input pubserialization.DataInput) Schema {
+	schemaId := input.ReadInt64()
+	schema, ok := c.ss.Get(schemaId)
+	if ok {
+		return schema
+	}
+	panic(hzerrors.NewSerializationError(fmt.Sprintf("the schema cannot be found with id: %d", schemaId), nil))
+}

--- a/internal/serialization/compact_test.go
+++ b/internal/serialization/compact_test.go
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package serialization_test
+
+import (
+	"reflect"
+
+	"github.com/hazelcast/hazelcast-go-client/serialization"
+)
+
+type MainDTO struct {
+	str *string
+	i   int32
+}
+
+func NewMainDTO() MainDTO {
+	str := "this is main object created for testing!"
+	return MainDTO{
+		i:   56789,
+		str: &str,
+	}
+}
+
+type MainDTOSerializer struct {
+}
+
+func (MainDTOSerializer) Type() reflect.Type {
+	return reflect.TypeOf(MainDTO{})
+}
+
+func (MainDTOSerializer) TypeName() string {
+	return "MainDTO"
+}
+
+func (MainDTOSerializer) Read(reader serialization.CompactReader) interface{} {
+	return MainDTO{
+		i:   reader.ReadInt32("i"),
+		str: reader.ReadString("str"),
+	}
+}
+
+func (MainDTOSerializer) Write(writer serialization.CompactWriter, value interface{}) {
+	c, ok := value.(MainDTO)
+	if !ok {
+		panic("not a MainDTO")
+	}
+	writer.WriteInt32("i", c.i)
+	writer.WriteString("str", c.str)
+}

--- a/internal/serialization/default_compact_reader.go
+++ b/internal/serialization/default_compact_reader.go
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package serialization
+
+import (
+	"fmt"
+
+	ihzerrors "github.com/hazelcast/hazelcast-go-client/internal/hzerrors"
+	pubserialization "github.com/hazelcast/hazelcast-go-client/serialization"
+)
+
+const nullOffset = -1
+
+type OffsetReader interface {
+	getOffset(input *ObjectDataInput, variableOffsetsPos, index int32) int32
+}
+
+type ByteOffsetReader struct{}
+
+func (ByteOffsetReader) getOffset(input *ObjectDataInput, variableOffsetsPos, index int32) int32 {
+	offset := input.ReadByteAtPosition(variableOffsetsPos + index)
+	if offset == 0xFF {
+		return nullOffset
+	}
+	return int32(offset)
+}
+
+type DefaultCompactReader struct {
+	offsetReader OffsetReader
+	in           *ObjectDataInput
+	serializer   CompactStreamSerializer
+	schema       Schema
+	startPos     int32
+	offsetsPos   int32
+}
+
+func (r DefaultCompactReader) ReadInt32(fieldName string) int32 {
+	fd := r.getFieldDefinition(fieldName)
+	switch fd.fieldKind {
+	case pubserialization.FieldKindInt32:
+		p := r.readFixedSizePosition(fd)
+		return r.in.ReadInt32AtPosition(p)
+	default:
+		panic(newUnexpectedFieldKind(fd.fieldKind, fieldName))
+	}
+}
+
+func (r DefaultCompactReader) ReadString(fieldName string) *string {
+	fd := r.getFieldDefinitionChecked(fieldName, pubserialization.FieldKindString)
+	value := r.readVariableSizeField(fd, func(in *ObjectDataInput) interface{} {
+		str := in.ReadString()
+		return &str
+	})
+	if value == nil {
+		return nil
+	}
+	return value.(*string)
+}
+
+func NewDefaultCompactReader(serializer CompactStreamSerializer, input *ObjectDataInput, schema Schema) DefaultCompactReader {
+	var offsetsPos, startPos, finalPos int32
+	if schema.numberOfVarSizeFields == 0 {
+		startPos = input.Position()
+		finalPos = startPos + schema.fixedSizeFieldsLength
+	} else {
+		dataLength := input.readInt32()
+		startPos = input.Position()
+		offsetsPos = startPos + dataLength
+		finalPos = offsetsPos + schema.numberOfVarSizeFields
+	}
+	input.SetPosition(finalPos)
+	return DefaultCompactReader{
+		schema:       schema,
+		in:           input,
+		serializer:   serializer,
+		startPos:     startPos,
+		offsetReader: &ByteOffsetReader{},
+		offsetsPos:   offsetsPos,
+	}
+}
+
+func (r *DefaultCompactReader) getFieldDefinition(fieldName string) FieldDescriptor {
+	fd := r.schema.GetField(fieldName)
+	if fd == nil {
+		panic(newUnknownField(fieldName, r.schema))
+	}
+	return *fd
+}
+
+func (r *DefaultCompactReader) getFieldDefinitionChecked(fieldName string, fieldKind pubserialization.FieldKind) FieldDescriptor {
+	fd := r.getFieldDefinition(fieldName)
+	if fd.fieldKind != fieldKind {
+		panic(newUnexpectedFieldKind(fd.fieldKind, fieldName))
+	}
+	return fd
+}
+
+func (r *DefaultCompactReader) readFixedSizePosition(fd FieldDescriptor) int32 {
+	return fd.offset + r.startPos
+}
+
+func newUnknownField(fieldName string, schema Schema) error {
+	return ihzerrors.NewSerializationError(fmt.Sprintf("unknown field name '%s' for %s", fieldName, schema), nil)
+}
+
+func newUnexpectedFieldKind(actualFieldKind pubserialization.FieldKind, fieldName string) error {
+	return ihzerrors.NewSerializationError(fmt.Sprintf("unexpected field kind '%d' for field %s", actualFieldKind, fieldName), nil)
+}
+
+func (r *DefaultCompactReader) readVariableSizeField(fd FieldDescriptor, reader func(*ObjectDataInput) interface{}) interface{} {
+	currentPos := r.in.Position()
+	defer r.in.SetPosition(currentPos)
+	position := r.readVariableSizeFieldPosition(fd)
+	if position == nullOffset {
+		return nil
+	}
+	r.in.SetPosition(position)
+	return reader(r.in)
+}
+
+func (r *DefaultCompactReader) readVariableSizeFieldPosition(fd FieldDescriptor) int32 {
+	offset := r.offsetReader.getOffset(r.in, r.offsetsPos, fd.index)
+	if offset == nullOffset {
+		return nullOffset
+	}
+	return offset + r.startPos
+}

--- a/internal/serialization/default_compact_writer.go
+++ b/internal/serialization/default_compact_writer.go
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package serialization
+
+import (
+	"fmt"
+
+	"github.com/hazelcast/hazelcast-go-client/internal/check"
+	ihzerrors "github.com/hazelcast/hazelcast-go-client/internal/hzerrors"
+	pubserialization "github.com/hazelcast/hazelcast-go-client/serialization"
+)
+
+type DefaultCompactWriter struct {
+	out               *PositionalObjectDataOutput
+	serializer        CompactStreamSerializer
+	fieldOffsets      []int32
+	schema            Schema
+	dataStartPos int32
+}
+
+func NewDefaultCompactWriter(serializer CompactStreamSerializer, out *PositionalObjectDataOutput, schema Schema) DefaultCompactWriter {
+	var fieldOffsets []int32
+	var dataStartPosition int32
+	if schema.numberOfVarSizeFields != 0 {
+		fieldOffsets = make([]int32, schema.numberOfVarSizeFields)
+		dataStartPosition = out.Position() + Int32SizeInBytes
+		// Skip for length and primitives.
+		out.WriteZeroBytes(int(schema.fixedSizeFieldsLength + Int32SizeInBytes))
+	} else {
+		dataStartPosition = out.Position()
+		// Skip for primitives. No need to write data length, when there is no
+		// variable-size fields.
+		out.WriteZeroBytes(int(schema.fixedSizeFieldsLength))
+	}
+	return DefaultCompactWriter{
+		serializer:        serializer,
+		out:               out,
+		schema:            schema,
+		fieldOffsets:      fieldOffsets,
+		dataStartPos: dataStartPosition,
+	}
+}
+
+func (r DefaultCompactWriter) WriteInt32(fieldName string, value int32) {
+	position := r.getFixedSizeFieldPosition(fieldName, pubserialization.FieldKindInt32)
+	r.out.PWriteInt32(position, value)
+}
+
+func (r DefaultCompactWriter) WriteString(fieldName string, value *string) {
+	r.writeVariableSizeField(fieldName, pubserialization.FieldKindString, value, func(out *PositionalObjectDataOutput, v interface{}) {
+		out.WriteString(*v.(*string))
+	})
+}
+
+// End ends the serialization of the compact objects by writing the offsets of the variable-size fields as well as the data length, if there are some variable-size fields.
+func (r DefaultCompactWriter) End() {
+	if r.schema.numberOfVarSizeFields == 0 {
+		return
+	}
+	position := r.out.Position()
+	dataLength := position - r.dataStartPos
+	r.writeOffsets(dataLength, r.fieldOffsets)
+	r.out.PWriteInt32(r.dataStartPos-Int32SizeInBytes, dataLength)
+}
+
+func (r *DefaultCompactWriter) getFieldDescriptorChecked(fieldName string, fieldKind pubserialization.FieldKind) FieldDescriptor {
+	fd := r.schema.GetField(fieldName)
+	if fd == nil {
+		panic(ihzerrors.NewSerializationError(fmt.Sprintf("Invalid field name: '%s' for %v", fieldName, r.schema), nil))
+	}
+	if fd.fieldKind != fieldKind {
+		panic(ihzerrors.NewSerializationError(fmt.Sprintf("Invalid field type: '%s' for %v", fieldName, r.schema), nil))
+	}
+	return *fd
+}
+
+func (r *DefaultCompactWriter) getFixedSizeFieldPosition(fieldName string, fieldKind pubserialization.FieldKind) int32 {
+	fd := r.getFieldDescriptorChecked(fieldName, fieldKind)
+	return fd.offset + r.dataStartPos
+}
+
+func (r *DefaultCompactWriter) setPosition(fieldName string, fieldKind pubserialization.FieldKind) error {
+	fd := r.getFieldDescriptorChecked(fieldName, fieldKind)
+	position := r.out.Position()
+	fieldPosition := position - r.dataStartPos
+	index := fd.index
+	r.fieldOffsets[index] = fieldPosition
+	return nil
+}
+
+func (r *DefaultCompactWriter) setPositionAsNull(fieldName string, fieldKind pubserialization.FieldKind) error {
+	fd := r.getFieldDescriptorChecked(fieldName, fieldKind)
+	index := fd.index
+	r.fieldOffsets[index] = -1
+	return nil
+}
+
+func (r *DefaultCompactWriter) writeVariableSizeField(fieldName string, fieldKind pubserialization.FieldKind, value interface{}, writer func(*PositionalObjectDataOutput, interface{})) error {
+	if check.Nil(value) {
+		err := r.setPositionAsNull(fieldName, fieldKind)
+		if err != nil {
+			return err
+		}
+	} else {
+		r.setPosition(fieldName, fieldKind)
+		writer(r.out, value)
+	}
+	return nil
+}
+
+func (r DefaultCompactWriter) writeOffsets(dataLength int32, fieldOffsets []int32) {
+	// Right now we don't need other offset writers
+	for _, offset := range fieldOffsets {
+		r.out.WriteByte(byte(offset))
+	}
+}

--- a/internal/serialization/field_description.go
+++ b/internal/serialization/field_description.go
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package serialization
+
+import pserialization "github.com/hazelcast/hazelcast-go-client/serialization"
+
+type FieldDescriptor struct {
+	fieldName string
+	fieldKind pserialization.FieldKind
+	index     int32
+	offset    int32
+	bitOffset int8
+}
+
+func NewFieldDescriptor(fieldName string, fieldKind pserialization.FieldKind) FieldDescriptor {
+	return FieldDescriptor{
+		fieldName: fieldName,
+		fieldKind: fieldKind,
+		index:     -1,
+		offset:    -1,
+		bitOffset: -1,
+	}
+}

--- a/internal/serialization/field_operations.go
+++ b/internal/serialization/field_operations.go
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package serialization
+
+import (
+	"fmt"
+
+	pserialization "github.com/hazelcast/hazelcast-go-client/serialization"
+)
+
+type FieldKindOperation interface {
+	KindSizeInBytes() int32
+}
+
+const variableKindSize = -1
+
+type Int32FieldKindOperation struct{}
+
+func (Int32FieldKindOperation) KindSizeInBytes() int32 {
+	return Int32SizeInBytes
+}
+
+type StringFieldKindOperation struct{}
+
+func (StringFieldKindOperation) KindSizeInBytes() int32 {
+	return variableKindSize
+}
+
+func FieldOperations(fieldKind pserialization.FieldKind) FieldKindOperation {
+	switch fieldKind {
+	case pserialization.FieldKindInt32:
+		return &Int32FieldKindOperation{}
+	case pserialization.FieldKindString:
+		return &StringFieldKindOperation{}
+	default:
+		panic(fmt.Sprintf("Unknown field kind for field operations: %d", fieldKind))
+	}
+}

--- a/internal/serialization/rabin.go
+++ b/internal/serialization/rabin.go
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package serialization
+
+const rabinFingerPrintInit int64 = -4513414715797952619
+
+type RabinFingerPrint struct {
+	table [256]int64
+}
+
+func NewRabinFingerPrint() RabinFingerPrint {
+	r := RabinFingerPrint{}
+
+	for i := int64(0); i < 256; i++ {
+		fp := i
+		for j := 0; j < 8; j++ {
+			fp = int64(uint64(fp)>>1) ^ (rabinFingerPrintInit & -(fp & 1))
+		}
+		r.table[i] = fp
+	}
+	return r
+}
+
+func (r RabinFingerPrint) OfSchema(schema *Schema) int64 {
+	fp := r.ofString(rabinFingerPrintInit, schema.TypeName())
+	fp = r.ofInt32(fp, int32(schema.FieldCount()))
+	for _, descriptor := range schema.fieldDefinitions {
+		fp = r.ofString(fp, descriptor.fieldName)
+		fp = r.ofInt32(fp, int32(descriptor.fieldKind))
+	}
+	return fp
+}
+
+func (r RabinFingerPrint) ofString(f int64, value string) int64 {
+	bytes := []byte(value)
+	fp := r.ofInt32(f, int32(len(bytes)))
+	for _, b := range bytes {
+		fp = r.ofByte(fp, b)
+	}
+	return fp
+}
+
+func (r RabinFingerPrint) ofInt32(f int64, value int32) int64 {
+	fp := r.ofByte(f, byte(value&0xff))
+	fp = r.ofByte(fp, byte((value>>8)&0xff))
+	fp = r.ofByte(fp, byte((value>>16)&0xff))
+	fp = r.ofByte(fp, byte((value>>24)&0xff))
+	return fp
+}
+
+func (r RabinFingerPrint) ofByte(f int64, value byte) int64 {
+	var rightShifted int64
+	if f >= 0 {
+		rightShifted = f >> 8
+	} else {
+		rightShifted = int64(uint64(f) >> 8)
+	}
+	return rightShifted ^ r.table[(f^int64(value))&0xff]
+}

--- a/internal/serialization/rabin_test.go
+++ b/internal/serialization/rabin_test.go
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package serialization_test
+
+import (
+	"testing"
+
+	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	pserialization "github.com/hazelcast/hazelcast-go-client/serialization"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRabinFingerprintIsConsistentWithWrittenData(t *testing.T) {
+	rabin := serialization.NewRabinFingerPrint()
+	fieldDefinitionMap := make(map[string]*serialization.FieldDescriptor)
+	ageField := serialization.NewFieldDescriptor("age", pserialization.FieldKindInt32)
+	nameField := serialization.NewFieldDescriptor("name", pserialization.FieldKindString)
+	fieldDefinitionMap["age"] = &ageField
+	fieldDefinitionMap["name"] = &nameField
+
+	schema := serialization.NewSchema("student", fieldDefinitionMap, rabin)
+	schemaId := schema.ID()
+	/*
+		The magic number is generated using the following code snippet:
+
+		SchemaWriter writer = new SchemaWriter("student");
+		writer.addField(new FieldDescriptor("age", FieldKind.INT32));
+		writer.addField(new FieldDescriptor("name", FieldKind.STRING));
+		Schema schema = writer.build();
+		System.out.println(schema.getSchemaId());
+	*/
+	assert.Equal(t, int64(6299127804903769351), schemaId)
+}

--- a/internal/serialization/schema.go
+++ b/internal/serialization/schema.go
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package serialization
+
+import (
+	"fmt"
+	"sort"
+)
+
+type Schema struct {
+	fieldDefinitionMap map[string]*FieldDescriptor
+	typeName           string
+	// Go does not have TreeMap, so we use a slice to store sorted fields
+	fieldDefinitions      []*FieldDescriptor
+	id                    int64
+	numberOfVarSizeFields int32
+	fixedSizeFieldsLength int32
+}
+
+func NewSchema(typeName string, fieldDefinitionMap map[string]*FieldDescriptor, rabin RabinFingerPrint) Schema {
+	fds := make([]*FieldDescriptor, len(fieldDefinitionMap))
+	c := 0
+	for _, fd := range fieldDefinitionMap {
+		fds[c] = fd
+		c += 1
+	}
+	// Sort according to field name
+	sort.SliceStable(fds, func(i, j int) bool {
+		return fds[i].fieldName < fds[j].fieldName
+	})
+	schema := Schema{
+		typeName:           typeName,
+		fieldDefinitionMap: fieldDefinitionMap,
+		fieldDefinitions:   fds,
+	}
+	schema.init(rabin)
+	return schema
+}
+
+func (s *Schema) GetField(fieldName string) *FieldDescriptor {
+	if fd, ok := s.fieldDefinitionMap[fieldName]; ok {
+		return fd
+	}
+	return nil
+}
+
+func (s *Schema) ID() int64 {
+	return s.id
+}
+
+func (s *Schema) FieldCount() int {
+	return len(s.fieldDefinitions)
+}
+
+func (s Schema) String() string {
+	return fmt.Sprintf("Schema{typeName=%s, numberOfComplexFields=%d, primitivesLength=%d, fieldDefinitionMap=%v}",
+		s.typeName, s.numberOfVarSizeFields, s.fixedSizeFieldsLength, s.fieldDefinitionMap)
+}
+
+func (s *Schema) TypeName() string {
+	return s.typeName
+}
+
+func (s *Schema) init(rabin RabinFingerPrint) {
+	var fixedSizeFields []*FieldDescriptor
+	var varSizeFields []*FieldDescriptor
+	for _, fd := range s.fieldDefinitionMap {
+		fieldKind := fd.fieldKind
+		if FieldOperations(fieldKind).KindSizeInBytes() == variableKindSize {
+			varSizeFields = append(varSizeFields, fd)
+		} else {
+			fixedSizeFields = append(fixedSizeFields, fd)
+		}
+	}
+	sort.SliceStable(fixedSizeFields, func(i, j int) bool {
+		kindSize1 := FieldOperations(fixedSizeFields[j].fieldKind).KindSizeInBytes()
+		kindSize2 := FieldOperations(fixedSizeFields[i].fieldKind).KindSizeInBytes()
+		return kindSize1 < kindSize2
+	})
+	var offset int32
+	for _, descriptor := range fixedSizeFields {
+		descriptor.offset = offset
+		offset += FieldOperations(descriptor.fieldKind).KindSizeInBytes()
+	}
+	s.fixedSizeFieldsLength = offset
+	for i, descriptor := range varSizeFields {
+		descriptor.index = int32(i)
+	}
+	s.numberOfVarSizeFields = int32(len(varSizeFields))
+	s.id = rabin.OfSchema(s)
+}

--- a/internal/serialization/schema_service.go
+++ b/internal/serialization/schema_service.go
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package serialization
+
+type SchemaService struct {
+	schemaMap map[int64]Schema
+}
+
+func NewSchemaService() *SchemaService {
+	return &SchemaService{
+		schemaMap: make(map[int64]Schema),
+	}
+}
+
+func (s *SchemaService) Get(schemaId int64) (Schema, bool) {
+	schema, ok := s.schemaMap[schemaId]
+	return schema, ok
+}
+
+func (s *SchemaService) PutLocal(schema Schema) {
+	s.schemaMap[schema.ID()] = schema
+}

--- a/internal/serialization/schema_writer.go
+++ b/internal/serialization/schema_writer.go
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package serialization
+
+import pubserialization "github.com/hazelcast/hazelcast-go-client/serialization"
+
+type SchemaWriter struct {
+	fieldDefinitionMap map[string]*FieldDescriptor
+	typeName           string
+}
+
+func NewSchemaWriter(typeName string) SchemaWriter {
+	return SchemaWriter{
+		typeName:           typeName,
+		fieldDefinitionMap: make(map[string]*FieldDescriptor),
+	}
+}
+
+func (s SchemaWriter) addField(fd FieldDescriptor) {
+	s.fieldDefinitionMap[fd.fieldName] = &fd
+}
+
+func (s SchemaWriter) Build(rabin RabinFingerPrint) Schema {
+	return NewSchema(s.typeName, s.fieldDefinitionMap, rabin)
+}
+
+func (s SchemaWriter) WriteInt32(fieldName string, value int32) {
+	s.addField(NewFieldDescriptor(fieldName, pubserialization.FieldKindInt32))
+}
+
+func (s SchemaWriter) WriteString(fieldName string, value *string) {
+	s.addField(NewFieldDescriptor(fieldName, pubserialization.FieldKindString))
+}

--- a/internal/serialization/serialization.go
+++ b/internal/serialization/serialization.go
@@ -37,6 +37,7 @@ type Service struct {
 	portableSerializer   *PortableSerializer
 	identifiedSerializer *IdentifiedDataSerializableSerializer
 	customSerializers    map[reflect.Type]pubserialization.Serializer
+	compactSerializer    *CompactStreamSerializer
 }
 
 func NewService(config *pubserialization.Config) (*Service, error) {
@@ -45,6 +46,7 @@ func NewService(config *pubserialization.Config) (*Service, error) {
 		SerializationConfig: config,
 		registry:            make(map[int32]pubserialization.Serializer),
 		customSerializers:   config.CustomSerializers(),
+		compactSerializer:   NewCompactStreamSerializer(config.Compact),
 	}
 	s.portableSerializer, err = NewPortableSerializer(s, s.SerializationConfig.PortableFactories(), s.SerializationConfig.PortableVersion)
 	if err != nil {
@@ -146,6 +148,9 @@ func (s *Service) LookUpDefaultSerializer(obj interface{}) pubserialization.Seri
 	if serializer != (pubserialization.Serializer)(nil) {
 		return serializer
 	}
+	if s.compactSerializer.IsRegisteredAsCompact(reflect.TypeOf(obj)) {
+		return s.compactSerializer
+	}
 	if _, ok := obj.(pubserialization.IdentifiedDataSerializable); ok {
 		return s.identifiedSerializer
 	}
@@ -159,6 +164,8 @@ func (s *Service) lookupBuiltinDeserializer(typeID int32) pubserialization.Seria
 	switch typeID {
 	case TypeNil:
 		return nilSerializer
+	case TypeCompact:
+		return s.compactSerializer
 	case TypePortable:
 		return s.portableSerializer
 	case TypeDataSerializable:

--- a/internal/serialization/serialization_consts.go
+++ b/internal/serialization/serialization_consts.go
@@ -50,6 +50,7 @@ const (
 	TypeJavaLocalTime      = -52
 	TypeJavaLocalDateTime  = -53
 	TypeJavaOffsetDateTime = -54
+	TypeCompact            = -55
 	TypeJSONSerialization  = -130
 	TypeGobSerialization   = -140
 )

--- a/serialization/api.go
+++ b/serialization/api.go
@@ -17,6 +17,8 @@
 package serialization
 
 import (
+	"reflect"
+
 	"github.com/hazelcast/hazelcast-go-client/types"
 )
 
@@ -406,3 +408,28 @@ type PortableReader interface {
 	// ReadDecimalArray a decimal array.
 	ReadDecimalArray(fieldName string) (ds []types.Decimal)
 }
+
+type CompactSerializer interface {
+	Type() reflect.Type
+	TypeName() string
+	Read(reader CompactReader) interface{}
+	Write(writer CompactWriter, value interface{})
+}
+
+type CompactReader interface {
+	ReadInt32(fieldName string) int32
+	ReadString(fieldName string) *string
+}
+
+type CompactWriter interface {
+	WriteInt32(fieldName string, value int32)
+	WriteString(fieldName string, value *string)
+}
+
+type FieldKind int32
+
+const (
+	FieldKindInt32        FieldKind = 8
+	FieldKindString       FieldKind = 16
+	FieldKindNotAvailable FieldKind = 46
+)

--- a/serialization/compact_config.go
+++ b/serialization/compact_config.go
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package serialization
+
+type CompactConfig struct {
+	serializers map[string]CompactSerializer
+}
+
+func (cc *CompactConfig) Clone() CompactConfig {
+	var clone CompactConfig
+	m := make(map[string]CompactSerializer, len(cc.serializers))
+	for k, v := range cc.serializers {
+		m[k] = v
+	}
+	clone.serializers = m
+	return clone
+}
+
+func (cc *CompactConfig) Serializers() map[string]CompactSerializer {
+	return cc.serializers
+}
+
+func (cc *CompactConfig) Validate() error {
+	cc.ensureSerializers()
+	return nil
+}
+
+func (cc *CompactConfig) SetSerializers(serializers ...CompactSerializer) {
+	cc.ensureSerializers()
+	for _, ser := range serializers {
+		cc.serializers[ser.TypeName()] = ser
+	}
+}
+
+func (cc *CompactConfig) ensureSerializers() {
+	if cc.serializers == nil {
+		cc.serializers = make(map[string]CompactSerializer)
+	}
+}

--- a/serialization/serialization_config.go
+++ b/serialization/serialization_config.go
@@ -26,6 +26,7 @@ import (
 type Config struct {
 	globalSerializer                    Serializer
 	customSerializers                   map[reflect.Type]Serializer
+	Compact                             CompactConfig
 	identifiedDataSerializableFactories []IdentifiedDataSerializableFactory
 	portableFactories                   []PortableFactory
 	classDefinitions                    []*ClassDefinition
@@ -71,6 +72,7 @@ func (c *Config) Clone() Config {
 		customSerializers:                   serializers,
 		globalSerializer:                    c.globalSerializer,
 		classDefinitions:                    defs,
+		Compact:                             c.Compact.Clone(),
 	}
 }
 
@@ -78,7 +80,7 @@ func (c *Config) Validate() error {
 	if c.customSerializers == nil {
 		c.customSerializers = map[reflect.Type]Serializer{}
 	}
-	return nil
+	return c.Compact.Validate()
 }
 
 // SetIdentifiedDataSerializableFactories adds zore or more identified data serializable factories.

--- a/sql/driver/driver_test.go
+++ b/sql/driver/driver_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/hazelcast/hazelcast-go-client/cluster"
+	"github.com/hazelcast/hazelcast-go-client/internal/it"
 	"github.com/hazelcast/hazelcast-go-client/internal/sql/driver"
 	"github.com/hazelcast/hazelcast-go-client/logger"
 	"github.com/hazelcast/hazelcast-go-client/serialization"
@@ -53,6 +54,7 @@ func TestSetSSLConfig(t *testing.T) {
 
 func TestSetSerializationConfig(t *testing.T) {
 	config := &serialization.Config{PortableVersion: 2}
+	it.Must(config.Validate())
 	if err := SetSerializationConfig(config); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
**feature branch port of #782, already approved**
Support client-side compact serialization only for the types `string` and `int32`

- toObject and toData is supported

- Compact configuration is supported.

- CompactSerializer interface and CompactReader, CompactWriter implementations (only int32 and string methods).

Tests written in this PR:

- **TestRabinFingerprintIsConsistentWithWrittenData**: Different than Java in a way that I used a magic number instead of testing it with `RabinFingerPrint(byte[])` like Java does. Because I am not sure my `RabinFingerPrint(byte)` implementation is correct, so I cannot test something with something I am not sure is working correctly.
- **TestWithExplicitSerializer**: Different than Java's test in a way that I used a different type. Instead of Employee, I used the Student type because this PR does not have types needed for Employee type (specifically long and boolean).   
- **TestAllTypesWithCustomSerializer**: Only includes the available types.