### PR TITLE
Near Cache Test Updates

### DIFF
--- a/client_internals_test_utils.go
+++ b/client_internals_test_utils.go
@@ -2,7 +2,7 @@
 // +build hazelcastinternal,hazelcastinternaltest
 
 /*
- * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -54,17 +54,28 @@ func (ci *ClientInternal) SerializationService() *serialization.Service {
 	return ci.client.ic.SerializationService
 }
 
+func (ci *ClientInternal) NewNearCacheManager(reconInterval, maxMiss int) *inearcache.Manager {
+	return inearcache.NewManager(ci.client.ic, reconInterval, maxMiss)
+}
+
 // MakeNearCacheAdapterFromMap returns the nearcache of the given map.
 // It returns an interface{} instead of it.NearCacheAdapter in order not to introduce an import cycle.
 func MakeNearCacheAdapterFromMap(m *Map) interface{} {
 	if m.hasNearCache {
-		return NearCacheTestAdapter{m: m}
+		return &NearCacheTestAdapter{m: m}
 	}
 	panic("hazelcast.MakeNearCacheAdapterFromMap: map has no near cache")
 }
 
 type NearCacheTestAdapter struct {
 	m *Map
+}
+
+func (n *NearCacheTestAdapter) NearCache() *inearcache.NearCache {
+	if n.m.hasNearCache {
+		return n.m.ncm.nc
+	}
+	panic("hazelcast.NearCacheTestAdapter.NearCache: map has no near cache")
 }
 
 func (n NearCacheTestAdapter) Size() int {

--- a/internal/it/adapters.go
+++ b/internal/it/adapters.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -36,4 +36,5 @@ type NearCacheAdapter interface {
 	GetRecord(key interface{}) (*inearcache.Record, bool)
 	InvalidationRequests() int64
 	ToNearCacheKey(key interface{}) interface{}
+	NearCache() *inearcache.NearCache
 }

--- a/internal/it/util.go
+++ b/internal/it/util.go
@@ -342,6 +342,16 @@ func (c TestCluster) DefaultConfig() hz.Config {
 	return config
 }
 
+func (c TestCluster) DefaultConfigWithNoSSL() hz.Config {
+	config := hz.Config{}
+	config.Cluster.Name = c.ClusterID
+	config.Cluster.Network.SetAddresses(fmt.Sprintf("localhost:%d", c.Port))
+	if TraceLoggingEnabled() {
+		config.Logger.Level = logger.TraceLevel
+	}
+	return config
+}
+
 func xmlConfig(clusterName string, port int) string {
 	return fmt.Sprintf(`
         <hazelcast xmlns="http://www.hazelcast.com/schema/config"

--- a/internal/nearcache/repairing_task.go
+++ b/internal/nearcache/repairing_task.go
@@ -481,10 +481,6 @@ func (mc *MetaDataContainer) CASStaleSequence(lastKnown, lastReceived int64) boo
 	return atomic.CompareAndSwapInt64(&mc.staleSeq, lastKnown, lastReceived)
 }
 
-func (mc *MetaDataContainer) SetMissedSequenceCount(count int64) {
-	atomic.StoreInt64(&mc.missedSeqs, count)
-}
-
 func (mc *MetaDataContainer) MissedSequenceCount() int64 {
 	return atomic.LoadInt64(&mc.missedSeqs)
 }

--- a/nearcache/nearcache_it_test.go
+++ b/nearcache/nearcache_it_test.go
@@ -1033,7 +1033,7 @@ func TestRepairingTaskRun(t *testing.T) {
 	// this is a test for covering sync init of RepairingTask.
 	clusterName := t.Name()
 	mapName := it.NewUniqueObjectName("map")
-	const port = 53001
+	const port = 53011
 	clsCfg := invalidationXMLConfig(clusterName, "non-existent", port)
 	cls := it.StartNewClusterWithConfig(1, clsCfg, port)
 	defer cls.Shutdown()
@@ -1087,6 +1087,7 @@ func memberInvalidatesClientNearCache(t *testing.T, port int, makeScript func(tc
 	cfg.AddNearCache(ncc)
 	tcx.Config = &cfg
 	client := it.MustClient(hz.StartNewClientWithConfig(nil, cfg))
+	defer client.Shutdown(ctx)
 	tcx.Client = client
 	m := it.MustValue(tcx.Client.GetMap(ctx, tcx.MapName)).(*hz.Map)
 	tcx.M = m

--- a/nearcache/nearcache_it_test.go
+++ b/nearcache/nearcache_it_test.go
@@ -925,7 +925,7 @@ func TestMemberLoadAllInvalidatesClientNearCache(t *testing.T) {
         	map.loadAll(true);
 		`, tcx.MapName)
 	}
-	memberInvalidatesClientNearCache(t, f)
+	memberInvalidatesClientNearCache(t, 51001, f)
 }
 
 func TestMemberPutAllInvalidatesClientNearCache(t *testing.T) {
@@ -940,11 +940,12 @@ func TestMemberPutAllInvalidatesClientNearCache(t *testing.T) {
         	map.putAll(items);
 		`, size, tcx.MapName)
 	}
-	memberInvalidatesClientNearCache(t, f)
+	memberInvalidatesClientNearCache(t, 51011, f)
 }
 
 func TestMemberSetAllInvalidatesClientNearCache(t *testing.T) {
 	// see: com.hazelcast.client.map.impl.nearcache.ClientMapNearCacheTest#testMemberSetAll_invalidates_clientNearCache
+	it.SkipIf(t, "hz > 4, hz < 4.1")
 	f := func(tcx it.MapTestContext, size int32) string {
 		return fmt.Sprintf(`
 			var items = new java.util.HashMap(%[1]d);
@@ -955,10 +956,10 @@ func TestMemberSetAllInvalidatesClientNearCache(t *testing.T) {
         	map.setAll(items);
 		`, size, tcx.MapName)
 	}
-	memberInvalidatesClientNearCache(t, f)
+	memberInvalidatesClientNearCache(t, 51021, f)
 }
 
-func memberInvalidatesClientNearCache(t *testing.T, makeScript func(tcx it.MapTestContext, size int32) string) {
+func memberInvalidatesClientNearCache(t *testing.T, port int, makeScript func(tcx it.MapTestContext, size int32) string) {
 	// ported from: com.hazelcast.client.map.impl.nearcache.ClientMapNearCacheTest#testMemberLoadAll_invalidates_clientNearCache
 	tcx := it.MapTestContext{
 		T:      t,
@@ -967,7 +968,6 @@ func memberInvalidatesClientNearCache(t *testing.T, makeScript func(tcx it.MapTe
 	}
 	clusterName := t.Name()
 	tcx.MapName = it.NewUniqueObjectName("map")
-	const port = 51001
 	clsCfg := invalidationXMLConfig(clusterName, tcx.MapName, port)
 	cls := it.StartNewClusterWithConfig(1, clsCfg, port)
 	defer cls.Shutdown()


### PR DESCRIPTION
This PR:
* Disables `TestMemberSetAllInvalidatesClientNearCache` for Hz 4.0.x
* Uses different cluster port numbers in `TestMemberXXXAllInvalidatesClientNearCache` tests.
* Increases Near Cache test coverage by adding two tests for the repairing task.
* Updates `TestNearCacheInvalidateOnChange` to match better with the reference implementation.
* Adds `cls.DefaultConfigWithNoSSL()` method that returns a client config with no SSL.