### PR TITLE
Partition ID and serializer ID byte orders depend on the configuration [API-1782]

### DIFF
--- a/internal/it/util.go
+++ b/internal/it/util.go
@@ -21,6 +21,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	iserialization "github.com/hazelcast/hazelcast-go-client/internal/serialization"
 	"math/rand"
 	"net"
 	"os"
@@ -200,12 +201,27 @@ func MustBool(value bool, err error) bool {
 	return value
 }
 
+// MustData returns data if err is nil, otherwise it panics.
+func MustData(value interface{}, err error) iserialization.Data {
+	if err != nil {
+		panic(err)
+	}
+	return value.(iserialization.Data)
+}
+
 // MustClient returns client if err is nil, otherwise it panics.
 func MustClient(client *hz.Client, err error) *hz.Client {
 	if err != nil {
 		panic(err)
 	}
 	return client
+}
+
+func MustSerializationService(ss *iserialization.Service, err error) *iserialization.Service {
+	if err != nil {
+		panic(err)
+	}
+	return ss
 }
 
 func NewUniqueObjectName(service string, labels ...string) string {

--- a/internal/serialization/object_data.go
+++ b/internal/serialization/object_data.go
@@ -134,6 +134,12 @@ func (o *ObjectDataOutput) WriteInt32(v int32) {
 	o.position += Int32SizeInBytes
 }
 
+func (o *ObjectDataOutput) WriteInt32_(v int32, bo binary.ByteOrder) {
+	o.EnsureAvailable(Int32SizeInBytes)
+	WriteInt32(o.buffer, o.position, v, bo)
+	o.position += Int32SizeInBytes
+}
+
 func (o *ObjectDataOutput) WriteInt64(v int64) {
 	o.EnsureAvailable(Int64SizeInBytes)
 	WriteInt64(o.buffer, o.position, v, o.bo)

--- a/internal/serialization/object_data.go
+++ b/internal/serialization/object_data.go
@@ -134,9 +134,9 @@ func (o *ObjectDataOutput) WriteInt32(v int32) {
 	o.position += Int32SizeInBytes
 }
 
-func (o *ObjectDataOutput) WriteInt32_(v int32, bo binary.ByteOrder) {
+func (o *ObjectDataOutput) WriteInt32BigEndian(v int32) {
 	o.EnsureAvailable(Int32SizeInBytes)
-	WriteInt32(o.buffer, o.position, v, bo)
+	WriteInt32(o.buffer, o.position, v, binary.BigEndian)
 	o.position += Int32SizeInBytes
 }
 

--- a/internal/serialization/serialization.go
+++ b/internal/serialization/serialization.go
@@ -17,6 +17,7 @@
 package serialization
 
 import (
+	"encoding/binary"
 	"fmt"
 	"math/big"
 	"reflect"
@@ -77,8 +78,8 @@ func (s *Service) ToData(object interface{}) (r Data, err error) {
 	if err != nil {
 		return Data{}, err
 	}
-	dataOutput.WriteInt32(0) // partition
-	dataOutput.WriteInt32(serializer.ID())
+	dataOutput.WriteInt32_(0, binary.BigEndian) // partition
+	dataOutput.WriteInt32_(serializer.ID(), binary.BigEndian)
 	serializer.Write(dataOutput, object)
 	return dataOutput.buffer[:dataOutput.position], err
 }

--- a/internal/serialization/serialization.go
+++ b/internal/serialization/serialization.go
@@ -17,7 +17,6 @@
 package serialization
 
 import (
-	"encoding/binary"
 	"fmt"
 	"math/big"
 	"reflect"
@@ -78,8 +77,8 @@ func (s *Service) ToData(object interface{}) (r Data, err error) {
 	if err != nil {
 		return Data{}, err
 	}
-	dataOutput.WriteInt32_(0, binary.BigEndian) // partition
-	dataOutput.WriteInt32_(serializer.ID(), binary.BigEndian)
+	dataOutput.WriteInt32BigEndian(0) // partition
+	dataOutput.WriteInt32BigEndian(serializer.ID())
 	serializer.Write(dataOutput, object)
 	return dataOutput.buffer[:dataOutput.position], err
 }

--- a/internal/serialization/serialization_test.go
+++ b/internal/serialization/serialization_test.go
@@ -19,6 +19,7 @@ package serialization_test
 import (
 	"bytes"
 	"encoding/gob"
+	"github.com/hazelcast/hazelcast-go-client/internal/it"
 	"reflect"
 	"testing"
 
@@ -36,58 +37,29 @@ const (
 
 func TestSerializationService_LookUpDefaultSerializer(t *testing.T) {
 	var a int32 = 5
-	service, err := iserialization.NewService(&serialization.Config{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	service := it.MustSerializationService(iserialization.NewService(&serialization.Config{}))
 	id := service.LookUpDefaultSerializer(a).ID()
 	var expectedID int32 = -7
-	if id != expectedID {
-		t.Error("LookUpDefaultSerializer() returns ", id, " expected ", expectedID)
-	}
+	require.Equal(t, expectedID, id)
 }
 
 func TestSerializationService_ToData(t *testing.T) {
-	var expected int32 = 5
+	var v int32 = 5
 	c := &serialization.Config{}
-	service, err := iserialization.NewService(c)
-	if err != nil {
-		t.Fatal(err)
-	}
-	data, err := service.ToData(expected)
-	if err != nil {
-		t.Fatal(err)
-	}
-	temp, err := service.ToObject(data)
-	if err != nil {
-		t.Fatal(err)
-	}
-	ret := temp.(int32)
-	if expected != ret {
-		t.Error("ToData() returns ", ret, " expected ", expected)
-	}
+	service := it.MustSerializationService(iserialization.NewService(c))
+	data := it.MustData(service.ToData(v))
+	obj := it.MustValue(service.ToObject(data))
+	require.Equal(t, obj, v)
 }
 
 func TestSerializationService_ToData_LittleEndianTrue(t *testing.T) {
-	var expected int32 = 100
+	var v int32 = 100
 	c := &serialization.Config{}
 	c.LittleEndian = true
-	service, err := iserialization.NewService(c)
-	if err != nil {
-		t.Fatal(err)
-	}
-	data, err := service.ToData(expected)
-	if err != nil {
-		t.Fatal(err)
-	}
-	temp, err := service.ToObject(data)
-	if err != nil {
-		t.Fatal(err)
-	}
-	ret := temp.(int32)
-	if expected != ret {
-		t.Error("ToData() returns ", ret, " expected ", expected)
-	}
+	service := it.MustSerializationService(iserialization.NewService(c))
+	data := it.MustData(service.ToData(v))
+	obj := it.MustValue(service.ToObject(data))
+	require.Equal(t, obj, v)
 }
 
 type CustomArtistSerializer struct {
@@ -188,12 +160,11 @@ func TestCustomSerializer(t *testing.T) {
 	customSerializer := &CustomArtistSerializer{}
 	config := &serialization.Config{}
 	config.SetCustomSerializer(reflect.TypeOf((*artist)(nil)).Elem(), customSerializer)
-	service := mustValue(iserialization.NewService(config)).(*iserialization.Service)
-	data := mustValue(service.ToData(m)).(iserialization.Data)
-	ret := mustValue(service.ToObject(data))
-	data2 := mustValue(service.ToData(p)).(iserialization.Data)
-	ret2 := mustValue(service.ToObject(data2))
-
+	service := it.MustSerializationService(iserialization.NewService(config))
+	data := it.MustData(service.ToData(m))
+	ret := it.MustValue(service.ToObject(data))
+	data2 := it.MustData(service.ToData(p))
+	ret2 := it.MustValue(service.ToObject(data2))
 	if !reflect.DeepEqual(m, ret) || !reflect.DeepEqual(p, ret2) {
 		t.Error("custom serialization failed")
 	}
@@ -203,10 +174,9 @@ func TestGlobalSerializer(t *testing.T) {
 	obj := &customObject{ID: 10, Person: "Furkan Şenharputlu"}
 	config := &serialization.Config{}
 	config.SetGlobalSerializer(&GlobalSerializer{})
-	service, _ := iserialization.NewService(config)
-	data, _ := service.ToData(obj)
-	ret, _ := service.ToObject(data)
-
+	service := it.MustSerializationService(iserialization.NewService(config))
+	data := it.MustData(service.ToData(obj))
+	ret := it.MustValue(service.ToObject(data))
 	if !reflect.DeepEqual(obj, ret) {
 		t.Error("global serialization failed")
 	}
@@ -270,44 +240,33 @@ func TestGobSerializer(t *testing.T) {
 	var strings = []string{w1, w2, w3}
 	expected := &fake2{Bool: aBoolean, B: aByte, C: aChar, D: aDouble, S: aShort, F: aFloat, I: anInt, L: aLong, Str: aString,
 		Bools: bools, Bytes: bytes, Chars: chars, Doubles: doubles, Shorts: shorts, Floats: floats, Ints: ints, Longs: longs, Strings: strings}
-	service, err := iserialization.NewService(&serialization.Config{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	data, err := service.ToData(expected)
-	if err != nil {
-		t.Fatal(err)
-	}
-	ret, err := service.ToObject(data)
-	if err != nil {
-		t.Fatal(err)
-	}
+	service := it.MustSerializationService(iserialization.NewService(&serialization.Config{}))
+	data := it.MustData(service.ToData(expected))
+	ret := it.MustValue(service.ToObject(data))
 	if !reflect.DeepEqual(expected, ret) {
 		t.Error("Gob Serializer failed")
 	}
-
 }
 
 func TestInt64SerializerWithInt(t *testing.T) {
 	var id = 15
 	config := &serialization.Config{}
-	service := mustSerializationService(iserialization.NewService(config))
-	data := mustData(service.ToData(id))
-	ret := mustValue(service.ToObject(data))
+	service := it.MustSerializationService(iserialization.NewService(config))
+	data := it.MustData(service.ToData(id))
+	ret := it.MustValue(service.ToObject(data))
 	assert.Equal(t, int64(id), ret)
 }
 
 func TestInt64ArraySerializerWithIntArray(t *testing.T) {
 	var ids = []int{15, 10, 20, 12, 35}
 	config := &serialization.Config{}
-	service := mustSerializationService(iserialization.NewService(config))
-	data := mustData(service.ToData(ids))
-	ret := mustValue(service.ToObject(data))
+	service := it.MustSerializationService(iserialization.NewService(config))
+	data := it.MustData(service.ToData(ids))
+	ret := it.MustValue(service.ToObject(data))
 	var ids64 = make([]int64, 5)
 	for k := 0; k < 5; k++ {
 		ids64[k] = int64(ids[k])
 	}
-
 	if !reflect.DeepEqual(ids64, ret) {
 		t.Error("[]int type serialization failed")
 	}
@@ -319,29 +278,26 @@ func TestDefaultSerializerWithUInt(t *testing.T) {
 	// This is wrong!
 	var id = uint(15)
 	config := &serialization.Config{}
-	service := mustSerializationService(iserialization.NewService(config))
-	data := mustData(service.ToData(id))
-	ret := mustValue(service.ToObject(data))
+	service := it.MustSerializationService(iserialization.NewService(config))
+	data := it.MustData(service.ToData(id))
+	ret := it.MustValue(service.ToObject(data))
 	assert.Equal(t, id, ret)
 }
 
 func TestIntSerializer(t *testing.T) {
 	var id = 15
 	config := &serialization.Config{}
-	service := mustSerializationService(iserialization.NewService(config))
-	data := mustData(service.ToData(id))
-	ret := mustValue(service.ToObject(data))
+	service := it.MustSerializationService(iserialization.NewService(config))
+	data := it.MustData(service.ToData(id))
+	ret := it.MustValue(service.ToObject(data))
 	assert.Equal(t, int64(id), ret)
 }
 
 func TestSerializeData(t *testing.T) {
 	data := iserialization.Data([]byte{10, 20, 0, 30, 5, 7, 6})
 	config := &serialization.Config{}
-	service := mustSerializationService(iserialization.NewService(config))
-	serializedData, err := service.ToData(data)
-	if err != nil {
-		t.Fatal(err)
-	}
+	service := it.MustSerializationService(iserialization.NewService(config))
+	serializedData := it.MustData(service.ToData(data))
 	if !reflect.DeepEqual(data, serializedData) {
 		t.Error("Data type should not be serialized")
 	}
@@ -349,41 +305,19 @@ func TestSerializeData(t *testing.T) {
 
 func TestSerializeRune(t *testing.T) {
 	config := &serialization.Config{}
-	ss := mustSerializationService(iserialization.NewService(config))
+	ss := it.MustSerializationService(iserialization.NewService(config))
 	var target rune = 0x2318
-	data, err := ss.ToData(target)
-	if err != nil {
-		t.Fatal(err)
-	}
-	value, err := ss.ToObject(data)
-	if err != nil {
-		t.Fatal(err)
-	}
+	data := it.MustData(ss.ToData(target))
+	value := it.MustValue(ss.ToObject(data))
 	assert.Equal(t, target, value)
 }
 
 func TestUndefinedDataDeserialization(t *testing.T) {
-	s, _ := iserialization.NewService(&serialization.Config{})
+	s := it.MustSerializationService(iserialization.NewService(&serialization.Config{}))
 	dataOutput := iserialization.NewPositionalObjectDataOutput(1, s, !s.SerializationConfig.LittleEndian)
 	dataOutput.WriteInt32(0) // partition
 	dataOutput.WriteInt32(-100)
 	dataOutput.WriteString("Furkan")
 	data := iserialization.Data(dataOutput.ToBuffer())
-	_, err := s.ToObject(data)
-	require.Errorf(t, err, "err should not be nil")
-}
-
-// mustValue returns value if err is nil, otherwise it panics.
-func mustValue(value interface{}, err error) interface{} {
-	if err != nil {
-		panic(err)
-	}
-	return value
-}
-
-func mustData(value interface{}, err error) iserialization.Data {
-	if err != nil {
-		panic(err)
-	}
-	return value.(iserialization.Data)
+	_ = it.MustValue(s.ToObject(data))
 }

--- a/internal/serialization/serialization_test.go
+++ b/internal/serialization/serialization_test.go
@@ -68,6 +68,28 @@ func TestSerializationService_ToData(t *testing.T) {
 	}
 }
 
+func TestSerializationService_ToData_LittleEndianTrue(t *testing.T) {
+	var expected int32 = 100
+	c := &serialization.Config{}
+	c.LittleEndian = true
+	service, err := iserialization.NewService(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := service.ToData(expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	temp, err := service.ToObject(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ret := temp.(int32)
+	if expected != ret {
+		t.Error("ToData() returns ", ret, " expected ", expected)
+	}
+}
+
 type CustomArtistSerializer struct {
 }
 

--- a/internal/serialization/serialization_test.go
+++ b/internal/serialization/serialization_test.go
@@ -315,9 +315,10 @@ func TestSerializeRune(t *testing.T) {
 func TestUndefinedDataDeserialization(t *testing.T) {
 	s := it.MustSerializationService(iserialization.NewService(&serialization.Config{}))
 	dataOutput := iserialization.NewPositionalObjectDataOutput(1, s, !s.SerializationConfig.LittleEndian)
-	dataOutput.WriteInt32(0) // partition
-	dataOutput.WriteInt32(-100)
+	dataOutput.WriteInt32BigEndian(0)    // partition
+	dataOutput.WriteInt32BigEndian(-100) // serializer id
 	dataOutput.WriteString("Furkan")
 	data := iserialization.Data(dataOutput.ToBuffer())
-	_ = it.MustValue(s.ToObject(data))
+	_, err := s.ToObject(data)
+	require.Errorf(t, err, "err should not be nil")
 }


### PR DESCRIPTION
If users configures byte order as LE, the partition and serializers ids are written as LE too in `service.ToData()` method. These IDs needs to encoded in BE regardless of the serialization configuration. 

Added a new `WriteInt32_()` function that takes the byte order as parameter and used it while writing IDs. 
Added a test for LE enabled configuration. 