### PR TITLE
Add ServerName to SSLOptions

### DIFF
--- a/cluster/ssl_config.go
+++ b/cluster/ssl_config.go
@@ -51,6 +51,8 @@ func (c *SSLConfig) Validate() error {
 }
 
 // SetTLSConfig overrides the internal TLS configuration.
+// Use this method only when you want to replace the internal TLS configuration.
+// It should be called before calling any other methods or setting any fields.
 func (c *SSLConfig) SetTLSConfig(tlsConfig *tls.Config) {
 	c.tlsConfig = tlsConfig.Clone()
 }

--- a/cluster/ssl_config.go
+++ b/cluster/ssl_config.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	ihzerrors "github.com/hazelcast/hazelcast-go-client/internal/hzerrors"
 )
@@ -31,14 +31,17 @@ import (
 // SSLConfig has tls.Config embedded in it so that users can set any field of tls config as they wish.
 type SSLConfig struct {
 	tlsConfig *tls.Config
-	Enabled   bool `json:",omitempty"`
+	// ServerName sets the host name of the server.
+	ServerName string
+	Enabled    bool `json:",omitempty"`
 }
 
 func (c *SSLConfig) Clone() SSLConfig {
 	c.ensureTLSConfig()
 	return SSLConfig{
-		Enabled:   c.Enabled,
-		tlsConfig: c.tlsConfig.Clone(),
+		ServerName: c.ServerName,
+		Enabled:    c.Enabled,
+		tlsConfig:  c.tlsConfig.Clone(),
 	}
 }
 
@@ -47,7 +50,7 @@ func (c *SSLConfig) Validate() error {
 	return nil
 }
 
-// SetTLSConfig resets the internal TLS configuration.
+// SetTLSConfig overrides the internal TLS configuration.
 func (c *SSLConfig) SetTLSConfig(tlsConfig *tls.Config) {
 	c.tlsConfig = tlsConfig.Clone()
 }
@@ -63,7 +66,7 @@ func (c *SSLConfig) SetCAPath(path string) error {
 	c.ensureTLSConfig()
 	// XXX: what happens if the path is loaded multiple times?
 	// load CA cert
-	if caCert, err := ioutil.ReadFile(path); err != nil {
+	if caCert, err := os.ReadFile(path); err != nil {
 		return ihzerrors.NewIOError("reading CA certificate: %w", err)
 	} else {
 		caCertPool := x509.NewCertPool()
@@ -108,10 +111,10 @@ func (c *SSLConfig) AddClientCertAndEncryptedKeyPath(certPath string, privateKey
 	var privKey *rsa.PrivateKey
 	var cert tls.Certificate
 	var err error
-	if certPEMBlock, err = ioutil.ReadFile(certPath); err != nil {
+	if certPEMBlock, err = os.ReadFile(certPath); err != nil {
 		return fmt.Errorf("reading cert: %w", err)
 	}
-	if privatePEM, err = ioutil.ReadFile(privateKeyPath); err != nil {
+	if privatePEM, err = os.ReadFile(privateKeyPath); err != nil {
 		return fmt.Errorf("reading private key: %w", err)
 	}
 	privatePEMBlock, _ := pem.Decode(privatePEM)
@@ -131,6 +134,8 @@ func (c *SSLConfig) AddClientCertAndEncryptedKeyPath(certPath string, privateKey
 
 func (c *SSLConfig) ensureTLSConfig() {
 	if c.tlsConfig == nil {
-		c.tlsConfig = &tls.Config{}
+		c.tlsConfig = &tls.Config{
+			ServerName: c.ServerName,
+		}
 	}
 }

--- a/cluster/ssl_config.go
+++ b/cluster/ssl_config.go
@@ -32,8 +32,8 @@ import (
 type SSLConfig struct {
 	tlsConfig *tls.Config
 	// ServerName sets the host name of the server.
-	ServerName string
-	Enabled    bool `json:",omitempty"`
+	ServerName string `json:",omitempty"`
+	Enabled    bool   `json:",omitempty"`
 }
 
 func (c *SSLConfig) Clone() SSLConfig {

--- a/cluster/ssl_config_test.go
+++ b/cluster/ssl_config_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,24 @@
 package cluster_test
 
 import (
+	"crypto/tls"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hazelcast/hazelcast-go-client/cluster"
 )
+
+func TestSSLConfig_Clone(t *testing.T) {
+	cfg1 := cluster.SSLConfig{
+		ServerName: "myserver.com",
+		Enabled:    true,
+	}
+	cfg1.SetTLSConfig(&tls.Config{InsecureSkipVerify: true})
+	cfg2 := cfg1.Clone()
+	assert.Equal(t, cfg1, cfg2)
+}
 
 func TestSSLConfig_SetCAPath(t *testing.T) {
 	sslConfig := cluster.SSLConfig{

--- a/cluster/ssl_config_test.go
+++ b/cluster/ssl_config_test.go
@@ -17,7 +17,6 @@
 package cluster_test
 
 import (
-	"crypto/tls"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,8 +30,8 @@ func TestSSLConfig_Clone(t *testing.T) {
 		ServerName: "myserver.com",
 		Enabled:    true,
 	}
-	cfg1.SetTLSConfig(&tls.Config{InsecureSkipVerify: true})
 	cfg2 := cfg1.Clone()
+	assert.Equal(t, "myserver.com", cfg2.TLSConfig().ServerName)
 	assert.Equal(t, cfg1, cfg2)
 }
 


### PR DESCRIPTION
`ServerName` option was misisng, which forced the user to override internal TLS config.
This PR remedies that.