### PR TITLE
Do not try to connect cluster members when the client is not connected to cluster [API-1492]

### DIFF
--- a/client_internals_it_test.go
+++ b/client_internals_it_test.go
@@ -435,10 +435,6 @@ func clientClusterConnectionConfigRetryTimeTest(t *testing.T) {
 	config.Cluster.ConnectionStrategy.Retry.InitialBackoff = types.Duration(math.MaxInt32 * time.Millisecond)
 	config.Cluster.ConnectionStrategy.Retry.MaxBackoff = types.Duration(math.MaxInt32 * time.Millisecond)
 	client := it.MustClient(hz.StartNewClientWithConfig(ctx, config))
-	defer func() {
-		ctx, _ := context.WithTimeout(ctx, time.Second*3)
-		client.Shutdown(ctx)
-	}()
 	ci := hz.NewClientInternal(client)
 	_, err := cls.RC.TerminateMember(ctx, cls.ClusterID, cls.MemberUUIDs[0])
 	require.NoError(t, err)
@@ -451,6 +447,9 @@ func clientClusterConnectionConfigRetryTimeTest(t *testing.T) {
 	require.Never(t, func() bool {
 		return len(cm.ActiveConnections()) != 0
 	}, AssertionSeconds*time.Second, time.Second)
+	ctx, cancel := context.WithTimeout(ctx, time.Second*3)
+	defer cancel()
+	client.Shutdown(ctx)
 }
 
 func proxyManagerShutdownTest(t *testing.T) {

--- a/client_internals_it_test.go
+++ b/client_internals_it_test.go
@@ -435,6 +435,10 @@ func clientClusterConnectionConfigRetryTimeTest(t *testing.T) {
 	config.Cluster.ConnectionStrategy.Retry.InitialBackoff = types.Duration(math.MaxInt32 * time.Millisecond)
 	config.Cluster.ConnectionStrategy.Retry.MaxBackoff = types.Duration(math.MaxInt32 * time.Millisecond)
 	client := it.MustClient(hz.StartNewClientWithConfig(ctx, config))
+	defer func() {
+		ctx, _ := context.WithTimeout(ctx, time.Second*3)
+		client.Shutdown(ctx)
+	}()
 	ci := hz.NewClientInternal(client)
 	_, err := cls.RC.TerminateMember(ctx, cls.ClusterID, cls.MemberUUIDs[0])
 	require.NoError(t, err)

--- a/client_internals_it_test.go
+++ b/client_internals_it_test.go
@@ -447,8 +447,8 @@ func clientClusterConnectionConfigRetryTimeTest(t *testing.T) {
 	require.Never(t, func() bool {
 		return len(cm.ActiveConnections()) != 0
 	}, AssertionSeconds*time.Second, time.Second)
-	ctx, cancel := context.WithTimeout(ctx, time.Second*3)
-	defer cancel()
+	ctx, cancel := context.WithCancel(ctx)
+	cancel()
 	client.Shutdown(ctx)
 }
 


### PR DESCRIPTION
Related tracking issue: https://github.com/hazelcast/hazelcast-go-client/issues/787
PR fix for Java client: https://github.com/hazelcast/hazelcast/pull/21705

Go Client runs correctly and the related problem does not occur. 