### PR TITLE
Fix TestClusterShutdownWithCancelOnFetchPage

### DIFF
--- a/sql/driver/driver_it_test.go
+++ b/sql/driver/driver_it_test.go
@@ -629,7 +629,7 @@ func TestClusterShutdownWithCancelOnFetchPage(t *testing.T) {
 	}()
 	select {
 	case <-finish:
-	case <-time.After(timeout):
+	case <-time.After(timeout + 1*time.Second):
 		t.Fatal("driver did not respect the context timeout")
 	}
 }

--- a/sql/driver/driver_it_test.go
+++ b/sql/driver/driver_it_test.go
@@ -606,12 +606,13 @@ func TestConcurrentQueries(t *testing.T) {
 }
 
 func TestClusterShutdownWithCancelOnFetchPage(t *testing.T) {
+	const timeout = 20 * time.Second
 	port := it.NextPort()
 	tc := it.StartNewClusterWithConfig(1, it.SQLXMLConfig(t.Name(), "localhost", port), port)
 	defer tc.Shutdown()
 	db := driver.Open(tc.DefaultConfigWithNoSSL())
 	defer db.Close()
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	rows, err := db.QueryContext(ctx, "select * from table(generate_stream(1))")
 	if err != nil {
@@ -628,7 +629,7 @@ func TestClusterShutdownWithCancelOnFetchPage(t *testing.T) {
 	}()
 	select {
 	case <-finish:
-	case <-time.After(3 * time.Second):
+	case <-time.After(timeout):
 		t.Fatal("driver did not respect the context timeout")
 	}
 }

--- a/sql/driver/driver_it_test.go
+++ b/sql/driver/driver_it_test.go
@@ -606,11 +606,12 @@ func TestConcurrentQueries(t *testing.T) {
 }
 
 func TestClusterShutdownWithCancelOnFetchPage(t *testing.T) {
-	tc := it.StartNewClusterWithConfig(1, it.SQLXMLConfig(t.Name(), "localhost", 60001), 60001)
+	port := it.NextPort()
+	tc := it.StartNewClusterWithConfig(1, it.SQLXMLConfig(t.Name(), "localhost", port), port)
 	defer tc.Shutdown()
 	db := driver.Open(tc.DefaultConfigWithNoSSL())
 	defer db.Close()
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 	rows, err := db.QueryContext(ctx, "select * from table(generate_stream(1))")
 	if err != nil {

--- a/sql/driver/driver_it_test.go
+++ b/sql/driver/driver_it_test.go
@@ -606,13 +606,12 @@ func TestConcurrentQueries(t *testing.T) {
 }
 
 func TestClusterShutdownWithCancelOnFetchPage(t *testing.T) {
-	const timeout = 20 * time.Second
 	port := it.NextPort()
 	tc := it.StartNewClusterWithConfig(1, it.SQLXMLConfig(t.Name(), "localhost", port), port)
 	defer tc.Shutdown()
 	db := driver.Open(tc.DefaultConfigWithNoSSL())
 	defer db.Close()
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	rows, err := db.QueryContext(ctx, "select * from table(generate_stream(1))")
 	if err != nil {
@@ -629,7 +628,7 @@ func TestClusterShutdownWithCancelOnFetchPage(t *testing.T) {
 	}()
 	select {
 	case <-finish:
-	case <-time.After(timeout + 1*time.Second):
+	case <-time.After(21 * time.Second):
 		t.Fatal("driver did not respect the context timeout")
 	}
 }

--- a/sql/driver/driver_it_test.go
+++ b/sql/driver/driver_it_test.go
@@ -606,12 +606,15 @@ func TestConcurrentQueries(t *testing.T) {
 }
 
 func TestClusterShutdownWithCancelOnFetchPage(t *testing.T) {
+	const timeout = 1 * time.Second
 	port := it.NextPort()
 	tc := it.StartNewClusterWithConfig(1, it.SQLXMLConfig(t.Name(), "localhost", port), port)
 	defer tc.Shutdown()
 	db := driver.Open(tc.DefaultConfigWithNoSSL())
+	// make sure the client connects to the cluster
+	db.Ping()
 	defer db.Close()
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	rows, err := db.QueryContext(ctx, "select * from table(generate_stream(1))")
 	if err != nil {
@@ -628,7 +631,7 @@ func TestClusterShutdownWithCancelOnFetchPage(t *testing.T) {
 	}()
 	select {
 	case <-finish:
-	case <-time.After(21 * time.Second):
+	case <-time.After(timeout + 1*time.Second):
 		t.Fatal("driver did not respect the context timeout")
 	}
 }


### PR DESCRIPTION
TestClusterShutdownWithCancelOnFetchPage failed twice in nightlies in the last two months. That may be caused by `driver.Open` not making the driver connect to the cluster (which is normal database/sql behaviour). Added a `Ping` to eforce the driver to connect to the cluster first.