### PR TITLE
UUID serializer read and write methods use different byte order [API-1784]

### DIFF
--- a/internal/serialization/default_serializer.go
+++ b/internal/serialization/default_serializer.go
@@ -387,8 +387,8 @@ func (UUIDSerializer) Read(input serialization.DataInput) interface{} {
 
 func (UUIDSerializer) Write(output serialization.DataOutput, i interface{}) {
 	uuid := i.(types.UUID)
-	output.WriteInt64(int64(uuid.LeastSignificantBits()))
 	output.WriteInt64(int64(uuid.MostSignificantBits()))
+	output.WriteInt64(int64(uuid.LeastSignificantBits()))
 }
 
 type JavaDateSerializer struct{}

--- a/internal/serialization/default_serializer_test.go
+++ b/internal/serialization/default_serializer_test.go
@@ -17,6 +17,7 @@
 package serialization
 
 import (
+	"github.com/hazelcast/hazelcast-go-client/types"
 	"reflect"
 	"testing"
 
@@ -31,6 +32,7 @@ func TestDefaultSerializer(t *testing.T) {
 		Target interface{}
 	}{
 		{Value: int8(-42), Target: uint8(0xd6)},
+		{Value: types.NewUUIDWith(uint64(1234), uint64(5678)), Target: types.NewUUIDWith(uint64(1234), uint64(5678))},
 	}
 	sc := &serialization.Config{}
 	sc.SetGlobalSerializer(&PanicingGlobalSerializer{})


### PR DESCRIPTION
The write and read orders for the UUID fields in default serializer were wrong. Write was writing the LSB first while `Read()` reads MSB first. 

Added a test for default UUID serialization. 