### PR TITLE
Map.RemoveAll doesn't clear the near cache [API-1519]

### DIFF
--- a/nearcache/nearcache_it_test.go
+++ b/nearcache/nearcache_it_test.go
@@ -325,9 +325,9 @@ func TestMapRemoveAll_WithNearCache(t *testing.T) {
 		const size = int32(100)
 		populateMap(tcx, size)
 		populateNearCache(tcx, size)
-		err := m.RemoveAll(context.Background(), predicate.True())
+		err := m.RemoveAll(context.Background(), predicate.Less("__key", int32(50)))
 		require.NoError(t, err)
-		require.Equal(t, int64(0), m.LocalMapStats().NearCacheStats.OwnedEntryCount)
+		require.Equal(t, int64(50), m.LocalMapStats().NearCacheStats.OwnedEntryCount)
 	})
 }
 

--- a/nearcache/nearcache_it_test.go
+++ b/nearcache/nearcache_it_test.go
@@ -22,6 +22,7 @@ package nearcache_test
 import (
 	"context"
 	"fmt"
+	"github.com/hazelcast/hazelcast-go-client/predicate"
 	"math/rand"
 	"os"
 	"strconv"
@@ -313,6 +314,20 @@ func TestMapRemove_WithNearCache(t *testing.T) {
 		stats := m.LocalMapStats().NearCacheStats
 		assert.Equal(t, int64(0), stats.OwnedEntryCount)
 		assert.Equal(t, int64(size), stats.Misses)
+	})
+}
+
+func TestMapRemoveAll_WithNearCache(t *testing.T) {
+	tcx := newNearCacheMapTestContext(t, nearcache.InMemoryFormatBinary, true)
+	tcx.Tester(func(tcx it.MapTestContext) {
+		t := tcx.T
+		m := tcx.M
+		const size = int32(100)
+		populateMap(tcx, size)
+		populateNearCache(tcx, size)
+		err := m.RemoveAll(context.Background(), predicate.True())
+		require.NoError(t, err)
+		require.Equal(t, int64(0), m.LocalMapStats().NearCacheStats.OwnedEntryCount)
 	})
 }
 

--- a/nearcache/nearcache_it_test.go
+++ b/nearcache/nearcache_it_test.go
@@ -325,9 +325,9 @@ func TestMapRemoveAll_WithNearCache(t *testing.T) {
 		const size = int32(100)
 		populateMap(tcx, size)
 		populateNearCache(tcx, size)
-		err := m.RemoveAll(context.Background(), predicate.Less("__key", int32(50)))
+		err := m.RemoveAll(context.Background(), predicate.True())
 		require.NoError(t, err)
-		require.Equal(t, int64(50), m.LocalMapStats().NearCacheStats.OwnedEntryCount)
+		require.Equal(t, int64(0), m.LocalMapStats().NearCacheStats.OwnedEntryCount)
 	})
 }
 

--- a/nearcache_map.go
+++ b/nearcache_map.go
@@ -362,15 +362,8 @@ func (ncm *nearCacheMap) Remove(ctx context.Context, m *Map, key interface{}) (i
 }
 
 func (ncm *nearCacheMap) RemoveAll(ctx context.Context, m *Map, predicate predicate.Predicate) (err error) {
-	keys, err := m.GetKeySetWithPredicate(ctx, predicate)
-	if err != nil {
-		return err
-	}
 	defer func() {
-		for _, key := range keys {
-			key, err = ncm.toNearCacheKey(key)
-			ncm.nc.Invalidate(key)
-		}
+		ncm.nc.Clear()
 	}()
 	return m.removeAllFromRemote(ctx, predicate)
 }

--- a/nearcache_map.go
+++ b/nearcache_map.go
@@ -19,6 +19,7 @@ package hazelcast
 import (
 	"context"
 	"fmt"
+	"github.com/hazelcast/hazelcast-go-client/predicate"
 	"sync/atomic"
 	"time"
 
@@ -358,6 +359,20 @@ func (ncm *nearCacheMap) Remove(ctx context.Context, m *Map, key interface{}) (i
 	}
 	defer ncm.nc.Invalidate(key)
 	return m.removeFromRemote(ctx, key)
+}
+
+func (ncm *nearCacheMap) RemoveAll(ctx context.Context, m *Map, predicate predicate.Predicate) (err error) {
+	keys, err := m.GetKeySetWithPredicate(ctx, predicate)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		for _, key := range keys {
+			key, err = ncm.toNearCacheKey(key)
+			ncm.nc.Invalidate(key)
+		}
+	}()
+	return m.removeAllFromRemote(ctx, predicate)
 }
 
 func (ncm *nearCacheMap) RemoveIfSame(ctx context.Context, m *Map, key interface{}, value interface{}) (bool, error) {

--- a/proxy_map.go
+++ b/proxy_map.go
@@ -703,7 +703,6 @@ func (m *Map) putTransientWithTTLAndMaxIdleFromRemote(ctx context.Context, key i
 	request := codec.EncodeMapPutTransientWithMaxIdleRequest(m.name, keyData, valueData, lid, ttl, maxIdle)
 	_, err = m.invokeOnKey(ctx, request, keyData)
 	return err
-
 }
 
 func (m *Map) putIfAbsentWithTTLFromRemote(ctx context.Context, key interface{}, value interface{}, ttl int64) (interface{}, error) {
@@ -749,13 +748,13 @@ func (m *Map) removeFromRemote(ctx context.Context, key interface{}) (interface{
 }
 
 func (m *Map) removeAllFromRemote(ctx context.Context, predicate predicate.Predicate) error {
-	if predicateData, err := m.validateAndSerialize(predicate); err != nil {
-		return err
-	} else {
-		request := codec.EncodeMapRemoveAllRequest(m.name, predicateData)
-		_, err := m.invokeOnRandomTarget(ctx, request, nil)
+	predicateData, err := m.validateAndSerialize(predicate)
+	if err != nil {
 		return err
 	}
+	request := codec.EncodeMapRemoveAllRequest(m.name, predicateData)
+	_, err = m.invokeOnRandomTarget(ctx, request, nil)
+	return err
 }
 
 func (m *Map) replaceFromRemote(ctx context.Context, key interface{}, value interface{}) (interface{}, error) {

--- a/proxy_map.go
+++ b/proxy_map.go
@@ -1158,6 +1158,9 @@ func (m *Map) Remove(ctx context.Context, key interface{}) (interface{}, error) 
 
 // RemoveAll deletes all entries matching the given predicate.
 func (m *Map) RemoveAll(ctx context.Context, predicate predicate.Predicate) error {
+	if m.hasNearCache {
+		return m.ncm.Clear(ctx, m)
+	}
 	if predicateData, err := m.validateAndSerialize(predicate); err != nil {
 		return err
 	} else {


### PR DESCRIPTION
Fix: https://github.com/hazelcast/hazelcast-go-client/issues/872

Near Cache clear() operation was missing when the removeAll() method is called on a map. 

**Changes**

- Added check for clearing Near Cache
- New test for map.removeAll() operation