### PR TITLE
Fixed races in the codebase

### DIFF
--- a/.github/workflows/test-race.yaml
+++ b/.github/workflows/test-race.yaml
@@ -1,0 +1,45 @@
+name: "Test Go Client with Race Detector Enabled"
+on: ["push", "pull_request"]
+jobs:
+  test:
+    runs-on: "ubuntu-latest"
+    env:
+      GOPATH: "${{ github.workspace }}"
+      HZ_VERSION: "5.1.2"
+    defaults:
+      run:
+        shell: "bash"
+        working-directory: "$HOME/hazelcast-go-client"
+    steps:
+      - name: "Checkout Code"
+        uses: "actions/checkout@v2"
+        with:
+          path: "$HOME/hazelcast-go-client"
+
+      - name: "Install Dependencies"
+        run: |
+          sudo apt-get update &&\
+          sudo apt-get install -y openjdk-8-jdk-headless maven
+
+      - name: "Start Hazelcast Remote Controller"
+        run: |
+          bash ./rc.sh start
+          sleep 2
+
+      - name: "Setup Go"
+        uses: "actions/setup-go@v2"
+        with:
+          go-version: "1.18"
+
+      - name: "Install Go tools"
+        run: |
+          go install golang.org/x/tools/...@v0.1.11
+          go install honnef.co/go/tools/cmd/staticcheck@2022.1.2
+
+      - name: "Go mod tidy"
+        run: |
+          go mod tidy
+
+      - name: "Run Tests with Race Detection"
+        run: |
+          make test-race

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ test: test-all
 test-all:
 	env MEMBER_COUNT=$(MEMBER_COUNT) go test $(TEST_FLAGS) $(PACKAGES) ./...
 
-test-all-race:
+test-race:
 	env MEMBER_COUNT=$(MEMBER_COUNT) go test $(TEST_FLAGS) -race $(PACKAGES)
 
 test-cover:

--- a/internal/security/base_credentials.go
+++ b/internal/security/base_credentials.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@
 package security
 
 import (
+	"sync/atomic"
+
 	"github.com/hazelcast/hazelcast-go-client/serialization"
 )
 
@@ -27,7 +29,7 @@ const (
 
 // BaseCredentials is base implementation for Credentials interface.
 type BaseCredentials struct {
-	endpoint  string
+	endpoint  atomic.Value
 	principal string
 }
 
@@ -41,20 +43,20 @@ func (bc *BaseCredentials) ClassID() int32 {
 
 func (bc *BaseCredentials) WritePortable(writer serialization.PortableWriter) {
 	writer.WriteString("principal", bc.principal)
-	writer.WriteString("endpoint", bc.endpoint)
+	writer.WriteString("endpoint", bc.Endpoint())
 }
 
 func (bc *BaseCredentials) ReadPortable(reader serialization.PortableReader) {
-	bc.endpoint = reader.ReadString("endpoint")
+	bc.SetEndpoint(reader.ReadString("endpoint"))
 	bc.principal = reader.ReadString("principal")
 }
 
 func (bc *BaseCredentials) Endpoint() string {
-	return bc.endpoint
+	return bc.endpoint.Load().(string)
 }
 
 func (bc *BaseCredentials) SetEndpoint(endpoint string) {
-	bc.endpoint = endpoint
+	bc.endpoint.Store(endpoint)
 }
 
 func (bc *BaseCredentials) Principal() string {

--- a/replicated_map_it_test.go
+++ b/replicated_map_it_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -247,6 +247,10 @@ func TestReplicatedMap_AddEntryListenerToKeyWithPredicate(t *testing.T) {
 		it.MustValue(m.Put(context.Background(), "k1", "foo"))
 		it.MustValue(m.Put(context.Background(), "k2", "foo"))
 		it.MustValue(m.Put(context.Background(), "k1", "foo2"))
-		it.Eventually(t, func() bool { return atomic.LoadInt32(&callCount) == targetCallCount }, "Call count ", callCount)
+		it.Eventually(t, func() bool {
+			cc := atomic.LoadInt32(&callCount)
+			t.Logf("call count: %d", cc)
+			return cc == targetCallCount
+		})
 	})
 }


### PR DESCRIPTION
Fixed the following races in the codebase, which caused tests fail when the race detector is enabled.

* ConnectionManager reset
* BaseCredentials endpoint
* `TestReplicatedMap_AddEntryListenerToKeyWithPredicate`

Also changed the target for the race enabled tests to `test-race`.

Added a workflow for running the tests with race detector.