### PR TITLE
Add ToTime and String methods to custom date/time types [API-1924]

### DIFF
--- a/types/duration.go
+++ b/types/duration.go
@@ -22,6 +22,13 @@ import (
 
 type Duration time.Duration
 
+func (d *Duration) ToDuration() time.Duration {
+	if d == nil {
+		return time.Duration(0)
+	}
+	return (time.Duration)(*d)
+}
+
 func (d Duration) String() string {
 	return time.Duration(d).String()
 }

--- a/types/duration_test.go
+++ b/types/duration_test.go
@@ -21,16 +21,31 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/hazelcast/hazelcast-go-client/types"
 )
 
-func TestDuration_String(t *testing.T) {
+func TestDuration(t *testing.T) {
+	testCases := []struct {
+		f    func(t *testing.T)
+		name string
+	}{
+		{name: "TestDuration_String", f: durationStringTest},
+		{name: "TestDuration_MarshalText", f: durationMarshalTextTest},
+		{name: "TestLocalTimeToTime", f: durationToDurationTest},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, tc.f)
+	}
+}
+
+func durationStringTest(t *testing.T) {
 	dr := types.Duration(time.Minute)
 	assert.Equal(t, time.Minute.String(), dr.String())
 }
 
-func TestDuration_MarshalText(t *testing.T) {
+func durationMarshalTextTest(t *testing.T) {
 	dr := types.Duration(time.Minute)
 	want := `1m0s`
 	text, err := dr.MarshalText()
@@ -38,4 +53,18 @@ func TestDuration_MarshalText(t *testing.T) {
 		t.Fatal(err)
 	}
 	assert.Equal(t, want, string(text))
+}
+
+func durationToDurationTest(t *testing.T) {
+	testCases := []struct {
+		tyd types.Duration
+		tid time.Duration
+	}{
+		{tyd: types.Duration(time.Second), tid: time.Second},
+		{tyd: types.Duration(time.Minute), tid: time.Minute},
+		{tyd: types.Duration(time.Hour), tid: time.Hour},
+	}
+	for _, tc := range testCases {
+		require.Equal(t, tc.tid, tc.tyd.ToDuration())
+	}
 }

--- a/types/duration_test.go
+++ b/types/duration_test.go
@@ -31,9 +31,9 @@ func TestDuration(t *testing.T) {
 		f    func(t *testing.T)
 		name string
 	}{
-		{name: "TestDuration_String", f: durationStringTest},
-		{name: "TestDuration_MarshalText", f: durationMarshalTextTest},
-		{name: "TestLocalTimeToTime", f: durationToDurationTest},
+		{name: "DurationString", f: durationStringTest},
+		{name: "DurationMarshalText", f: durationMarshalTextTest},
+		{name: "DurationToDuration", f: durationToDurationTest},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, tc.f)

--- a/types/time.go
+++ b/types/time.go
@@ -20,6 +20,13 @@ import (
 	"time"
 )
 
+const (
+	dateFormat           = "2006-01-02"
+	timeFormat           = "15:04:05.999999999"
+	dateTimeFormat       = "2006-01-02T15:04:05.999999999"
+	offsetDateTimeFormat = "2006-01-02T15:04:05.999999999Z07:00"
+)
+
 // LocalDate is the date part of time.Time.
 type LocalDate time.Time
 
@@ -43,7 +50,7 @@ func (ld *LocalDate) String() string {
 	if ld == nil {
 		return ""
 	}
-	return (*time.Time)(ld).String()
+	return (*time.Time)(ld).Format(dateFormat)
 }
 
 func (lt *LocalTime) ToTime() time.Time {
@@ -57,7 +64,7 @@ func (lt *LocalTime) String() string {
 	if lt == nil {
 		return ""
 	}
-	return (*time.Time)(lt).String()
+	return (*time.Time)(lt).Format(timeFormat)
 }
 
 func (ldt *LocalDateTime) ToTime() time.Time {
@@ -71,7 +78,7 @@ func (ldt *LocalDateTime) String() string {
 	if ldt == nil {
 		return ""
 	}
-	return (*time.Time)(ldt).String()
+	return (*time.Time)(ldt).Format(dateTimeFormat)
 }
 
 func (odt *OffsetDateTime) ToTime() time.Time {
@@ -85,5 +92,5 @@ func (odt *OffsetDateTime) String() string {
 	if odt == nil {
 		return ""
 	}
-	return (*time.Time)(odt).String()
+	return (*time.Time)(odt).Format(offsetDateTimeFormat)
 }

--- a/types/time.go
+++ b/types/time.go
@@ -20,13 +20,6 @@ import (
 	"time"
 )
 
-const (
-	dateFormat           = "2006-01-02"
-	timeFormat           = "15:04:05.999999999"
-	dateTimeFormat       = "2006-01-02T15:04:05.999999999"
-	offsetDateTimeFormat = "2006-01-02T15:04:05.999999999Z07:00"
-)
-
 // LocalDate is the date part of time.Time.
 type LocalDate time.Time
 
@@ -50,7 +43,7 @@ func (ld *LocalDate) String() string {
 	if ld == nil {
 		return ""
 	}
-	return (*time.Time)(ld).Format(dateFormat)
+	return (*time.Time)(ld).String()
 }
 
 func (lt *LocalTime) ToTime() time.Time {
@@ -64,7 +57,7 @@ func (lt *LocalTime) String() string {
 	if lt == nil {
 		return ""
 	}
-	return (*time.Time)(lt).Format(timeFormat)
+	return (*time.Time)(lt).String()
 }
 
 func (ldt *LocalDateTime) ToTime() time.Time {
@@ -78,7 +71,7 @@ func (ldt *LocalDateTime) String() string {
 	if ldt == nil {
 		return ""
 	}
-	return (*time.Time)(ldt).Format(dateTimeFormat)
+	return (*time.Time)(ldt).String()
 }
 
 func (odt *OffsetDateTime) ToTime() time.Time {
@@ -92,5 +85,5 @@ func (odt *OffsetDateTime) String() string {
 	if odt == nil {
 		return ""
 	}
-	return (*time.Time)(odt).Format(offsetDateTimeFormat)
+	return (*time.Time)(odt).String()
 }

--- a/types/time.go
+++ b/types/time.go
@@ -31,3 +31,59 @@ type LocalDateTime time.Time
 
 // OffsetDateTime is the date and time with a timezone.
 type OffsetDateTime time.Time
+
+func (ld *LocalDate) ToTime() time.Time {
+	if ld == nil {
+		return time.Time{}
+	}
+	return *(*time.Time)(ld)
+}
+
+func (ld *LocalDate) String() string {
+	if ld == nil {
+		return ""
+	}
+	return (*time.Time)(ld).String()
+}
+
+func (lt *LocalTime) ToTime() time.Time {
+	if lt == nil {
+		return time.Time{}
+	}
+	return *(*time.Time)(lt)
+}
+
+func (lt *LocalTime) String() string {
+	if lt == nil {
+		return ""
+	}
+	return (*time.Time)(lt).String()
+}
+
+func (ldt *LocalDateTime) ToTime() time.Time {
+	if ldt == nil {
+		return time.Time{}
+	}
+	return *(*time.Time)(ldt)
+}
+
+func (ldt *LocalDateTime) String() string {
+	if ldt == nil {
+		return ""
+	}
+	return (*time.Time)(ldt).String()
+}
+
+func (odt *OffsetDateTime) ToTime() time.Time {
+	if odt == nil {
+		return time.Time{}
+	}
+	return *(*time.Time)(odt)
+}
+
+func (odt *OffsetDateTime) String() string {
+	if odt == nil {
+		return ""
+	}
+	return (*time.Time)(odt).String()
+}

--- a/types/time_test.go
+++ b/types/time_test.go
@@ -47,9 +47,9 @@ func localDateStringTest(t *testing.T) {
 		ld  types.LocalDate
 		str string
 	}{
-		{ld: types.LocalDate(time.Date(2021, 12, 21, 0, 0, 0, 0, time.Local)), str: "2021-12-21"},
-		{ld: types.LocalDate(time.Date(1914, 7, 28, 0, 0, 0, 0, time.Local)), str: "1914-07-28"},
-		{ld: types.LocalDate(time.Date(1923, 4, 23, 0, 0, 0, 0, time.Local)), str: "1923-04-23"},
+		{ld: types.LocalDate(time.Date(2021, 12, 21, 0, 0, 0, 0, time.UTC)), str: "2021-12-21 00:00:00 +0000 UTC"},
+		{ld: types.LocalDate(time.Date(1914, 7, 28, 0, 0, 0, 0, time.UTC)), str: "1914-07-28 00:00:00 +0000 UTC"},
+		{ld: types.LocalDate(time.Date(1923, 4, 23, 0, 0, 0, 0, time.UTC)), str: "1923-04-23 00:00:00 +0000 UTC"},
 	}
 	for _, tc := range testCases {
 		require.Equal(t, tc.str, tc.ld.String())
@@ -75,9 +75,9 @@ func localTimeStringTest(t *testing.T) {
 		ld  types.LocalTime
 		str string
 	}{
-		{ld: types.LocalTime(time.Date(0, 1, 1, 14, 15, 16, 200, time.Local)), str: "14:15:16.0000002"},
-		{ld: types.LocalTime(time.Date(0, 1, 1, 9, 5, 20, 400, time.Local)), str: "09:05:20.0000004"},
-		{ld: types.LocalTime(time.Date(0, 1, 1, 23, 59, 59, 999, time.Local)), str: "23:59:59.000000999"},
+		{ld: types.LocalTime(time.Date(0, 1, 1, 14, 15, 16, 200, time.UTC)), str: "0000-01-01 14:15:16.0000002 +0000 UTC"},
+		{ld: types.LocalTime(time.Date(0, 1, 1, 9, 5, 20, 400, time.UTC)), str: "0000-01-01 09:05:20.0000004 +0000 UTC"},
+		{ld: types.LocalTime(time.Date(0, 1, 1, 23, 59, 59, 999, time.UTC)), str: "0000-01-01 23:59:59.000000999 +0000 UTC"},
 	}
 	for _, tc := range testCases {
 		require.Equal(t, tc.str, tc.ld.String())
@@ -103,9 +103,9 @@ func localDateTimeStringTest(t *testing.T) {
 		ldt types.LocalDateTime
 		str string
 	}{
-		{ldt: types.LocalDateTime(time.Date(2021, 12, 21, 14, 15, 16, 200, time.Local)), str: "2021-12-21T14:15:16.0000002"},
-		{ldt: types.LocalDateTime(time.Date(1914, 7, 28, 9, 5, 20, 400, time.Local)), str: "1914-07-28T09:05:20.0000004"},
-		{ldt: types.LocalDateTime(time.Date(1923, 4, 23, 23, 59, 59, 999, time.Local)), str: "1923-04-23T23:59:59.000000999"},
+		{ldt: types.LocalDateTime(time.Date(2021, 12, 21, 14, 15, 16, 200, time.UTC)), str: "2021-12-21 14:15:16.0000002 +0000 UTC"},
+		{ldt: types.LocalDateTime(time.Date(1914, 7, 28, 9, 5, 20, 400, time.UTC)), str: "1914-07-28 09:05:20.0000004 +0000 UTC"},
+		{ldt: types.LocalDateTime(time.Date(1923, 4, 23, 23, 59, 59, 999, time.UTC)), str: "1923-04-23 23:59:59.000000999 +0000 UTC"},
 	}
 	for _, tc := range testCases {
 		require.Equal(t, tc.str, tc.ldt.String())
@@ -132,9 +132,9 @@ func offsetDateTimeStringTest(t *testing.T) {
 		odt types.OffsetDateTime
 		str string
 	}{
-		{odt: types.OffsetDateTime(time.Date(2021, 12, 21, 14, 15, 16, 200, time.UTC)), str: "2021-12-21T14:15:16.0000002Z"},
-		{odt: types.OffsetDateTime(time.Date(1923, 4, 23, 23, 59, 59, 999, time.FixedZone("UTC+3", 3*60*60))), str: "1923-04-23T23:59:59.000000999+03:00"},
-		{odt: types.OffsetDateTime(time.Date(2025, 2, 6, 4, 07, 15, 500, time.FixedZone("UTC-5", -5*60*60))), str: "2025-02-06T04:07:15.0000005-05:00"},
+		{odt: types.OffsetDateTime(time.Date(2021, 12, 21, 14, 15, 16, 200, time.UTC)), str: "2021-12-21 14:15:16.0000002 +0000 UTC"},
+		{odt: types.OffsetDateTime(time.Date(1923, 4, 23, 23, 59, 59, 999, time.FixedZone("UTC+3", 3*60*60))), str: "1923-04-23 23:59:59.000000999 +0300 UTC+3"},
+		{odt: types.OffsetDateTime(time.Date(2025, 2, 6, 4, 07, 15, 50000, time.FixedZone("UTC-5", -5*60*60))), str: "2025-02-06 04:07:15.00005 -0500 UTC-5"},
 	}
 	for _, tc := range testCases {
 		require.Equal(t, tc.str, tc.odt.String())

--- a/types/time_test.go
+++ b/types/time_test.go
@@ -1,0 +1,142 @@
+package types_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hazelcast/hazelcast-go-client/types"
+)
+
+func TestTime(t *testing.T) {
+	testCases := []struct {
+		f    func(t *testing.T)
+		name string
+	}{
+		{name: "TestLocalDateToTime", f: localDateToTimeTest},
+		{name: "TestLocalDateString", f: localDateStringTest},
+		{name: "TestLocalTimeToTime", f: localTimeToTimeTest},
+		{name: "TestLocalTimeString", f: localTimeStringTest},
+		{name: "TestLocalDateTimeToTime", f: localDateTimeToTimeTest},
+		{name: "TestLocalDateTimeString", f: localDateTimeStringTest},
+		{name: "OffsetDateTimeToTime", f: offsetDateTimeToTimeTest},
+		{name: "OffsetDateTimeString", f: offsetDateTimeStringTest},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, tc.f)
+	}
+}
+
+func localDateToTimeTest(t *testing.T) {
+	testCases := []struct {
+		ld   types.LocalDate
+		time time.Time
+	}{
+		{ld: types.LocalDate(time.Date(2021, 12, 21, 0, 0, 0, 0, time.Local)), time: time.Date(2021, time.December, 21, 0, 0, 0, 0, time.Local)},
+		{ld: types.LocalDate(time.Date(1914, 7, 28, 0, 0, 0, 0, time.Local)), time: time.Date(1914, time.July, 28, 0, 0, 0, 0, time.Local)},
+		{ld: types.LocalDate(time.Date(1923, 4, 23, 0, 0, 0, 0, time.Local)), time: time.Date(1923, time.April, 23, 0, 0, 0, 0, time.Local)},
+	}
+	for _, tc := range testCases {
+		require.Equal(t, tc.time, tc.ld.ToTime())
+	}
+}
+
+func localDateStringTest(t *testing.T) {
+	testCases := []struct {
+		ld  types.LocalDate
+		str string
+	}{
+		{ld: types.LocalDate(time.Date(2021, 12, 21, 0, 0, 0, 0, time.Local)), str: "2021-12-21"},
+		{ld: types.LocalDate(time.Date(1914, 7, 28, 0, 0, 0, 0, time.Local)), str: "1914-07-28"},
+		{ld: types.LocalDate(time.Date(1923, 4, 23, 0, 0, 0, 0, time.Local)), str: "1923-04-23"},
+	}
+	for _, tc := range testCases {
+		require.Equal(t, tc.str, tc.ld.String())
+	}
+}
+
+func localTimeToTimeTest(t *testing.T) {
+	testCases := []struct {
+		lt   types.LocalTime
+		time time.Time
+	}{
+		{lt: types.LocalTime(time.Date(0, 1, 1, 14, 15, 16, 200, time.Local)), time: time.Date(0, 1, 1, 14, 15, 16, 200, time.Local)},
+		{lt: types.LocalTime(time.Date(0, 1, 1, 9, 5, 20, 400, time.Local)), time: time.Date(0, 1, 1, 9, 5, 20, 400, time.Local)},
+		{lt: types.LocalTime(time.Date(0, 1, 1, 23, 59, 59, 999, time.Local)), time: time.Date(0, 1, 1, 23, 59, 59, 999, time.Local)},
+	}
+	for _, tc := range testCases {
+		require.Equal(t, tc.time, tc.lt.ToTime())
+	}
+}
+
+func localTimeStringTest(t *testing.T) {
+	testCases := []struct {
+		ld  types.LocalTime
+		str string
+	}{
+		{ld: types.LocalTime(time.Date(0, 1, 1, 14, 15, 16, 200, time.Local)), str: "14:15:16.0000002"},
+		{ld: types.LocalTime(time.Date(0, 1, 1, 9, 5, 20, 400, time.Local)), str: "09:05:20.0000004"},
+		{ld: types.LocalTime(time.Date(0, 1, 1, 23, 59, 59, 999, time.Local)), str: "23:59:59.000000999"},
+	}
+	for _, tc := range testCases {
+		require.Equal(t, tc.str, tc.ld.String())
+	}
+}
+
+func localDateTimeToTimeTest(t *testing.T) {
+	testCases := []struct {
+		ldt  types.LocalDateTime
+		time time.Time
+	}{
+		{ldt: types.LocalDateTime(time.Date(2021, 12, 21, 14, 15, 16, 200, time.Local)), time: time.Date(2021, 12, 21, 14, 15, 16, 200, time.Local)},
+		{ldt: types.LocalDateTime(time.Date(1914, 7, 28, 9, 5, 20, 400, time.Local)), time: time.Date(1914, 7, 28, 9, 5, 20, 400, time.Local)},
+		{ldt: types.LocalDateTime(time.Date(1923, 4, 23, 23, 59, 59, 999, time.Local)), time: time.Date(1923, 4, 23, 23, 59, 59, 999, time.Local)},
+	}
+	for _, tc := range testCases {
+		require.Equal(t, tc.time, tc.ldt.ToTime())
+	}
+}
+
+func localDateTimeStringTest(t *testing.T) {
+	testCases := []struct {
+		ldt types.LocalDateTime
+		str string
+	}{
+		{ldt: types.LocalDateTime(time.Date(2021, 12, 21, 14, 15, 16, 200, time.Local)), str: "2021-12-21T14:15:16.0000002"},
+		{ldt: types.LocalDateTime(time.Date(1914, 7, 28, 9, 5, 20, 400, time.Local)), str: "1914-07-28T09:05:20.0000004"},
+		{ldt: types.LocalDateTime(time.Date(1923, 4, 23, 23, 59, 59, 999, time.Local)), str: "1923-04-23T23:59:59.000000999"},
+	}
+	for _, tc := range testCases {
+		require.Equal(t, tc.str, tc.ldt.String())
+	}
+}
+
+func offsetDateTimeToTimeTest(t *testing.T) {
+	testCases := []struct {
+		odt  types.OffsetDateTime
+		time time.Time
+	}{
+		{odt: types.OffsetDateTime(time.Date(2021, 12, 21, 14, 15, 16, 200, time.UTC)), time: time.Date(2021, 12, 21, 14, 15, 16, 200, time.UTC)},
+		{odt: types.OffsetDateTime(time.Date(1914, 7, 28, 9, 5, 20, 400, time.Local)), time: time.Date(1914, 7, 28, 9, 5, 20, 400, time.Local)},
+		{odt: types.OffsetDateTime(time.Date(1923, 4, 23, 23, 59, 59, 999, time.FixedZone("", 3*60*60))), time: time.Date(1923, 4, 23, 23, 59, 59, 999, time.FixedZone("", 3*60*60))},
+		{odt: types.OffsetDateTime(time.Date(2025, 2, 6, 4, 07, 15, 500, time.FixedZone("", -5*60*60))), time: time.Date(2025, 2, 6, 4, 07, 15, 500, time.FixedZone("", -5*60*60))},
+	}
+	for _, tc := range testCases {
+		require.Equal(t, tc.time, tc.odt.ToTime())
+	}
+}
+
+func offsetDateTimeStringTest(t *testing.T) {
+	testCases := []struct {
+		odt types.OffsetDateTime
+		str string
+	}{
+		{odt: types.OffsetDateTime(time.Date(2021, 12, 21, 14, 15, 16, 200, time.UTC)), str: "2021-12-21T14:15:16.0000002Z"},
+		{odt: types.OffsetDateTime(time.Date(1923, 4, 23, 23, 59, 59, 999, time.FixedZone("UTC+3", 3*60*60))), str: "1923-04-23T23:59:59.000000999+03:00"},
+		{odt: types.OffsetDateTime(time.Date(2025, 2, 6, 4, 07, 15, 500, time.FixedZone("UTC-5", -5*60*60))), str: "2025-02-06T04:07:15.0000005-05:00"},
+	}
+	for _, tc := range testCases {
+		require.Equal(t, tc.str, tc.odt.String())
+	}
+}

--- a/types/time_test.go
+++ b/types/time_test.go
@@ -14,12 +14,12 @@ func TestTime(t *testing.T) {
 		f    func(t *testing.T)
 		name string
 	}{
-		{name: "TestLocalDateToTime", f: localDateToTimeTest},
-		{name: "TestLocalDateString", f: localDateStringTest},
-		{name: "TestLocalTimeToTime", f: localTimeToTimeTest},
-		{name: "TestLocalTimeString", f: localTimeStringTest},
-		{name: "TestLocalDateTimeToTime", f: localDateTimeToTimeTest},
-		{name: "TestLocalDateTimeString", f: localDateTimeStringTest},
+		{name: "LocalDateToTime", f: localDateToTimeTest},
+		{name: "LocalDateString", f: localDateStringTest},
+		{name: "LocalTimeToTime", f: localTimeToTimeTest},
+		{name: "LocalTimeString", f: localTimeStringTest},
+		{name: "LocalDateTimeToTime", f: localDateTimeToTimeTest},
+		{name: "LocalDateTimeString", f: localDateTimeStringTest},
 		{name: "OffsetDateTimeToTime", f: offsetDateTimeToTimeTest},
 		{name: "OffsetDateTimeString", f: offsetDateTimeStringTest},
 	}


### PR DESCRIPTION
Implemented conversion methods for time types.

These methods are very simple, should we add any tests, wdyt @yuce? 