### PR TITLE
Fix flaky test Dispatch Service [API-1213]

### DIFF
--- a/internal/event/dispatch_service_test.go
+++ b/internal/event/dispatch_service_test.go
@@ -123,19 +123,27 @@ func TestDispatchServiceOrderIsGuaranteed(t *testing.T) {
 }
 
 func TestDispatchServiceAllPublishedAreHandledBeforeClose(t *testing.T) {
-	it.MarkFlaky(t, "https://github.com/hazelcast/hazelcast-go-client/issues/683")
-	goroutineCount := 10_000
 	dispatchCount := int32(0)
 	handler := func(event event.Event) {
 		atomic.AddInt32(&dispatchCount, 1)
 	}
 	service := event.NewDispatchService(logger.LogAdaptor{Logger: logger.New()})
 	service.Subscribe("sample.event", 100, handler)
-	go service.Stop(context.Background())
+	stopped := make(chan struct{})
+	go func() {
+		stopped <- struct{}{}
+		service.Stop(context.Background())
+	}()
 	successfulPubCnt := int32(0)
-	for i := 0; i < goroutineCount; i++ {
-		if service.Publish(sampleEvent{}) {
-			atomic.AddInt32(&successfulPubCnt, 1)
+end:
+	for {
+		select {
+		case <-stopped:
+			break end
+		default:
+			if service.Publish(sampleEvent{}) {
+				atomic.AddInt32(&successfulPubCnt, 1)
+			}
 		}
 	}
 	it.Eventually(t, func() bool {

--- a/internal/event/dispatch_service_test.go
+++ b/internal/event/dispatch_service_test.go
@@ -130,6 +130,7 @@ func TestDispatchServiceAllPublishedAreHandledBeforeClose(t *testing.T) {
 	service := event.NewDispatchService(logger.LogAdaptor{Logger: logger.New()})
 	service.Subscribe("sample.event", 100, handler)
 	stopped := make(chan struct{})
+	defer close(stopped)
 	go func() {
 		stopped <- struct{}{}
 		service.Stop(context.Background())


### PR DESCRIPTION
**Flaky case is occurring when**;
OS schedules `service.Stop(context.Background())` before the all certain amount of publishing has been finished without knowing exactly where it scheduled. Then the test expects the `dispatchCount` should be equivalent to `successfulPubCnt`.

**Fix**:
When stoping happens, dispatch service should not publish an event. It is achieved through introducing a new channel.