### PR TITLE
Changed the log level of "duplicate connection to the same member" log

### DIFF
--- a/internal/cluster/connection_manager.go
+++ b/internal/cluster/connection_manager.go
@@ -564,7 +564,7 @@ func (m *ConnectionManager) processAuthenticationResult(conn *Connection, result
 		m.clusterIDMu.Unlock()
 		if oldConn, ok := m.connMap.GetOrAddConnection(conn, *address); !ok {
 			// there is already a connection to this member
-			m.logger.Warnf("duplicate connection to the same member with UUID: %s", conn.MemberUUID())
+			m.logger.Infof("duplicate connection to the same member with UUID: %s", conn.MemberUUID())
 			conn.close(nil)
 			return oldConn, nil
 		}


### PR DESCRIPTION
The client writes a warning log if the same member is attempted to be connected again. Although the client does the correct thing and closes the connection, the users think there's something wrong.

The corresponding log has level INFO in the reference implementation, so changed the log level for the Go client to INFO too. Here's the relevant lines:

com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java:955
com/hazelcast/client/impl/connection/tcp/TcpClientConnection.java:208


