### PR TITLE
Use a sync.Map instead of map + mutex for proxy local cache [API-1855]

### DIFF
--- a/nearcache/nearcache_it_test.go
+++ b/nearcache/nearcache_it_test.go
@@ -1110,7 +1110,7 @@ func TestNearCacheMemLeakForEachGetMap(t *testing.T) {
 			}
 		})
 		t.Logf("allocated: %d", a)
-		if a > 64*iterations {
+		if a > 80*iterations {
 			t.Fatalf("Memory leak")
 		}
 	})

--- a/proxy_manager.go
+++ b/proxy_manager.go
@@ -28,7 +28,6 @@ import (
 )
 
 type proxyManager struct {
-	mu              *sync.RWMutex
 	proxies         *sync.Map
 	invocationProxy *proxy
 	serviceBundle   creationBundle
@@ -39,7 +38,6 @@ type proxyManager struct {
 func newProxyManager(bundle creationBundle) *proxyManager {
 	bundle.Check()
 	pm := &proxyManager{
-		mu:             &sync.RWMutex{},
 		proxies:        &sync.Map{},
 		serviceBundle:  bundle,
 		refIDGenerator: iproxy.NewReferenceIDGenerator(1),
@@ -188,8 +186,6 @@ func (m *proxyManager) removeDistributedObjectEventListener(ctx context.Context,
 
 func (m *proxyManager) remove(ctx context.Context, serviceName string, objectName string) bool {
 	name := makeProxyName(serviceName, objectName)
-	m.mu.Lock()
-	defer m.mu.Unlock()
 	p, ok := m.proxies.Load(name)
 	if !ok {
 		return false


### PR DESCRIPTION
This PR changes map + sync.RWMutex to `sync.Map` for proxy local cache in order to have better write performance under high concurrency.