### PR TITLE
Added Clone() method for FlakeIDGeneratorConfig struct. [API-1428]

### DIFF
--- a/config.go
+++ b/config.go
@@ -119,10 +119,7 @@ func (c *Config) Clone() Config {
 	c.ensureMembershipListeners()
 	newLabels := make([]string, len(c.Labels))
 	copy(newLabels, c.Labels)
-	newFlakeIDConfigs := make(map[string]FlakeIDGeneratorConfig, len(c.FlakeIDGenerators))
-	for k, v := range c.FlakeIDGenerators {
-		newFlakeIDConfigs[k] = v
-	}
+	newFlakeIDConfigs := c.copyFlakeIDGeneratorConfig()
 	nccs := c.copyNearCacheConfig()
 	newNCs := make([]nearcache.Config, 0, len(c.NearCaches))
 	newNCs = append(newNCs, c.NearCaches...)
@@ -255,6 +252,15 @@ func (c Config) copyNearCacheConfig() map[string]nearcache.Config {
 	return configs
 }
 
+func (c Config) copyFlakeIDGeneratorConfig() map[string]FlakeIDGeneratorConfig {
+	c.ensureFlakeIDGenerators()
+	configs := make(map[string]FlakeIDGeneratorConfig, len(c.FlakeIDGenerators))
+	for k, v := range c.FlakeIDGenerators {
+		configs[k] = v.Clone()
+	}
+	return configs
+}
+
 type configForMarshal Config
 
 // StatsConfig contains configuration for Management Center.
@@ -303,6 +309,14 @@ func (f *FlakeIDGeneratorConfig) Validate() error {
 		return err
 	}
 	return nil
+}
+
+// Clone returns a copy of the FlakeIDGeneratorConfig struct
+func (f *FlakeIDGeneratorConfig) Clone() FlakeIDGeneratorConfig {
+	return FlakeIDGeneratorConfig{
+		PrefetchCount:  f.PrefetchCount,
+		PrefetchExpiry: f.PrefetchExpiry,
+	}
 }
 
 // NearCacheInvalidationConfig contains invalidation configuration for all Near Caches.

--- a/config_test.go
+++ b/config_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/hazelcast/hazelcast-go-client"
 	"github.com/hazelcast/hazelcast-go-client/cluster"
@@ -433,13 +434,9 @@ func configCloneFlakeIDGeneratorConfigTest(t *testing.T) {
 		PrefetchCount:  50_000,
 		PrefetchExpiry: types.Duration(time.Minute * 2),
 	}
-	err := cfg.Validate()
-	if err != nil {
-		return
-	}
+	require.NoError(t, cfg.Validate())
 	newCfg := cfg.Clone()
-	assert.True(t, reflect.DeepEqual(newCfg.PrefetchCount, cfg.PrefetchCount))
-	assert.True(t, reflect.DeepEqual(newCfg.PrefetchExpiry, cfg.PrefetchExpiry))
+	require.Equal(t, cfg, newCfg)
 }
 
 func configAddFlakeIDGeneratorTest(t *testing.T) {

--- a/config_test.go
+++ b/config_test.go
@@ -50,6 +50,7 @@ func TestConfig(t *testing.T) {
 		{name: "MarshalDefaultConfig", f: configMarshalDefaultConfigTest},
 		{name: "MarshalWithNearCacheConfig", f: configMarshalWithNearCacheConfigTest},
 		{name: "ValidateFlakeIDGeneratorConfig", f: configValidateFlakeIDGeneratorConfigTest},
+		{name: "CloneFlakeIDGeneratorConfig", f: configCloneFlakeIDGeneratorConfigTest},
 		{name: "AddFlakeIDGenerator", f: configAddFlakeIDGeneratorTest},
 		{name: "AddExistingFlakeIDGenerator", f: configAddExistingFlakeIDGeneratorTest},
 		{name: "AddNearCache", f: configAddNearCacheTest},
@@ -425,6 +426,20 @@ func configValidateFlakeIDGeneratorConfigTest(t *testing.T) {
 			}
 		})
 	}
+}
+
+func configCloneFlakeIDGeneratorConfigTest(t *testing.T) {
+	cfg := hazelcast.FlakeIDGeneratorConfig{
+		PrefetchCount:  50_000,
+		PrefetchExpiry: types.Duration(time.Minute * 2),
+	}
+	err := cfg.Validate()
+	if err != nil {
+		return
+	}
+	newCfg := cfg.Clone()
+	assert.True(t, reflect.DeepEqual(newCfg.PrefetchCount, cfg.PrefetchCount))
+	assert.True(t, reflect.DeepEqual(newCfg.PrefetchExpiry, cfg.PrefetchExpiry))
 }
 
 func configAddFlakeIDGeneratorTest(t *testing.T) {


### PR DESCRIPTION
- Edited `hazelcast.Config.Clone()` to use new `FlakeIDGeneratorConfig.Clone()` method instead of creating copies inside the function, similar to NearCache configs.
- Added test for `FlakeIDGeneratorConfig.Clone()`. 