### PR TITLE
[master] Fixes map PutIfAbsentXXX methods

### DIFF
--- a/map_it_test.go
+++ b/map_it_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -93,13 +93,17 @@ func TestMap_PutWithTTLAndMaxIdle(t *testing.T) {
 func TestMap_PutIfAbsent(t *testing.T) {
 	it.MapTester(t, func(t *testing.T, m *hz.Map) {
 		targetValue := "value"
-		if _, err := m.PutIfAbsent(context.Background(), "key", targetValue); err != nil {
+		v, err := m.PutIfAbsent(context.Background(), "key", targetValue)
+		if err != nil {
 			t.Fatal(err)
 		}
+		it.AssertEquals(t, nil, v)
 		it.AssertEquals(t, targetValue, it.MustValue(m.Get(context.Background(), "key")))
-		if _, err := m.PutIfAbsent(context.Background(), "key", "another-value"); err != nil {
+		v, err = m.PutIfAbsent(context.Background(), "key", "another-value")
+		if err != nil {
 			t.Fatal(err)
 		}
+		it.AssertEquals(t, "value", v)
 		it.AssertEquals(t, targetValue, it.MustValue(m.Get(context.Background(), "key")))
 	})
 }
@@ -107,9 +111,11 @@ func TestMap_PutIfAbsent(t *testing.T) {
 func TestMap_PutIfAbsentWithTTL(t *testing.T) {
 	it.MapTester(t, func(t *testing.T, m *hz.Map) {
 		targetValue := "value"
-		if _, err := m.PutIfAbsentWithTTL(context.Background(), "key", targetValue, 1*time.Second); err != nil {
+		v, err := m.PutIfAbsentWithTTL(context.Background(), "key", targetValue, 1*time.Second)
+		if err != nil {
 			t.Fatal(err)
 		}
+		assert.Equal(t, nil, v)
 		assert.Equal(t, targetValue, it.MustValue(m.Get(context.Background(), "key")))
 		it.Eventually(t, func() bool {
 			return it.MustValue(m.Get(context.Background(), "key")) == nil
@@ -120,9 +126,11 @@ func TestMap_PutIfAbsentWithTTL(t *testing.T) {
 func TestMap_PutIfAbsentWithTTLAndMaxIdle(t *testing.T) {
 	it.MapTester(t, func(t *testing.T, m *hz.Map) {
 		targetValue := "value"
-		if _, err := m.PutIfAbsentWithTTLAndMaxIdle(context.Background(), "key", targetValue, 1*time.Second, 1*time.Second); err != nil {
+		v, err := m.PutIfAbsentWithTTLAndMaxIdle(context.Background(), "key", targetValue, 1*time.Second, 1*time.Second)
+		if err != nil {
 			t.Fatal(err)
 		}
+		assert.Equal(t, nil, v)
 		assert.Equal(t, targetValue, it.MustValue(m.Get(context.Background(), "key")))
 		it.Eventually(t, func() bool {
 			return it.MustValue(m.Get(context.Background(), "key")) == nil

--- a/proxy_map.go
+++ b/proxy_map.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -180,7 +180,7 @@ func (m *Map) mapListenerEventHandler(listener MapListener) EntryNotifiedHandler
 			listener.MapCleared(event)
 		case EntryAllEvicted:
 			listener.MapEvicted(event)
-		default: 
+		default:
 			m.logger.Warnf("Not a known map event type: %d", event.EventType)
 		}
 	}
@@ -779,7 +779,7 @@ func (m *Map) PutIfAbsentWithTTLAndMaxIdle(ctx context.Context, key interface{},
 		if response, err := m.invokeOnKey(ctx, request, keyData); err != nil {
 			return nil, err
 		} else {
-			return codec.DecodeMapPutIfAbsentWithMaxIdleResponse(response), nil
+			return m.convertToObject(codec.DecodeMapPutIfAbsentWithMaxIdleResponse(response))
 		}
 	}
 }
@@ -1149,7 +1149,7 @@ func (m *Map) putIfAbsent(ctx context.Context, key interface{}, value interface{
 		if response, err := m.invokeOnKey(ctx, request, keyData); err != nil {
 			return nil, err
 		} else {
-			return codec.DecodeMapPutIfAbsentResponse(response), nil
+			return m.convertToObject(codec.DecodeMapPutIfAbsentResponse(response))
 		}
 	}
 }


### PR DESCRIPTION
Map's `PutIfAbsentXXX` methods erroneously returned `serialization.Data` instead of actual values. This PR fixes that and updates the tests to catch that problem.