### PR TITLE
[TRIVIAL] Fix client not allowed error in TestClusterID

### DIFF
--- a/internal/it/util.go
+++ b/internal/it/util.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"math/rand"
 	"os"
@@ -37,7 +36,6 @@ import (
 	"go.uber.org/goleak"
 
 	hz "github.com/hazelcast/hazelcast-go-client"
-	"github.com/hazelcast/hazelcast-go-client/hzerrors"
 	"github.com/hazelcast/hazelcast-go-client/internal/proxy"
 	"github.com/hazelcast/hazelcast-go-client/logger"
 	"github.com/hazelcast/hazelcast-go-client/serialization"
@@ -199,22 +197,6 @@ func MustClient(client *hz.Client, err error) *hz.Client {
 		panic(err)
 	}
 	return client
-}
-
-// EnsureClient prevents client start to fail the test when the client is not allowed in the cluster.
-func EnsureClient(config hz.Config) *hz.Client {
-	for i := 0; i < 60; i++ {
-		client, err := hz.StartNewClientWithConfig(context.Background(), config)
-		if err != nil {
-			if errors.Is(err, hzerrors.ErrClientNotAllowedInCluster) {
-				time.Sleep(1 * time.Second)
-				continue
-			}
-			panic(err)
-		}
-		return client
-	}
-	panic("the client could not connect to the cluster in 60 seconds.")
 }
 
 func NewUniqueObjectName(service string, labels ...string) string {


### PR DESCRIPTION
It seems I've modified the wrong ClusterID test last time. This one fixes the correct one, and converts `ensureClient` to a package function.

See: https://github.com/hazelcast/hazelcast-go-client/pull/841