### PR TITLE
Do not return an error with discovery strategy and failover

### DIFF
--- a/cluster/discovery_config.go
+++ b/cluster/discovery_config.go
@@ -19,8 +19,11 @@ package cluster
 import "github.com/hazelcast/hazelcast-go-client/cluster/discovery"
 
 type DiscoveryConfig struct {
-	Strategy    discovery.Strategy `json:",omitempty"`
-	UsePublicIP bool               `json:",omitempty"`
+	// Strategy is a discovery.Strategy implementation.
+	// See the documentation in the discovery package.
+	Strategy discovery.Strategy `json:",omitempty"`
+	// UsePublicIP causes the client to use the public addresses of members instead of their private addresses, if available.
+	UsePublicIP bool `json:",omitempty"`
 }
 
 func (c DiscoveryConfig) Clone() DiscoveryConfig {

--- a/cluster/failover_config.go
+++ b/cluster/failover_config.go
@@ -146,6 +146,7 @@ func sanitizedConfig(c Config) Config {
 	c.Cloud = CloudConfig{}
 	c.ConnectionStrategy = ConnectionStrategyConfig{}
 	c.Discovery.Strategy = nil
+	c.Discovery.UsePublicIP = false
 	return c
 }
 

--- a/cluster/failover_config.go
+++ b/cluster/failover_config.go
@@ -145,6 +145,7 @@ func sanitizedConfig(c Config) Config {
 	c.Network.Addresses = nil
 	c.Cloud = CloudConfig{}
 	c.ConnectionStrategy = ConnectionStrategyConfig{}
+	c.Discovery.Strategy = nil
 	return c
 }
 


### PR DESCRIPTION
Do not return an error with discovery strategy and failover are configured together.