### PR TITLE
Near Cache Fix [API-1854]

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -149,6 +149,9 @@ func (c *Client) GetMap(ctx context.Context, name string) (*Map, error) {
 	m, err := c.proxyManager.getMap(ctx, name)
 	if err != nil {
 		return nil, err
+	}
+	if m.hasNearCache {
+		return m, nil
 	}
 	ncc, ok, err := c.cfg.GetNearCache(name)
 	if err != nil {

--- a/proxy_manager.go
+++ b/proxy_manager.go
@@ -18,7 +18,6 @@ package hazelcast
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
 	"github.com/hazelcast/hazelcast-go-client/internal/proto"
@@ -242,7 +241,7 @@ func (m *proxyManager) getFlakeIDGeneratorConfig(name string) FlakeIDGeneratorCo
 }
 
 func makeProxyName(serviceName string, objectName string) string {
-	return fmt.Sprintf("%s%s", serviceName, objectName)
+	return serviceName + objectName
 }
 
 type proxyDestroyer interface {

--- a/proxy_manager.go
+++ b/proxy_manager.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -64,10 +64,8 @@ func (m *proxyManager) Proxies() map[string]interface{} {
 	return cp
 }
 
-func (m *proxyManager) getMap(ctx context.Context, name string) (*Map, error) {
-	p, err := m.proxyFor(ctx, ServiceNameMap, name, func(p *proxy) (interface{}, error) {
-		return newMap(p), nil
-	})
+func (m *proxyManager) getMap(ctx context.Context, name string, fn func(p *proxy) (interface{}, error)) (*Map, error) {
+	p, err := m.proxyFor(ctx, ServiceNameMap, name, fn)
 	if err != nil {
 		return nil, err
 	}
@@ -205,12 +203,7 @@ func (m *proxyManager) remove(ctx context.Context, serviceName string, objectNam
 	return true
 }
 
-func (m *proxyManager) proxyFor(
-	ctx context.Context,
-	serviceName string,
-	objectName string,
-	wrapProxyFn func(p *proxy) (interface{}, error)) (interface{}, error) {
-
+func (m *proxyManager) proxyFor(ctx context.Context, serviceName string, objectName string, wrapProxyFn func(p *proxy) (interface{}, error)) (interface{}, error) {
 	name := makeProxyName(serviceName, objectName)
 	m.mu.RLock()
 	wrapper, ok := m.proxies[name]


### PR DESCRIPTION
Avoids creating the backing near cache map and adding an invalidation handler with each `Client.GetMap` call.