### PR TITLE
Prevent enterprise test to run on forked repo [API-1462]

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,12 +1,9 @@
 #### Contributing
 If you would like to contribute to hazelcast-go-client;
-- Fork the original repo
-- Commit your contributions in a new branch
-- Send a Pull Request
+1. Fork the original repo.
+2. Commit your contributions in a new branch.
+3. Send a Pull Request.
 
 For detailed instructions for our git process: [Developing with Git](https://hazelcast.atlassian.net/wiki/display/COM/Developing+with+Git)
 
-In order to merge your pull request, we need the contributor to sign [Hazelcast Contributor Agreement](https://hazelcast.atlassian.net/wiki/display/COM/Hazelcast+Contributor+Agreement). You do not have to wait for approval for doing this step.
-
-Please make sure that your code passes `sh linter.sh`. This is a script for [gometalinter](https://github.com/alecthomas/gometalinter)
-Please make sure that your code compiles and passes all the tests by running `localTest.sh` before sending a pull request.
+In order to merge your pull request, We need the contributor to sign [Hazelcast Contributor Agreement](https://hazelcast.atlassian.net/wiki/display/COM/Hazelcast+Contributor+Agreement). You do not have to wait for an approval for this specific step.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -5,10 +5,10 @@ Number of the clients:
 Cluster size, i.e. the number of Hazelcast cluster members:
 OS version : Windows/Linux/OSX
 
-#### Expected behaviour
+#### Expected behavior
 
 
-#### Actual behaviour
+#### Actual behavior
 
 
-#### Steps to reproduce the behaviour
+#### Steps to reproduce the behavior

--- a/.github/workflows/nightly_tests.yaml
+++ b/.github/workflows/nightly_tests.yaml
@@ -7,6 +7,7 @@ jobs:
   test_client:
     runs-on: ${{ matrix.os }}
     name: Run tests of master on ${{ matrix.os }} with Go ${{ matrix.go_version }}
+    if: github.repository == 'hazelcast/hazelcast-go-client'
     strategy:
         matrix:
             os: [ ubuntu-latest ]


### PR DESCRIPTION
Ensure nightly jobs are only running on original repository.
Remove unnecessary obsolete explanation and fix typos.