### PR TITLE
[QUICK REVIEW] Do not destroy remote proxies on shutdown

### DIFF
--- a/client_internals_it_test.go
+++ b/client_internals_it_test.go
@@ -453,32 +453,30 @@ func clientClusterConnectionConfigRetryTimeTest(t *testing.T) {
 }
 
 func proxyManagerShutdownTest(t *testing.T) {
-	clientTester(t, func(t *testing.T, smart bool) {
-		ctx := context.Background()
-		tc := it.StartNewClusterWithOptions(t.Name(), it.NextPort(), 1)
-		defer tc.Shutdown()
-		config := tc.DefaultConfig()
-		config.Cluster.Unisocket = !smart
-		client := it.MustClient(hz.StartNewClientWithConfig(ctx, config))
-		defer client.Shutdown(ctx)
-		m := it.MustValue(client.GetMap(ctx, it.NewUniqueObjectName("map"))).(*hz.Map)
-		q := it.MustValue(client.GetQueue(ctx, it.NewUniqueObjectName("queue"))).(*hz.Queue)
-		value := "dummy-value"
-		key := "dummy-key"
-		if _, err := m.Put(ctx, key, value); err != nil {
-			t.Fatal(err)
-		}
-		if err := q.Put(ctx, value); err != nil {
-			t.Fatal(err)
-		}
-		ci := hz.NewClientInternal(client)
-		proxies := ci.Proxies()
-		require.EqualValues(t, 2, len(proxies))
-		if err := client.Shutdown(ctx); err != nil {
-			t.Fatal(err)
-		}
-		proxies = ci.Proxies()
-		require.EqualValues(t, 0, len(proxies))
+	ctx := context.Background()
+	tc := it.StartNewClusterWithOptions(t.Name(), it.NextPort(), 1)
+	defer tc.Shutdown()
+	config := tc.DefaultConfigWithNoSSL()
+	client := it.MustClient(hz.StartNewClientWithConfig(ctx, config))
+	defer client.Shutdown(ctx)
+	mapName := it.NewUniqueObjectName("map")
+	it.MustValue(client.GetMap(ctx, mapName))
+	it.MustValue(client.GetQueue(ctx, it.NewUniqueObjectName("queue")))
+	ci := hz.NewClientInternal(client)
+	proxies := ci.Proxies()
+	require.EqualValues(t, 2, len(proxies))
+	if err := client.Shutdown(ctx); err != nil {
+		t.Fatal(err)
+	}
+	proxies = ci.Proxies()
+	require.EqualValues(t, 0, len(proxies))
+	require.NoError(t, client.Shutdown(ctx))
+	// make sure the map was not destroyed
+	client = it.MustClient(hz.StartNewClientWithConfig(ctx, config))
+	defer client.Shutdown(ctx)
+	it.Eventually(t, func() bool {
+		ois := it.MustValue(client.GetDistributedObjectsInfo(ctx)).([]types.DistributedObjectInfo)
+		return len(ois) == 2
 	})
 }
 

--- a/client_internals_it_test.go
+++ b/client_internals_it_test.go
@@ -477,7 +477,12 @@ func proxyManagerShutdownTest(t *testing.T) {
 	it.Eventually(t, func() bool {
 		ois := it.MustValue(client.GetDistributedObjectsInfo(ctx)).([]types.DistributedObjectInfo)
 		t.Logf("OIS: %v", ois)
-		return len(ois) == 2
+		for _, item := range ois {
+			if item.Name == mapName && item.ServiceName == hz.ServiceNameMap {
+				return true
+			}
+		}
+		return false
 	})
 }
 

--- a/client_internals_it_test.go
+++ b/client_internals_it_test.go
@@ -454,7 +454,7 @@ func clientClusterConnectionConfigRetryTimeTest(t *testing.T) {
 
 func proxyManagerShutdownTest(t *testing.T) {
 	ctx := context.Background()
-	tc := it.StartNewClusterWithOptions(t.Name(), it.NextPort(), 1)
+	tc := it.StartNewClusterWithOptions(it.NewUniqueObjectName(t.Name()), it.NextPort(), 1)
 	defer tc.Shutdown()
 	config := tc.DefaultConfigWithNoSSL()
 	client := it.MustClient(hz.StartNewClientWithConfig(ctx, config))
@@ -476,6 +476,7 @@ func proxyManagerShutdownTest(t *testing.T) {
 	defer client.Shutdown(ctx)
 	it.Eventually(t, func() bool {
 		ois := it.MustValue(client.GetDistributedObjectsInfo(ctx)).([]types.DistributedObjectInfo)
+		t.Logf("OIS: %v", ois)
 		return len(ois) == 2
 	})
 }

--- a/client_internals_it_test.go
+++ b/client_internals_it_test.go
@@ -474,16 +474,16 @@ func proxyManagerShutdownTest(t *testing.T) {
 	// make sure the map was not destroyed
 	client = it.MustClient(hz.StartNewClientWithConfig(ctx, config))
 	defer client.Shutdown(ctx)
-	it.Eventually(t, func() bool {
-		ois := it.MustValue(client.GetDistributedObjectsInfo(ctx)).([]types.DistributedObjectInfo)
-		t.Logf("OIS: %v", ois)
-		for _, item := range ois {
-			if item.Name == mapName && item.ServiceName == hz.ServiceNameMap {
-				return true
-			}
+	ois := it.MustValue(client.GetDistributedObjectsInfo(ctx)).([]types.DistributedObjectInfo)
+	t.Logf("OIS: %v", ois)
+	var ok bool
+	for _, item := range ois {
+		if item.Name == mapName && item.ServiceName == hz.ServiceNameMap {
+			ok = true
+			break
 		}
-		return false
-	})
+	}
+	require.True(t, ok)
 }
 
 type invokeFilter func(inv invocation.Invocation) (ok bool)

--- a/proxy_manager.go
+++ b/proxy_manager.go
@@ -242,15 +242,8 @@ func makeProxyName(serviceName string, objectName string) string {
 	return fmt.Sprintf("%s%s", serviceName, objectName)
 }
 
-type proxyDestroyer interface {
-	Destroy(ctx context.Context) error
-}
-
 func (m *proxyManager) destroyProxies(ctx context.Context) {
-	for key, p := range m.Proxies() {
-		ds := p.(proxyDestroyer)
-		if err := ds.Destroy(ctx); err != nil {
-			m.serviceBundle.Logger.Errorf("proxy %s key cannot be destroyed: %w", key, err)
-		}
+	for _, p := range m.Proxies() {
+		p.(*proxy).destroyLocally(ctx)
 	}
 }

--- a/proxy_manager.go
+++ b/proxy_manager.go
@@ -242,8 +242,12 @@ func makeProxyName(serviceName string, objectName string) string {
 	return fmt.Sprintf("%s%s", serviceName, objectName)
 }
 
+type proxyDestroyer interface {
+	removeFromCache(ctx context.Context) bool
+}
+
 func (m *proxyManager) destroyProxies(ctx context.Context) {
 	for _, p := range m.Proxies() {
-		p.(*proxy).destroyLocally(ctx)
+		p.(proxyDestroyer).removeFromCache(ctx)
 	}
 }

--- a/proxy_map.go
+++ b/proxy_map.go
@@ -1347,7 +1347,7 @@ func (m *Map) LocalMapStats() LocalMapStats {
 	return LocalMapStats{}
 }
 
-func (m *Map) destroyLocally(ctx context.Context) bool {
+func (m *Map) destroyLocally(ctx context.Context) {
 	m.logger.Trace(func() string {
 		return fmt.Sprintf("hazelcast.Map.destroyLocally: %s", m.name)
 	})
@@ -1356,7 +1356,6 @@ func (m *Map) destroyLocally(ctx context.Context) bool {
 			m.logger.Errorf("hazelcast.Map.destroyLocally: %w", err)
 		}
 	}
-	return true
 }
 
 func (m *Map) addIndex(ctx context.Context, indexConfig types.IndexConfig) error {

--- a/proxy_map.go
+++ b/proxy_map.go
@@ -39,7 +39,7 @@ Map is a distributed map.
 Hazelcast Go client enables you to perform operations like reading and writing from/to a Hazelcast Map with methods like Get and Put.
 For details, see https://docs.hazelcast.com/imdg/latest/data-structures/map.html
 
-Listening for Map Events
+# Listening for Map Events
 
 To listen events of a map, you can use the AddListener, AddListenerWithKey, AddListenerWithPredicate and AddListenerWithPredicateAndKey methods.
 The first method adds a listener to the map's all events. The others filter the events depending on a key and/or a predicate.
@@ -71,7 +71,7 @@ Adding an event listener returns a subscription ID, which you can later use to r
 
 	err = m.RemoveListener(ctx, subscriptionID)
 
-Using Locks
+# Using Locks
 
 You can lock entries in a Map.
 When an entry is locked, only the owner of that lock can access that entry in the cluster until it is unlocked by the owner of force unlocked.
@@ -98,7 +98,7 @@ Once the lock context is created, it can be used to lock/unlock entries and used
 As mentioned before, lock context is a regular context.Context which carry a special lock ID.
 You can pass any context.Context to any Map function, but in that case lock ownership between operations using the same hazelcast.Client instance is not possible.
 
-Using the Near Cache
+# Using the Near Cache
 
 Map entries in Hazelcast are partitioned across the cluster members.
 Hazelcast clients do not have local data at all.
@@ -108,9 +108,9 @@ If you have a data structure that is mostly read, then you should consider creat
 
 These benefits do not come for free. See the following trade-offs:
 
-    * Clients with a Near Cache has to hold the extra cached data, which increases memory consumption.
-    * If invalidation is enabled and entries are updated frequently, then invalidations will be costly.
-    * Near Cache breaks the strong consistency guarantees; you might be reading stale data.
+  - Clients with a Near Cache has to hold the extra cached data, which increases memory consumption.
+  - If invalidation is enabled and entries are updated frequently, then invalidations will be costly.
+  - Near Cache breaks the strong consistency guarantees; you might be reading stale data.
 
 Near Cache is highly recommended for data structures that are mostly read.
 
@@ -138,49 +138,48 @@ That can be accomplished by setting SerializeKeys: true, shown in the example be
 
 The following types cannot be used as keys without setting SerializeKeys==true:
 
-	* Maps
-	* Slices
-	* Structs with having at least one field with an incomparable type.
+  - Maps
+  - Slices
+  - Structs with having at least one field with an incomparable type.
 
 Following Map methods support the Near Cache:
 
-	* Clear
-	* ContainsKey
-	* Delete
-	* Evict
-	* EvictAll
-	* ExecuteOnKey
-	* ExecuteOnKeys
-	* Get
-	* GetAll
-	* LoadAllReplacing
-	* LoadAllWithoutReplacing
-	* LocalMapStats
-	* Put
-	* PutWithMaxIdle
-	* PutWithTTL
-	* PutWithTTLAndMaxIdle
-	* PutAll
-	* PutIfAbsent
-	* PutIfAbsentWithTTL
-	* PutIfAbsentWithTTLAndMaxIdle
-	* PutTransient
-	* PutTransientWithMaxIdle
-	* PutTransientWithTTL
-	* PutTransientWithTTLAndMaxIdle
-	* Remove
-	* RemoveIfSame
-	* RemoveAll
-	* Replace
-	* ReplaceIfSame
-	* Set
-	* SetWithTTL
-	* SetWithTTLAndMaxIdle
-	* TryPut
-	* TryPutWithTimeout
-	* TryRemove
-	* TryRemoveWithTimeout
-
+  - Clear
+  - ContainsKey
+  - Delete
+  - Evict
+  - EvictAll
+  - ExecuteOnKey
+  - ExecuteOnKeys
+  - Get
+  - GetAll
+  - LoadAllReplacing
+  - LoadAllWithoutReplacing
+  - LocalMapStats
+  - Put
+  - PutWithMaxIdle
+  - PutWithTTL
+  - PutWithTTLAndMaxIdle
+  - PutAll
+  - PutIfAbsent
+  - PutIfAbsentWithTTL
+  - PutIfAbsentWithTTLAndMaxIdle
+  - PutTransient
+  - PutTransientWithMaxIdle
+  - PutTransientWithTTL
+  - PutTransientWithTTLAndMaxIdle
+  - Remove
+  - RemoveIfSame
+  - RemoveAll
+  - Replace
+  - ReplaceIfSame
+  - Set
+  - SetWithTTL
+  - SetWithTTLAndMaxIdle
+  - TryPut
+  - TryPutWithTimeout
+  - TryRemove
+  - TryRemoveWithTimeout
 */
 type Map struct {
 	*proxy
@@ -1346,17 +1345,6 @@ func (m *Map) LocalMapStats() LocalMapStats {
 		return m.ncm.GetLocalMapStats()
 	}
 	return LocalMapStats{}
-}
-
-func (m *Map) destroyLocally(ctx context.Context) {
-	m.logger.Trace(func() string {
-		return fmt.Sprintf("hazelcast.Map.destroyLocally: %s", m.name)
-	})
-	if m.hasNearCache {
-		if err := m.ncm.Destroy(ctx, m.name); err != nil {
-			m.logger.Errorf("hazelcast.Map.destroyLocally: %w", err)
-		}
-	}
 }
 
 func (m *Map) addIndex(ctx context.Context, indexConfig types.IndexConfig) error {

--- a/proxy_map.go
+++ b/proxy_map.go
@@ -1347,6 +1347,18 @@ func (m *Map) LocalMapStats() LocalMapStats {
 	return LocalMapStats{}
 }
 
+func (m *Map) destroyLocally(ctx context.Context) bool {
+	m.logger.Trace(func() string {
+		return fmt.Sprintf("hazelcast.Map.destroyLocally: %s", m.name)
+	})
+	if m.hasNearCache {
+		if err := m.ncm.Destroy(ctx, m.name); err != nil {
+			m.logger.Errorf("hazelcast.Map.destroyLocally: %w", err)
+		}
+	}
+	return true
+}
+
 func (m *Map) addIndex(ctx context.Context, indexConfig types.IndexConfig) error {
 	if err := validateAndNormalizeIndexConfig(&indexConfig); err != nil {
 		return err


### PR DESCRIPTION
We introduced a regression in master when we merged: https://github.com/hazelcast/hazelcast-go-client/pull/772 With that PR, we destroy the remote proxies when the client is shutdown. But we should've only destroyed local proxies. This PR fixes that.

Note that. although this PR does not require a documentation change, `gofmt` automatically updated some documentation to the new style, please disregard those changes.