### PR TITLE
Check for the minimum size of the bytes read only once per frame [API-1493]

### DIFF
--- a/internal/cluster/client_message_test.go
+++ b/internal/cluster/client_message_test.go
@@ -11,8 +11,8 @@ import (
 
 func TestClientMessageReader(t *testing.T) {
 	testCases := []struct {
-		name string
 		f    func(t *testing.T)
+		name string
 	}{
 		{name: "readSingleFrame", f: readSingleFrame},
 		{name: "readMultiFrameMessage", f: readMultiFrameMessage},

--- a/internal/cluster/client_message_test.go
+++ b/internal/cluster/client_message_test.go
@@ -1,0 +1,152 @@
+package cluster
+
+import (
+	"bytes"
+	"github.com/hazelcast/hazelcast-go-client/internal/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"math/rand"
+	"testing"
+)
+
+func TestClientMessageReader(t *testing.T) {
+	testCases := []struct {
+		name string
+		f    func(t *testing.T)
+	}{
+		{name: "readSingleFrame", f: readSingleFrame},
+		{name: "readMultiFrameMessage", f: readMultiFrameMessage},
+		{name: "readFramesInMultipleCallsToRead", f: readFramesInMultipleCallsToRead},
+		{name: "readWhenTheFrameLengthAndFlagsNotReceivedAtFirst", f: readWhenTheFrameLengthAndFlagsNotReceivedAtFirst},
+		{name: "readFramesInMultipleCallsToReadFromWhenLastPieceIsSmall", f: readFramesInMultipleCallsToReadFromWhenLastPieceIsSmall},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			tc.f(t)
+		})
+	}
+}
+
+func readSingleFrame(t *testing.T) {
+	frame := createFrameWithRandomBytes(t, 42)
+	message := proto.NewClientMessage(frame)
+	buffer := writeToBuffer(t, message)
+	reader := newClientMessageReader()
+	reader.Append(buffer.Bytes())
+	require.NotNil(t, reader.Read())
+	iterator := proto.NewForwardFrameIterator(reader.clientMessage.Frames)
+	require.True(t, iterator.HasNext())
+	frameRead := iterator.Next()
+	require.Equal(t, frame.Content, frameRead.Content)
+	require.False(t, iterator.HasNext())
+}
+
+func readMultiFrameMessage(t *testing.T) {
+	frame1 := createFrameWithRandomBytes(t, 10)
+	frame2 := createFrameWithRandomBytes(t, 20)
+	frame3 := createFrameWithRandomBytes(t, 30)
+	message := proto.NewClientMessageForEncode()
+	message.AddFrame(frame1)
+	message.AddFrame(frame2)
+	message.AddFrame(frame3)
+	buffer := writeToBuffer(t, message)
+	reader := newClientMessageReader()
+	reader.Append((*buffer).Bytes())
+	require.NotNil(t, reader.Read())
+	iterator := reader.clientMessage.FrameIterator()
+	require.True(t, iterator.HasNext())
+	frameRead := iterator.Next()
+	require.Equal(t, frame1.Content, frameRead.Content)
+	require.True(t, iterator.HasNext())
+	frameRead = iterator.Next()
+	require.Equal(t, frame2.Content, frameRead.Content)
+	require.True(t, iterator.HasNext())
+	frameRead = iterator.Next()
+	require.Equal(t, frame3.Content, frameRead.Content)
+	require.False(t, iterator.HasNext())
+}
+
+func readFramesInMultipleCallsToRead(t *testing.T) {
+	frame := createFrameWithRandomBytes(t, 1000)
+	message := proto.NewClientMessage(frame)
+	buffer := writeToBuffer(t, message)
+	// split message two part and send sequentially
+	part1 := buffer.Next(750)
+	part2 := buffer.Bytes()
+	part1buffer := bytes.NewBuffer(part1)
+	part2buffer := bytes.NewBuffer(part2)
+	reader := newClientMessageReader()
+	reader.Append(part1buffer.Bytes())
+	// should not finish reading
+	require.Nil(t, reader.Read())
+	reader.Append(part2buffer.Bytes())
+	// all the message has been read
+	require.NotNil(t, reader.Read())
+	iterator := reader.clientMessage.FrameIterator()
+	require.True(t, iterator.HasNext())
+	frameRead := iterator.Next()
+	require.Equal(t, frame.Content, frameRead.Content)
+	assert.False(t, iterator.HasNext())
+
+}
+
+func readWhenTheFrameLengthAndFlagsNotReceivedAtFirst(t *testing.T) {
+	frame := createFrameWithRandomBytes(t, 100)
+	message := proto.NewClientMessage(frame)
+	buffer := writeToBuffer(t, message)
+	reader := newClientMessageReader()
+	// should not be able to read with just 4 bytes of data
+	reader.Append((buffer.Bytes())[:4])
+	require.Nil(t, reader.Read())
+	// should be able to read when the rest of the data comes
+	reader.Append(buffer.Bytes()[4:buffer.Len()])
+	require.NotNil(t, reader.Read())
+	iterator := reader.clientMessage.FrameIterator()
+	require.True(t, iterator.HasNext())
+	frameRead := iterator.Next()
+	require.Equal(t, frame.Content, frameRead.Content)
+	require.False(t, iterator.HasNext())
+}
+
+func readFramesInMultipleCallsToReadFromWhenLastPieceIsSmall(t *testing.T) {
+	frame := createFrameWithRandomBytes(t, 1000)
+	message := proto.NewClientMessage(frame)
+	buffer := writeToBuffer(t, message)
+	// Message Length = 1000 + 6 bytes
+	// part1 = 750, part2 = 252, part3 = 4 bytes
+	part1 := buffer.Next(750)
+	part2 := buffer.Next(252)
+	part3 := buffer.Bytes()
+	part1Buffer := bytes.NewBuffer(part1)
+	part2Buffer := bytes.NewBuffer(part2)
+	part3Buffer := bytes.NewBuffer(part3)
+	// create a reader and send message part by part
+	reader := newClientMessageReader()
+	reader.Append(part1Buffer.Bytes())
+	require.Nil(t, reader.Read())
+	reader.Append(part2Buffer.Bytes())
+	require.Nil(t, reader.Read())
+	// it should only be able to read after part 3
+	reader.Append(part3Buffer.Bytes())
+	require.NotNil(t, reader.Read())
+	iterator := reader.clientMessage.FrameIterator()
+	frameRead := iterator.Next()
+	require.Equal(t, frame.Content, frameRead.Content)
+	require.False(t, iterator.HasNext())
+}
+
+func createFrameWithRandomBytes(t *testing.T, bytes int) proto.Frame {
+	content := make([]byte, bytes)
+	n, err := rand.Read(content)
+	require.Equal(t, n, bytes)
+	require.NoError(t, err)
+	return proto.NewFrame(content)
+}
+
+func writeToBuffer(t *testing.T, message *proto.ClientMessage) *bytes.Buffer {
+	buffer := bytes.NewBuffer(make([]byte, 0, message.TotalLength()))
+	err := message.Write(buffer)
+	require.NoError(t, err)
+	return buffer
+}

--- a/internal/cluster/client_message_test.go
+++ b/internal/cluster/client_message_test.go
@@ -3,7 +3,6 @@ package cluster
 import (
 	"bytes"
 	"github.com/hazelcast/hazelcast-go-client/internal/proto"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"math/rand"
 	"testing"
@@ -88,7 +87,7 @@ func readFramesInMultipleCallsToRead(t *testing.T) {
 	require.True(t, iterator.HasNext())
 	frameRead := iterator.Next()
 	require.Equal(t, frame.Content, frameRead.Content)
-	assert.False(t, iterator.HasNext())
+	require.False(t, iterator.HasNext())
 }
 
 func readWhenTheFrameLengthAndFlagsNotReceivedAtFirst(t *testing.T) {

--- a/internal/cluster/client_message_test.go
+++ b/internal/cluster/client_message_test.go
@@ -13,7 +13,7 @@ func TestClientMessageReader(t *testing.T) {
 		f    func(t *testing.T)
 		name string
 	}{
-		{name: "readSingleFrame", f: readSingleFrame},
+		{name: "readSingleFrameMessage", f: readSingleFrameMessage},
 		{name: "readMultiFrameMessage", f: readMultiFrameMessage},
 		{name: "readFramesInMultipleCallsToRead", f: readFramesInMultipleCallsToRead},
 		{name: "readWhenTheFrameLengthAndFlagsNotReceivedAtFirst", f: readWhenTheFrameLengthAndFlagsNotReceivedAtFirst},
@@ -26,7 +26,8 @@ func TestClientMessageReader(t *testing.T) {
 	}
 }
 
-func readSingleFrame(t *testing.T) {
+func readSingleFrameMessage(t *testing.T) {
+	// ported from: com.hazelcast.client.impl.protocol.util.ClientMessageReaderTest#testReadSingleFrameMessage
 	frame := createFrameWithRandomBytes(t, 42)
 	message := proto.NewClientMessageForEncode()
 	message.AddFrame(frame)
@@ -42,6 +43,7 @@ func readSingleFrame(t *testing.T) {
 }
 
 func readMultiFrameMessage(t *testing.T) {
+	// ported from: com.hazelcast.client.impl.protocol.util.ClientMessageReaderTest#testReadMultiFrameMessage
 	frame1 := createFrameWithRandomBytes(t, 10)
 	frame2 := createFrameWithRandomBytes(t, 20)
 	frame3 := createFrameWithRandomBytes(t, 30)
@@ -67,6 +69,7 @@ func readMultiFrameMessage(t *testing.T) {
 }
 
 func readFramesInMultipleCallsToRead(t *testing.T) {
+	// ported from: com.hazelcast.client.impl.protocol.util.ClientMessageReaderTest#testReadFramesInMultipleCallsToReadFrom
 	frame := createFrameWithRandomBytes(t, 1000)
 	message := proto.NewClientMessageForEncode()
 	message.AddFrame(frame)
@@ -91,6 +94,7 @@ func readFramesInMultipleCallsToRead(t *testing.T) {
 }
 
 func readWhenTheFrameLengthAndFlagsNotReceivedAtFirst(t *testing.T) {
+	// ported from: com.hazelcast.client.impl.protocol.util.ClientMessageReaderTest#testRead_whenTheFrameLengthAndFlagsNotReceivedAtFirst
 	frame := createFrameWithRandomBytes(t, 100)
 	message := proto.NewClientMessage(frame)
 	buffer := writeToBuffer(t, message)
@@ -109,6 +113,7 @@ func readWhenTheFrameLengthAndFlagsNotReceivedAtFirst(t *testing.T) {
 }
 
 func readFramesInMultipleCallsToReadFromWhenLastPieceIsSmall(t *testing.T) {
+	// ported from: com.hazelcast.client.impl.protocol.util.ClientMessageReaderTest#testReadFramesInMultipleCallsToReadFrom_whenLastPieceIsSmall
 	frame := createFrameWithRandomBytes(t, 1000)
 	message := proto.NewClientMessage(frame)
 	buffer := writeToBuffer(t, message)
@@ -136,6 +141,7 @@ func readFramesInMultipleCallsToReadFromWhenLastPieceIsSmall(t *testing.T) {
 }
 
 func createFrameWithRandomBytes(t *testing.T, bytes int) proto.Frame {
+	// ported from: com.hazelcast.client.impl.protocol.util.ClientMessageReaderTest#createFrameWithRandomBytes
 	content := make([]byte, bytes)
 	_, err := rand.Read(content)
 	require.NoError(t, err)
@@ -143,6 +149,7 @@ func createFrameWithRandomBytes(t *testing.T, bytes int) proto.Frame {
 }
 
 func writeToBuffer(t *testing.T, message *proto.ClientMessage) *bytes.Buffer {
+	// ported from: com.hazelcast.client.impl.protocol.util.ClientMessageReaderTest#writeToBuffer
 	buffer := bytes.NewBuffer(make([]byte, 0, message.TotalLength()))
 	err := message.Write(buffer)
 	require.NoError(t, err)

--- a/internal/cluster/client_message_test.go
+++ b/internal/cluster/client_message_test.go
@@ -13,11 +13,11 @@ func TestClientMessageReader(t *testing.T) {
 		f    func(t *testing.T)
 		name string
 	}{
-		{name: "readFramesInMultipleCallsToRead", f: readFramesInMultipleCallsToRead},
-		{name: "readFramesInMultipleCallsToReadFromWhenLastPieceIsSmall", f: readFramesInMultipleCallsToReadFromWhenLastPieceIsSmall},
-		{name: "readMultiFrameMessage", f: readMultiFrameMessage},
-		{name: "readSingleFrameMessage", f: readSingleFrameMessage},
-		{name: "readWhenTheFrameLengthAndFlagsNotReceivedAtFirst", f: readWhenTheFrameLengthAndFlagsNotReceivedAtFirst},
+		{name: "readFramesInMultipleCallsToRead", f: readFramesInMultipleCallsToReadTest},
+		{name: "readFramesInMultipleCallsToReadFromWhenLastPieceIsSmall", f: readFramesInMultipleCallsToReadFromWhenLastPieceIsSmallTest},
+		{name: "readMultiFrameMessage", f: readMultiFrameMessageTest},
+		{name: "readSingleFrameMessage", f: readSingleFrameMessageTest},
+		{name: "readWhenTheFrameLengthAndFlagsNotReceivedAtFirst", f: readWhenTheFrameLengthAndFlagsNotReceivedAtFirstTest},
 	}
 	for _, tc := range testCases {
 		tc := tc
@@ -28,7 +28,7 @@ func TestClientMessageReader(t *testing.T) {
 	}
 }
 
-func readSingleFrameMessage(t *testing.T) {
+func readSingleFrameMessageTest(t *testing.T) {
 	// ported from: com.hazelcast.client.impl.protocol.util.ClientMessageReaderTest#testReadSingleFrameMessage
 	frame := createFrameWithRandomBytes(t, 42)
 	msg := proto.NewClientMessageForEncode()
@@ -43,7 +43,7 @@ func readSingleFrameMessage(t *testing.T) {
 	require.False(t, iter.HasNext())
 }
 
-func readMultiFrameMessage(t *testing.T) {
+func readMultiFrameMessageTest(t *testing.T) {
 	// ported from: com.hazelcast.client.impl.protocol.util.ClientMessageReaderTest#testReadMultiFrameMessage
 	frame1 := createFrameWithRandomBytes(t, 10)
 	frame2 := createFrameWithRandomBytes(t, 20)
@@ -66,7 +66,7 @@ func readMultiFrameMessage(t *testing.T) {
 	require.False(t, iter.HasNext())
 }
 
-func readFramesInMultipleCallsToRead(t *testing.T) {
+func readFramesInMultipleCallsToReadTest(t *testing.T) {
 	// ported from: com.hazelcast.client.impl.protocol.util.ClientMessageReaderTest#testReadFramesInMultipleCallsToReadFrom
 	frame := createFrameWithRandomBytes(t, 1000)
 	msg := proto.NewClientMessageForEncode()
@@ -90,7 +90,7 @@ func readFramesInMultipleCallsToRead(t *testing.T) {
 	require.False(t, iter.HasNext())
 }
 
-func readWhenTheFrameLengthAndFlagsNotReceivedAtFirst(t *testing.T) {
+func readWhenTheFrameLengthAndFlagsNotReceivedAtFirstTest(t *testing.T) {
 	// ported from: com.hazelcast.client.impl.protocol.util.ClientMessageReaderTest#testRead_whenTheFrameLengthAndFlagsNotReceivedAtFirst
 	frame := createFrameWithRandomBytes(t, 100)
 	msg := proto.NewClientMessage(frame)
@@ -108,7 +108,7 @@ func readWhenTheFrameLengthAndFlagsNotReceivedAtFirst(t *testing.T) {
 	require.False(t, iter.HasNext())
 }
 
-func readFramesInMultipleCallsToReadFromWhenLastPieceIsSmall(t *testing.T) {
+func readFramesInMultipleCallsToReadFromWhenLastPieceIsSmallTest(t *testing.T) {
 	// ported from: com.hazelcast.client.impl.protocol.util.ClientMessageReaderTest#testReadFramesInMultipleCallsToReadFrom_whenLastPieceIsSmall
 	frame := createFrameWithRandomBytes(t, 1000)
 	msg := proto.NewClientMessage(frame)


### PR DESCRIPTION
This PR closes https://github.com/hazelcast/hazelcast-go-client/issues/783.

See [hazelcast/hazelcast#21502](https://github.com/hazelcast/hazelcast/pull/21502) for details.

Go Client had no problem related to the six-byte bug in Java Client. Go Client checks the length of the unread portion versus six-byte only while reading the frame's header. After the `frameLength` and `flags` (those are six-byte in total) are read, we are not comparing the unread size with six-byte. 

Changes
- Added tests for ClientMessageReader, reflecting the Java Client tests. 
