### PR TITLE
[EASY] [LOW PRIORITY] Added TraceHere method

### DIFF
--- a/internal/logger/default_logger.go
+++ b/internal/logger/default_logger.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"runtime"
 	"strings"
 
 	"github.com/hazelcast/hazelcast-go-client/logger"
@@ -104,6 +105,22 @@ func (la LogAdaptor) Debug(f func() string) {
 // Trace runs the given function to generate the logger string, if logger level is trace or finer.
 func (la LogAdaptor) Trace(f func() string) {
 	la.Log(logger.WeightTrace, f)
+}
+
+// TraceHere logs the function name, source file and line number of the call site.
+func (la LogAdaptor) TraceHere() {
+	const pkg = "github.com/hazelcast/hazelcast-go-client/"
+	const pkgLen = len(pkg)
+	la.Log(logger.WeightTrace, func() string {
+		pc, file, line, ok := runtime.Caller(3)
+		if ok {
+			if details := runtime.FuncForPC(pc); details != nil {
+				fun := details.Name()[pkgLen:]
+				return fmt.Sprintf("HERE -> %s [%s:%d]", fun, file, line)
+			}
+		}
+		return fmt.Sprintf("(could not generate TraceHere output)")
+	})
 }
 
 // Info runs the given function to generate the logger string, if logger level is trace or finer.


### PR DESCRIPTION
`TraceHere` logs the function, file and line number of its call site.

Sample usage:
```go
func (c *Client) GetMap(ctx context.Context, name string) (*Map, error) {
	c.ic.Logger.TraceHere()
	if c.ic.State() != client.Ready {
		return nil, hzerrors.ErrClientNotActive
	}
	return c.proxyManager.getMap(ctx, name)
}
```

Sample output:
```
2022/07/06 22:57:09 TRACE: event.DispatchService.Publish: lifecyclestatechanged
2022/07/06 22:57:09 TRACE: HERE -> (*Client).GetMap [/var/git/dev/Projects/hazelcast-go-client/client.go:120]
2022/07/06 22:57:09 TRACE: HERE -> internal/client.(*Client).State [/var/git/dev/Projects/hazelcast-go-client/internal/client/client.go:190]
2022/07/06 22:57:09 TRACE: invocation.Service.sendInvocation correlationID: 3
```
