### PR TITLE
Remove discovery token from debug log [API-1739]

### DIFF
--- a/internal/cloud/cloud_discovery.go
+++ b/internal/cloud/cloud_discovery.go
@@ -19,12 +19,13 @@ package cloud
 import (
 	"context"
 	"fmt"
-	"github.com/hazelcast/hazelcast-go-client/cluster"
-	"github.com/hazelcast/hazelcast-go-client/internal/logger"
-	"github.com/hazelcast/hazelcast-go-client/internal/rest"
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/hazelcast/hazelcast-go-client/cluster"
+	"github.com/hazelcast/hazelcast-go-client/internal/logger"
+	"github.com/hazelcast/hazelcast-go-client/internal/rest"
 )
 
 const envCoordinatorBaseURL = "HZ_CLOUD_COORDINATOR_BASE_URL"

--- a/internal/cloud/cloud_discovery.go
+++ b/internal/cloud/cloud_discovery.go
@@ -19,6 +19,7 @@ package cloud
 import (
 	"context"
 	"fmt"
+	"github.com/hazelcast/hazelcast-go-client/internal/hzerrors"
 	"os"
 	"strconv"
 	"strings"
@@ -47,7 +48,7 @@ func NewDiscoveryClient(config *cluster.CloudConfig, logger logger.LogAdaptor) *
 func (c *DiscoveryClient) DiscoverNodes(ctx context.Context) ([]Address, error) {
 	url := makeCoordinatorURL(c.token)
 	if j, err := c.httpClient.GetJSONArray(ctx, url); err != nil {
-		return nil, err
+		return nil, hzerrors.NewInvalidConfigurationError(fmt.Sprintf("failed to connect Hazelcast Cloud service: %s", baseURL()), nil)
 	} else {
 		addrs := extractAddresses(j)
 		c.logger.Trace(func() string { return fmt.Sprintf("cloud addresses: %v", addrs) })

--- a/internal/cloud/cloud_discovery.go
+++ b/internal/cloud/cloud_discovery.go
@@ -18,12 +18,10 @@ package cloud
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"github.com/hazelcast/hazelcast-go-client/cluster"
 	"github.com/hazelcast/hazelcast-go-client/internal/logger"
 	"github.com/hazelcast/hazelcast-go-client/internal/rest"
-	iurl "net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -48,10 +46,6 @@ func NewDiscoveryClient(config *cluster.CloudConfig, logger logger.LogAdaptor) *
 func (c *DiscoveryClient) DiscoverNodes(ctx context.Context) ([]Address, error) {
 	url := makeCoordinatorURL(c.token)
 	if j, err := c.httpClient.GetJSONArray(ctx, url); err != nil {
-		var e *iurl.Error
-		if errors.As(err, &e) {
-			e.URL = ""
-		}
 		return nil, err
 	} else {
 		addrs := extractAddresses(j)

--- a/internal/rest/http_client.go
+++ b/internal/rest/http_client.go
@@ -22,7 +22,7 @@ import (
 	"errors"
 	"io/ioutil"
 	"net/http"
-	iurl "net/url"
+	uri "net/url"
 	"time"
 
 	"github.com/hazelcast/hazelcast-go-client/internal/cb"
@@ -66,7 +66,7 @@ func (c *HTTPClient) Get(ctx context.Context, url string, headers ...HTTPHeader)
 	}
 	i, err := c.cb.TryContext(ctx, func(ctx context.Context, attempt int) (interface{}, error) {
 		if resp, err := c.httpClient.Do(req); err != nil {
-			var e *iurl.Error
+			var e *uri.Error
 			if errors.As(err, &e) {
 				e.URL = ""
 			}

--- a/internal/rest/http_client.go
+++ b/internal/rest/http_client.go
@@ -22,7 +22,7 @@ import (
 	"errors"
 	"io/ioutil"
 	"net/http"
-	uri "net/url"
+	"net/url"
 	"time"
 
 	"github.com/hazelcast/hazelcast-go-client/internal/cb"
@@ -56,8 +56,8 @@ func NewHTTPClient() *HTTPClient {
 	}
 }
 
-func (c *HTTPClient) Get(ctx context.Context, url string, headers ...HTTPHeader) ([]byte, error) {
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+func (c *HTTPClient) Get(ctx context.Context, uri string, headers ...HTTPHeader) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", uri, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +66,7 @@ func (c *HTTPClient) Get(ctx context.Context, url string, headers ...HTTPHeader)
 	}
 	i, err := c.cb.TryContext(ctx, func(ctx context.Context, attempt int) (interface{}, error) {
 		if resp, err := c.httpClient.Do(req); err != nil {
-			var e *uri.Error
+			var e *url.Error
 			if errors.As(err, &e) {
 				e.URL = ""
 			}

--- a/internal/rest/http_client.go
+++ b/internal/rest/http_client.go
@@ -19,8 +19,10 @@ package rest
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io/ioutil"
 	"net/http"
+	iurl "net/url"
 	"time"
 
 	"github.com/hazelcast/hazelcast-go-client/internal/cb"
@@ -64,6 +66,10 @@ func (c *HTTPClient) Get(ctx context.Context, url string, headers ...HTTPHeader)
 	}
 	i, err := c.cb.TryContext(ctx, func(ctx context.Context, attempt int) (interface{}, error) {
 		if resp, err := c.httpClient.Do(req); err != nil {
+			var e *iurl.Error
+			if errors.As(err, &e) {
+				e.URL = ""
+			}
 			return nil, err
 		} else if resp.StatusCode < 300 {
 			return resp, nil


### PR DESCRIPTION
Previously, the client was printing the `url.Error()` error directly, so the token was also leaking to logs. Instead, it should print an `InvalidConfigurationError`.

Switch statement is added since we might get an invalid discovery token error here, and its print log is different. 

Old error:
```
2022/12/02 11:28:03 DEBUG: cluster.ConnectionManager: error connecting to cluster, attempt 1: failed to refresh seed addresses: Get "https://ap.viridian.hazelcast.com/cluster/discovery?token=<TOKEN_LEAK>": dial tcp: lookup ap.viridian.hazelcast.com: no such host
```

New error:
```
2022/12/02 12:13:20 DEBUG: cluster.ConnectionManager: error connecting to cluster, attempt 1: failed to refresh seed addresses: failed to reach Hazelcast Cloud/Viridian service: https://foo.com: invalid configuration error
```