### PR TITLE
Try to connect to the cluster infinitely if reconnect mode is ON [API-1825]

### DIFF
--- a/client_internals_it_test.go
+++ b/client_internals_it_test.go
@@ -58,7 +58,7 @@ func TestClientInternal(t *testing.T) {
 		{name: "ClusterID_2", f: clientInternalClusterID_2Test},
 		{name: "ConnectedToMember", f: clientInternalConnectedToMemberTest},
 		{name: "EncodeData", f: clientInternalEncodeDataTest},
-		{name: "InfiniteRestart", f: infiniteRestartTest},
+		{name: "InfiniteRestart", f: infiniteReconnectTest},
 		{name: "InternalInvokeOnKey", f: clientInternalInvokeOnKeyTest},
 		{name: "InternalListenersAfterClientDisconnected", f: clientInternalListenersAfterClientDisconnectedTest},
 		{name: "InvokeOnMember", f: clientInternalInvokeOnMemberTest},
@@ -490,7 +490,7 @@ func proxyManagerShutdownTest(t *testing.T) {
 	require.True(t, ok)
 }
 
-func infiniteRestartTest(t *testing.T) {
+func infiniteReconnectTest(t *testing.T) {
 	skip.If(t, "enterprise")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/client_internals_it_test.go
+++ b/client_internals_it_test.go
@@ -64,6 +64,7 @@ func TestClientInternal(t *testing.T) {
 		{name: "InvokeOnMember", f: clientInternalInvokeOnMemberTest},
 		{name: "InvokeOnPartition", f: clientInternalInvokeOnPartitionTest},
 		{name: "InvokeOnRandomTarget", f: clientInternalInvokeOnRandomTargetTest},
+		{name: "NoReconnect", f: noReconnectTest},
 		{name: "NotReceivedInvocation", f: clientInternalNotReceivedInvocationTest},
 		{name: "OrderedMembers", f: clientInternalOrderedMembersTest},
 		{name: "ProxyManagerShutdown", f: proxyManagerShutdownTest},
@@ -496,6 +497,7 @@ func infiniteRestartTest(t *testing.T) {
 	tc := it.StartNewClusterWithOptions(it.NewUniqueObjectName(t.Name()), it.NextPort(), 1)
 	defer tc.Shutdown()
 	config := tc.DefaultConfigWithNoSSL()
+	config.Cluster.ConnectionStrategy.ReconnectMode = cluster.ReconnectModeOn
 	config.Cluster.ConnectionStrategy.Timeout = types.Duration(1 * time.Second)
 	client := it.MustClient(hz.StartNewClientWithConfig(ctx, config))
 	defer client.Shutdown(ctx)
@@ -524,6 +526,33 @@ func infiniteRestartTest(t *testing.T) {
 	})).(types.UUID)
 	it.MustValue(tc.RC.StartMember(ctx, tc.ClusterID))
 	wg.Wait()
+}
+
+func noReconnectTest(t *testing.T) {
+	skip.If(t, "enterprise")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	tc := it.StartNewClusterWithOptions(it.NewUniqueObjectName(t.Name()), it.NextPort(), 1)
+	defer tc.Shutdown()
+	config := tc.DefaultConfigWithNoSSL()
+	config.Cluster.ConnectionStrategy.ReconnectMode = cluster.ReconnectModeOff
+	config.Cluster.ConnectionStrategy.Timeout = types.Duration(1 * time.Second)
+	client := it.MustClient(hz.StartNewClientWithConfig(ctx, config))
+	defer client.Shutdown(ctx)
+	require.True(t, client.Running())
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	it.MustValue(client.AddLifecycleListener(func(ev hz.LifecycleStateChanged) {
+		if ev.State == hz.LifecycleStateDisconnected {
+			wg.Done()
+		}
+	}))
+	for _, mem := range tc.MemberUUIDs {
+		it.MustValue(tc.RC.TerminateMember(ctx, tc.ClusterID, mem))
+	}
+	// wait for disconnection to the cluster
+	wg.Wait()
+	require.False(t, client.Running())
 }
 
 type invokeFilter func(inv invocation.Invocation) (ok bool)

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -298,15 +298,20 @@ func (c *Client) handleClusterEvent(event event.Event) {
 		return
 	}
 	c.Logger.Debug(func() string { return "cluster disconnected, rebooting" })
-	// try to reboot cluster connection
-	c.ConnectionManager.Stop()
-	c.ClusterService.Reset()
-	c.PartitionService.Reset()
-	if err := c.ConnectionManager.Start(ctx); err != nil {
-		c.Logger.Errorf("cannot reconnect to cluster, shutting down: %w", err)
-		// Shutdown is blocking operation which will make sure all the event goroutines are closed.
-		// If we wait here blocking, it will be a deadlock
-		go c.Shutdown(ctx)
+	for {
+		if c.State() != Ready {
+			break
+		}
+		// try to reboot cluster connection
+		c.ConnectionManager.Stop()
+		c.ClusterService.Reset()
+		c.PartitionService.Reset()
+		if err := c.ConnectionManager.Start(ctx); err != nil {
+			c.Logger.Errorf("cannot reconnect to cluster: %w", err)
+			time.Sleep(1 * time.Second)
+			continue
+		}
+		break
 	}
 }
 


### PR DESCRIPTION
The client reboots the connection manager if it is disconnected from the cluster (all connections are closed). But it tries rebooting only once, which causes a client shutdown on Kubernetes.

Fixes: https://github.com/hazelcast/hazelcast-go-client/issues/909