### PR TITLE
Remove unncessary MarkRacy annotations

### DIFF
--- a/client_it_test.go
+++ b/client_it_test.go
@@ -258,21 +258,18 @@ func TestClient_Name(t *testing.T) {
 }
 
 func TestClientPortRangeAllAddresses(t *testing.T) {
-	it.MarkRacy(t)
 	portRangeConnectivityTest(t, func(validPort int) []string {
 		return []string{"127.0.0.1", "localhost", "0.0.0.0"}
 	}, 4, 3)
 }
 
 func TestClientPortRangeMultipleAddresses(t *testing.T) {
-	it.MarkRacy(t)
 	portRangeConnectivityTest(t, func(validPort int) []string {
 		return []string{"127.0.0.1", "localhost", fmt.Sprintf("0.0.0.0:%d", validPort)}
 	}, 4, 3)
 }
 
 func TestClientPortRangeSingleAddress(t *testing.T) {
-	it.MarkRacy(t)
 	portRangeConnectivityTest(t, func(validPort int) []string {
 		return []string{fmt.Sprintf("localhost:%d", validPort), "127.0.0.1", fmt.Sprintf("0.0.0.0:%d", validPort)}
 	}, 4, 3)
@@ -487,7 +484,6 @@ func TestClient_AddDistributedObjectListener(t *testing.T) {
 }
 
 func TestClusterReconnection_ShutdownCluster(t *testing.T) {
-	it.MarkRacy(t)
 	ctx := context.Background()
 	cls := it.StartNewClusterWithOptions("go-cli-test-cluster", 15701, it.MemberCount())
 	mu := &sync.Mutex{}
@@ -832,11 +828,10 @@ func TestClientFixConnection(t *testing.T) {
 
 func TestClientVersion(t *testing.T) {
 	// adding this test here, so there's no "unused lint warning.
-	assert.Equal(t, "1.3.0", hz.ClientVersion)
+	assert.Equal(t, "1.4.0", hz.ClientVersion)
 }
 
 func TestInvocationTimeout(t *testing.T) {
-	it.MarkRacy(t)
 	clientTester(t, func(t *testing.T, smart bool) {
 		tc := it.StartNewClusterWithOptions("invocation-timeout", 41701, 1)
 		defer tc.Shutdown()

--- a/internal/common.go
+++ b/internal/common.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ package internal
 const (
 	AggregateFactoryID = -29
 	// CurrentClientVersion should be manually set
-	CurrentClientVersion = "1.3.0"
+	CurrentClientVersion = "1.4.0"
 )
 
 // ClientType is used in the Management Center

--- a/proxy_it_test.go
+++ b/proxy_it_test.go
@@ -28,7 +28,6 @@ import (
 )
 
 func TestRetryWithoutRedoOperation(t *testing.T) {
-	it.MarkRacy(t)
 	// The connection should be retried on IOError
 	retryResult(t, false, true)
 }


### PR DESCRIPTION
Currently the codebase doesn't contain any known race condition. Some of the tests were marked as `MarkRacy`, which is wrong.

Also bumped the client version.