### PR TITLE
Fix nightly bug

### DIFF
--- a/.github/workflows/nightly_tests.yaml
+++ b/.github/workflows/nightly_tests.yaml
@@ -11,10 +11,10 @@ jobs:
     strategy:
         matrix:
             os: [ ubuntu-latest ]
-            go_version: [ 1.17, 1.18 ]
+            go_version: [ 1.17, 1.18, 1.19 ]
         fail-fast: false
-    steps:     
-    
+    steps:
+
       - name: Setup Java
         uses: actions/setup-java@v1
         with:

--- a/client.go
+++ b/client.go
@@ -116,8 +116,8 @@ func newClient(config Config) (*Client, error) {
 	}
 	c.addConfigEvents(&config)
 	c.createComponents(&config)
-	c.ic.AddShutdownHandler(c.destroyProxies)
-	c.ic.AddShutdownHandler(c.stopNearCacheManagers)
+	c.ic.AddBeforeShutdownHandler(c.destroyProxies)
+	c.ic.AddAfterShutdownHandler(c.stopNearCacheManagers)
 	return c, nil
 }
 

--- a/client_internals_it_test.go
+++ b/client_internals_it_test.go
@@ -387,9 +387,9 @@ func TestClientInternal_EncodeData(t *testing.T) {
 func TestProxyManagerShutdown(t *testing.T) {
 	clientTester(t, func(t *testing.T, smart bool) {
 		ctx := context.Background()
-		tc := it.StartNewClusterWithOptions("proxy-manager-graceful-shutdown", 5701, 1)
+		tc := it.StartNewClusterWithOptions("proxy-manager-graceful-shutdown", 35701, 1)
 		defer tc.Shutdown()
-		config := tc.DefaultConfigWithNoSSL()
+		config := tc.DefaultConfig()
 		config.Cluster.Unisocket = !smart
 		client := it.MustClient(hz.StartNewClientWithConfig(ctx, config))
 		defer client.Shutdown(ctx)

--- a/client_internals_it_test.go
+++ b/client_internals_it_test.go
@@ -387,7 +387,7 @@ func TestClientInternal_EncodeData(t *testing.T) {
 func TestProxyManagerShutdown(t *testing.T) {
 	clientTester(t, func(t *testing.T, smart bool) {
 		ctx := context.Background()
-		tc := it.StartNewClusterWithOptions("proxy-manager-graceful-shutdown", 35701, 1)
+		tc := it.StartNewClusterWithOptions(t.Name(), 35701, 1)
 		defer tc.Shutdown()
 		config := tc.DefaultConfig()
 		config.Cluster.Unisocket = !smart


### PR DESCRIPTION
Add Go 1.19 to nightly tests.
There was a bug due to location of shutdown handlers execution, the design has changed.
`TestProxyManagerShutdown` is using SSL enabled member side XML config, client config has changed according to it.