### PR TITLE
Fix Invocation Service group lost handling

### DIFF
--- a/internal/invocation/invocation_service.go
+++ b/internal/invocation/invocation_service.go
@@ -73,13 +73,11 @@ func NewService(handler Handler, ed *event.DispatchService, lg logger.LogAdaptor
 	}
 	s.eventDispatcher.Subscribe(EventGroupLost, serviceSubID, func(event event.Event) {
 		go func() {
-			for {
-				select {
-				case s.groupLostCh <- event.(*GroupLostEvent):
-					return
-				case <-s.doneCh:
-					return
-				}
+			select {
+			case s.groupLostCh <- event.(*GroupLostEvent):
+				return
+			case <-s.doneCh:
+				return
 			}
 		}()
 	})


### PR DESCRIPTION
This PR fixes group lost event handling in the Invocation Service:

* The subscriber to the group lost event in the invocation service should return if the invocation service is stopped.
* `handleGroupLost` relied on an atomic value for protection, which was wrong. Replaced that with a mutex.