### PR TITLE
Fixed flakeIDGeneratorServiceNameTest

### DIFF
--- a/flake_id_generator_it_test.go
+++ b/flake_id_generator_it_test.go
@@ -220,15 +220,15 @@ func flakeIDGeneratorServiceNameTest(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer f.Destroy(ctx)
-		objs, err := client.GetDistributedObjectsInfo(ctx)
-		require.NoError(t, err)
-		var ok bool
-		for _, obj := range objs {
-			if obj.ServiceName == hz.ServiceNameFlakeIDGenerator && obj.Name == name {
-				ok = true
-				break
+		it.Eventually(t, func() bool {
+			objs, err := client.GetDistributedObjectsInfo(ctx)
+			require.NoError(t, err)
+			for _, obj := range objs {
+				if obj.ServiceName == hz.ServiceNameFlakeIDGenerator && obj.Name == name {
+					return true
+				}
 			}
-		}
-		assert.True(t, ok)
+			return false
+		})
 	})
 }


### PR DESCRIPTION
`GetDistributedObjectsInfo` is sent to a random member, but there may be a window where the created FlakeIDGenerator was not synced to all members.

This PR makes sure that the test doesn't give up until the FlakeIDGenrator is synced to all members.

The following command always reproduces the test failure:
```
MEMBER_COUNT=15 go test -count 1000 -timeout 60m -run TestFlakeIDGenerator
```