### PR TITLE
Serialization Internal API for CLC [API-1925]

### DIFF
--- a/client_internals.go
+++ b/client_internals.go
@@ -29,6 +29,7 @@ import (
 	"github.com/hazelcast/hazelcast-go-client/internal/hzerrors"
 	"github.com/hazelcast/hazelcast-go-client/internal/proto"
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	pubserialization "github.com/hazelcast/hazelcast-go-client/serialization"
 	"github.com/hazelcast/hazelcast-go-client/types"
 )
 
@@ -44,6 +45,9 @@ type ClientMessageHandler = proto.ClientMessageHandler
 type Frame = proto.Frame
 type ForwardFrameIterator = proto.ForwardFrameIterator
 type Pair = proto.Pair
+type Schema = serialization.Schema
+type GenericCompactDeserializer = serialization.GenericCompactDeserializer
+type GenericPortableDeserializer = serialization.GenericPortableDeserializer
 
 var (
 	NullFrame  = NewFrameWith([]byte{}, IsNullFlag)
@@ -65,6 +69,18 @@ func NewFrameWith(content []byte, flags uint16) Frame {
 
 func NewPair(key, value interface{}) Pair {
 	return Pair{Key: key, Value: value}
+}
+
+func SetDefaultCompactDeserializer(ds GenericCompactDeserializer) {
+	serialization.DefaultCompactDeserializer = ds
+}
+
+func SetDefaultPortableDeserializer(ds GenericPortableDeserializer) {
+	serialization.DefaultPortableDeserializer = ds
+}
+
+func SetBuiltinDeserializer(serializer pubserialization.Serializer) {
+	serialization.BuiltinDeserializers[serializer.ID()] = serializer
 }
 
 type InvokeOptions struct {

--- a/internal/serialization/default_portable_reader_test.go
+++ b/internal/serialization/default_portable_reader_test.go
@@ -407,7 +407,7 @@ func TestDefaultPortableReader_ReadPortableArray(t *testing.T) {
 	classDef.AddField(NewFieldDefinition(0, "engineers", serialization.TypePortableArray,
 		classDef.FactoryID, classDef.ClassID, 0))
 	o := NewPositionalObjectDataOutput(0, nil, false)
-	serializer, err := NewPortableSerializer(service, config.PortableFactories(), 0)
+	serializer, err := NewPortableSerializer(service, config.PortableFactories(), 0, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/serialization/internal_serialization_methods_it_test.go
+++ b/internal/serialization/internal_serialization_methods_it_test.go
@@ -1,0 +1,194 @@
+//go:build hazelcastinternal && hazelcastinternaltest
+// +build hazelcastinternal,hazelcastinternaltest
+
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package serialization_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hazelcast/hazelcast-go-client"
+	"github.com/hazelcast/hazelcast-go-client/internal/it"
+	iserialization "github.com/hazelcast/hazelcast-go-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-go-client/serialization"
+)
+
+func TestInternalSerializationMethods(t *testing.T) {
+	testCases := []struct {
+		name string
+		f    func(t *testing.T)
+	}{
+		{name: "DefaultCompactSerializer", f: defaultCompactSerializerTest},
+		{name: "DefaultPortableSerializer", f: defaultPortableSerializerTest},
+		{name: "OverrideBuiltinSerializer", f: overrideBuiltinSerializerTest},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, tc.f)
+	}
+}
+
+func defaultCompactSerializerTest(t *testing.T) {
+	var sc serialization.Config
+	sc.Compact.SetSerializers(FooCompactSerializer{})
+	tcx := it.MapTestContext{
+		T: t,
+		ConfigCallback: func(tcx it.MapTestContext) {
+			tcx.Config.Serialization = sc
+		},
+	}
+	tcx.Tester(func(tcx it.MapTestContext) {
+		ctx := context.Background()
+		hazelcast.SetDefaultCompactDeserializer(DefaultCompactDeserializer{})
+		require.NoError(t, tcx.M.Set(ctx, "foo", NewFoo("abc")))
+		cfg2 := *tcx.Config
+		cfg2.Serialization.Compact = serialization.CompactConfig{}
+		require.NoError(t, cfg2.Validate())
+		client2 := it.MustClient(hazelcast.StartNewClientWithConfig(ctx, cfg2))
+		defer client2.Shutdown(ctx)
+		m2 := it.MustValue(client2.GetMap(ctx, tcx.MapName)).(*hazelcast.Map)
+		v := it.MustValue(m2.Get(ctx, "foo"))
+		require.Equal(t, NewFoo("OK"), v)
+	})
+}
+
+func defaultPortableSerializerTest(t *testing.T) {
+	hazelcast.SetDefaultPortableDeserializer(DefaultPortableDeserializer{})
+	var cfg1 serialization.Config
+	cfg1.SetPortableFactories(&FooPortableFactory{})
+	ss1 := mustSerializationService(iserialization.NewService(&cfg1, nil))
+	data := mustData(ss1.ToData(&FooPortableSerializer{foo: NewFoo("abc")}))
+	var cfg2 serialization.Config
+	ss2 := mustSerializationService(iserialization.NewService(&cfg2, nil))
+	v := it.MustValue(ss2.ToObject(data))
+	assert.Equal(t, &FooPortableSerializer{foo: NewFoo("OK")}, v)
+}
+
+func overrideBuiltinSerializerTest(t *testing.T) {
+	hazelcast.SetBuiltinDeserializer(Int32Deserializer{})
+	var cfg serialization.Config
+	ss := mustSerializationService(iserialization.NewService(&cfg, nil))
+	data := mustData(ss.ToData(int32(100)))
+	v := it.MustValue(ss.ToObject(data))
+	assert.Equal(t, int32(38), v)
+}
+
+type Foo struct {
+	value *string
+}
+
+func NewFoo(v string) Foo {
+	return Foo{value: &v}
+}
+
+func (f Foo) String() string {
+	if f.value == nil {
+		return ""
+	}
+	return *f.value
+}
+
+type FooCompactSerializer struct{}
+
+func (s FooCompactSerializer) Type() reflect.Type {
+	return reflect.TypeOf(Foo{})
+}
+
+func (s FooCompactSerializer) TypeName() string {
+	return "foo"
+}
+
+func (s FooCompactSerializer) Read(r serialization.CompactReader) interface{} {
+	return Foo{
+		value: r.ReadString("value"),
+	}
+}
+
+func (s FooCompactSerializer) Write(w serialization.CompactWriter, v interface{}) {
+	vv := v.(Foo)
+	w.WriteString("value", vv.value)
+}
+
+type DefaultCompactDeserializer struct{}
+
+func (s DefaultCompactDeserializer) Read(schema *iserialization.Schema, reader serialization.CompactReader) interface{} {
+	v := "OK"
+	return Foo{value: &v}
+}
+
+type FooPortableSerializer struct {
+	foo Foo
+}
+
+func (f *FooPortableSerializer) FactoryID() int32 {
+	return 100
+}
+
+func (f *FooPortableSerializer) ClassID() int32 {
+	return 50
+}
+
+func (f *FooPortableSerializer) WritePortable(w serialization.PortableWriter) {
+	w.WriteString("value", f.foo.String())
+}
+
+func (f *FooPortableSerializer) ReadPortable(r serialization.PortableReader) {
+	s := r.ReadString("value")
+	f.foo = NewFoo(s)
+}
+
+type FooPortableFactory struct{}
+
+func (f FooPortableFactory) Create(classID int32) serialization.Portable {
+	if classID != 50 {
+		panic("unexpected classID")
+	}
+	return &FooPortableSerializer{}
+}
+
+func (f FooPortableFactory) FactoryID() int32 {
+	return 100
+}
+
+type DefaultPortableDeserializer struct{}
+
+func (s DefaultPortableDeserializer) CreatePortableValue(factoryID, classID int32) serialization.Portable {
+	return &FooPortableSerializer{foo: NewFoo("OK")}
+}
+
+func (s DefaultPortableDeserializer) ReadPortableWithClassDefinition(cd *serialization.ClassDefinition, reader serialization.PortableReader) {
+	// pass
+}
+
+type Int32Deserializer struct{}
+
+func (s Int32Deserializer) ID() int32 {
+	return iserialization.TypeInt32
+}
+
+func (s Int32Deserializer) Read(input serialization.DataInput) interface{} {
+	return int32(38)
+}
+
+func (s Int32Deserializer) Write(output serialization.DataOutput, object interface{}) {
+	// pass
+}

--- a/internal/serialization/internal_serialization_methods_it_test.go
+++ b/internal/serialization/internal_serialization_methods_it_test.go
@@ -84,7 +84,11 @@ func defaultPortableSerializerTest(t *testing.T) {
 }
 
 func overrideBuiltinSerializerTest(t *testing.T) {
+	backup := iserialization.BuiltinDeserializers[iserialization.TypeInt32]
 	hazelcast.SetBuiltinDeserializer(Int32Deserializer{})
+	defer func() {
+		iserialization.BuiltinDeserializers[iserialization.TypeInt32] = backup
+	}()
 	var cfg serialization.Config
 	ss := mustSerializationService(iserialization.NewService(&cfg, nil))
 	data := mustData(ss.ToData(int32(100)))

--- a/internal/serialization/internal_serialization_methods_it_test.go
+++ b/internal/serialization/internal_serialization_methods_it_test.go
@@ -179,7 +179,7 @@ func (s DefaultPortableDeserializer) CreatePortableValue(factoryID, classID int3
 	return &FooPortableSerializer{foo: NewFoo("OK")}
 }
 
-func (s DefaultPortableDeserializer) ReadPortableWithClassDefinition(cd *serialization.ClassDefinition, reader serialization.PortableReader) {
+func (s DefaultPortableDeserializer) ReadPortableWithClassDefinition(portable serialization.Portable, cd *serialization.ClassDefinition, reader serialization.PortableReader) {
 	// pass
 }
 

--- a/internal/serialization/morphing_portable_reader_test.go
+++ b/internal/serialization/morphing_portable_reader_test.go
@@ -1370,7 +1370,7 @@ func TestMorphingPortableReader_ReadPortableArray(t *testing.T) {
 	classDef.AddField(NewFieldDefinition(0, "engineers", serialization.TypePortableArray,
 		classDef.FactoryID, classDef.ClassID, classDef.Version))
 	o := NewPositionalObjectDataOutput(0, nil, false)
-	serializer, err := NewPortableSerializer(service, config.PortableFactories(), 0)
+	serializer, err := NewPortableSerializer(service, config.PortableFactories(), 0, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1399,7 +1399,7 @@ func TestMorphingPortableReader_ReadPortableArrayWithEmptyFieldName(t *testing.T
 	classDef.AddField(NewFieldDefinition(0, "engineers", serialization.TypePortableArray,
 		classDef.FactoryID, classDef.ClassID, classDef.Version))
 	o := NewPositionalObjectDataOutput(0, nil, false)
-	serializer, err := NewPortableSerializer(service, config.PortableFactories(), 0)
+	serializer, err := NewPortableSerializer(service, config.PortableFactories(), 0, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/serialization/object_data_test.go
+++ b/internal/serialization/object_data_test.go
@@ -266,7 +266,7 @@ func TestObjectDataInput_ReadObject(t *testing.T) {
 
 func TestObjectDataInput_ReadObject_UnknownTypeID(t *testing.T) {
 	defer func() {
-		const target = "unknown type ID: -120"
+		const target = "serialization.Service.ReadObject: there is no suitable de-serializer for type -120"
 		if err := recover(); err == nil {
 			t.Fatal("should have failed")
 		} else if err != target {

--- a/internal/serialization/portable_serializer.go
+++ b/internal/serialization/portable_serializer.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -24,22 +24,37 @@ import (
 	"github.com/hazelcast/hazelcast-go-client/serialization"
 )
 
-type PortableSerializer struct {
-	service         *Service
-	portableContext *PortableContext
-	factories       map[int32]serialization.PortableFactory
+type GenericPortableDeserializer interface {
+	CreatePortableValue(factoryID, classID int32) serialization.Portable
+	ReadPortableWithClassDefinition(cd *serialization.ClassDefinition, reader serialization.PortableReader)
 }
 
-func NewPortableSerializer(service *Service, factories []serialization.PortableFactory, version int32) (*PortableSerializer, error) {
+type PortableReaderEnder interface {
+	End()
+}
+
+type PortableSerializer struct {
+	service             *Service
+	portableContext     *PortableContext
+	factories           map[int32]serialization.PortableFactory
+	defaultDeserializer GenericPortableDeserializer
+}
+
+func NewPortableSerializer(service *Service, factories []serialization.PortableFactory, version int32, ds GenericPortableDeserializer) (*PortableSerializer, error) {
 	pf := map[int32]serialization.PortableFactory{}
 	for _, f := range factories {
 		fid := f.FactoryID()
 		if _, ok := pf[fid]; ok {
-			return nil, ihzerrors.NewSerializationError("this serializer is already in the registry", nil)
+			return nil, ihzerrors.NewSerializationError("this portable serializer is already in the registry", nil)
 		}
 		pf[fid] = f
 	}
-	ser := &PortableSerializer{service, NewPortableContext(service, version), pf}
+	ser := &PortableSerializer{
+		service,
+		NewPortableContext(service, version),
+		pf,
+		ds,
+	}
 	return ser, nil
 }
 
@@ -65,31 +80,36 @@ func (ps *PortableSerializer) ReadObject(input serialization.DataInput, factoryI
 		classDefinition = ps.portableContext.ReadClassDefinitionFromInput(input, factoryID, classID, version)
 		input.SetPosition(backupPos)
 	}
+	version = ps.portableContext.portableVersion
+	if pv, ok := portable.(serialization.VersionedPortable); ok {
+		version = pv.Version()
+	}
 	var reader serialization.PortableReader
-	var isMorphing bool
-	if classDefinition.Version == ps.portableContext.ClassVersion(portable) {
+	if classDefinition.Version == version {
 		reader = NewDefaultPortableReader(ps, input, classDefinition)
-		isMorphing = false
 	} else {
 		reader = NewMorphingPortableReader(ps, input, classDefinition)
-		isMorphing = true
 	}
-	portable.ReadPortable(reader)
-	if isMorphing {
-		reader.(*MorphingPortableReader).End()
+	if ps.defaultDeserializer != nil {
+		ps.defaultDeserializer.ReadPortableWithClassDefinition(classDefinition, reader)
 	} else {
-		reader.(*DefaultPortableReader).End()
+		portable.ReadPortable(reader)
+	}
+	if e, ok := reader.(PortableReaderEnder); ok {
+		e.End()
 	}
 	return portable
 }
 
-func (ps *PortableSerializer) createNewPortableInstance(factoryID int32, classID int32) (serialization.Portable, error) {
+func (ps *PortableSerializer) createNewPortableInstance(factoryID, classID int32) (serialization.Portable, error) {
 	factory := ps.factories[factoryID]
 	if factory == nil {
+		if ps.defaultDeserializer != nil {
+			return ps.defaultDeserializer.CreatePortableValue(factoryID, classID), nil
+		}
 		return nil, ihzerrors.NewSerializationError(fmt.Sprintf("there is no suitable portable factory for factory id: %d",
 			factoryID), nil)
 	}
-
 	portable := factory.Create(classID)
 	if portable == nil {
 		return nil, ihzerrors.NewSerializationError(fmt.Sprintf("%v is not able to create an instance for id: %d on factory id: %d",

--- a/internal/serialization/portable_serializer.go
+++ b/internal/serialization/portable_serializer.go
@@ -26,7 +26,7 @@ import (
 
 type GenericPortableDeserializer interface {
 	CreatePortableValue(factoryID, classID int32) serialization.Portable
-	ReadPortableWithClassDefinition(cd *serialization.ClassDefinition, reader serialization.PortableReader)
+	ReadPortableWithClassDefinition(portable serialization.Portable, cd *serialization.ClassDefinition, reader serialization.PortableReader)
 }
 
 type PortableReaderEnder interface {
@@ -91,7 +91,7 @@ func (ps *PortableSerializer) ReadObject(input serialization.DataInput, factoryI
 		reader = NewMorphingPortableReader(ps, input, classDefinition)
 	}
 	if ps.defaultDeserializer != nil {
-		ps.defaultDeserializer.ReadPortableWithClassDefinition(classDefinition, reader)
+		ps.defaultDeserializer.ReadPortableWithClassDefinition(portable, classDefinition, reader)
 	} else {
 		portable.ReadPortable(reader)
 	}

--- a/internal/serialization/portable_serializer.go
+++ b/internal/serialization/portable_serializer.go
@@ -50,10 +50,10 @@ func NewPortableSerializer(service *Service, factories []serialization.PortableF
 		pf[fid] = f
 	}
 	ser := &PortableSerializer{
-		service,
-		NewPortableContext(service, version),
-		pf,
-		ds,
+		service:             service,
+		portableContext:     NewPortableContext(service, version),
+		factories:           pf,
+		defaultDeserializer: ds,
 	}
 	return ser, nil
 }

--- a/internal/serialization/serialization.go
+++ b/internal/serialization/serialization.go
@@ -30,9 +30,11 @@ import (
 )
 
 // DefaultCompactDeserializer must be set before the client is created and should not be changed afterwards.
+// DefaultCompactDeserializer is used if a compact deserializer for a type is not found.
 var DefaultCompactDeserializer GenericCompactDeserializer
 
 // DefaultPortableDeserializer must be set before the client is created and should not be changed afterwards.
+// DefaultPortableDeserializer is used if the portable factory of a value is not found.
 var DefaultPortableDeserializer GenericPortableDeserializer
 
 // BuiltinDeserializers must be set before the client is created and should not be changed afterwards.

--- a/internal/serialization/serialization.go
+++ b/internal/serialization/serialization.go
@@ -29,10 +29,20 @@ import (
 	"github.com/hazelcast/hazelcast-go-client/types"
 )
 
+// DefaultCompactDeserializer must be set before the client is created and should not be changed afterwards.
+var DefaultCompactDeserializer GenericCompactDeserializer
+
+// DefaultPortableDeserializer must be set before the client is created and should not be changed afterwards.
+var DefaultPortableDeserializer GenericPortableDeserializer
+
+// BuiltinDeserializers must be set before the client is created and should not be changed afterwards.
+var BuiltinDeserializers map[int32]pubserialization.Serializer
+
 // Service serializes user objects to Data and back to Object.
 // Data is the internal representation of binary Data in Hazelcast.
 type Service struct {
 	SerializationConfig  *pubserialization.Config
+	builtinSerializers   map[int32]pubserialization.Serializer
 	registry             map[int32]pubserialization.Serializer
 	portableSerializer   *PortableSerializer
 	identifiedSerializer *IdentifiedDataSerializableSerializer
@@ -42,19 +52,24 @@ type Service struct {
 
 func NewService(config *pubserialization.Config, schemaCh chan SchemaMsg) (*Service, error) {
 	var err error
-	cs, err := NewCompactStreamSerializer(config.Compact, schemaCh)
+	cs, err := NewCompactStreamSerializer(config.Compact, schemaCh, DefaultCompactDeserializer)
 	if err != nil {
 		return nil, err
 	}
 	s := &Service{
 		SerializationConfig: config,
-		registry:            make(map[int32]pubserialization.Serializer),
+		registry:            map[int32]pubserialization.Serializer{},
+		builtinSerializers:  map[int32]pubserialization.Serializer{},
 		customSerializers:   config.CustomSerializers(),
 		compactSerializer:   cs,
 	}
-	s.portableSerializer, err = NewPortableSerializer(s, s.SerializationConfig.PortableFactories(), s.SerializationConfig.PortableVersion)
+	s.portableSerializer, err = NewPortableSerializer(s, s.SerializationConfig.PortableFactories(), s.SerializationConfig.PortableVersion, DefaultPortableDeserializer)
 	if err != nil {
 		return nil, err
+	}
+	// copy the builtin deserializers, so other client instances can have different deserializers
+	for k, v := range BuiltinDeserializers {
+		s.builtinSerializers[k] = v
 	}
 	s.registerClassDefinitions(s.portableSerializer, s.SerializationConfig.ClassDefinitions())
 	s.registerCustomSerializers(config.CustomSerializers())
@@ -62,6 +77,11 @@ func NewService(config *pubserialization.Config, schemaCh chan SchemaMsg) (*Serv
 	if err = s.registerIdentifiedFactories(); err != nil {
 		return nil, err
 	}
+	// set the compact, portable and identified deserializers.
+	// we have to set them here, since they depend on this service.
+	s.builtinSerializers[TypeCompact] = s.compactSerializer
+	s.builtinSerializers[TypePortable] = s.portableSerializer
+	s.builtinSerializers[TypeDataSerializable] = s.identifiedSerializer
 	return s, nil
 }
 
@@ -118,7 +138,7 @@ func (s *Service) ToObject(data Data) (r interface{}, err error) {
 	if serializer == nil {
 		serializer, ok = s.registry[typeID]
 		if !ok {
-			return nil, ihzerrors.NewSerializationError(fmt.Sprintf("there is no suitable de-serializer for type %d", typeID), nil)
+			return nil, ihzerrors.NewSerializationError(fmt.Sprintf("serialization.Service.ToObject: there is no suitable de-serializer for type %d", typeID), nil)
 		}
 	}
 	dataInput := NewObjectDataInput(data, DataOffset, s, !s.SerializationConfig.LittleEndian)
@@ -142,7 +162,7 @@ func (s *Service) ReadObject(input pubserialization.DataInput) interface{} {
 	if serializer := s.registry[typeID]; serializer != nil {
 		return serializer.Read(input)
 	}
-	panic(fmt.Sprintf("unknown type ID: %d", typeID))
+	panic(fmt.Sprintf("serialization.Service.ReadObject: there is no suitable de-serializer for type %d", typeID))
 }
 
 func (s *Service) FindSerializerFor(obj interface{}) (pubserialization.Serializer, error) {
@@ -177,79 +197,8 @@ func (s *Service) LookUpDefaultSerializer(obj interface{}) pubserialization.Seri
 }
 
 func (s *Service) lookupBuiltinDeserializer(typeID int32) pubserialization.Serializer {
-	switch typeID {
-	case TypeNil:
-		return nilSerializer
-	case TypeCompact:
-		return s.compactSerializer
-	case TypePortable:
-		return s.portableSerializer
-	case TypeDataSerializable:
-		return s.identifiedSerializer
-	case TypeBool:
-		return boolSerializer
-	case TypeString:
-		return stringSerializer
-	case TypeByte:
-		return uint8Serializer
-	case TypeUInt16:
-		return uint16Serializer
-	case TypeInt16:
-		return int16Serializer
-	case TypeInt32:
-		return int32Serializer
-	case TypeInt64:
-		return int64Serializer
-	case TypeFloat32:
-		return float32Serializer
-	case TypeFloat64:
-		return float64Serializer
-	case TypeBoolArray:
-		return boolArraySerializer
-	case TypeStringArray:
-		return stringArraySerializer
-	case TypeByteArray:
-		return uint8ArraySerializer
-	case TypeUInt16Array:
-		return uint16ArraySerializer
-	case TypeInt16Array:
-		return int16ArraySerializer
-	case TypeInt32Array:
-		return int32ArraySerializer
-	case TypeInt64Array:
-		return int64ArraySerializer
-	case TypeFloat32Array:
-		return float32ArraySerializer
-	case TypeFloat64Array:
-		return float64ArraySerializer
-	case TypeUUID:
-		return uuidSerializer
-	case TypeJavaDate:
-		return javaDateSerializer
-	case TypeJavaBigInteger:
-		return javaBigIntegerSerializer
-	case TypeJavaDecimal:
-		return javaDecimalSerializer
-	case TypeJSONSerialization:
-		return jsonSerializer
-	case TypeJavaArray:
-		return javaArraySerializer
-	case TypeJavaArrayList:
-		return javaArrayListSerializer
-	case TypeJavaLinkedList:
-		return javaLinkedListSerializer
-	case TypeJavaLocalDate:
-		return javaLocalDateSerializer
-	case TypeJavaLocalTime:
-		return javaLocalTimeSerializer
-	case TypeJavaLocalDateTime:
-		return javaLocalDateTimeSerializer
-	case TypeJavaOffsetDateTime:
-		return javaOffsetDateTimeSerializer
-	case TypeJavaClass:
-		return javaClassSerializer
-	case TypeGobSerialization:
-		return gobSerializer
+	if s, ok := s.builtinSerializers[typeID]; ok {
+		return s
 	}
 	return nil
 }
@@ -312,7 +261,7 @@ func (s *Service) registerIdentifiedFactories() error {
 	for _, f := range s.SerializationConfig.IdentifiedDataSerializableFactories() {
 		fid := f.FactoryID()
 		if _, ok := fs[fid]; ok {
-			return ihzerrors.NewSerializationError("this serializer is already in the registry", nil)
+			return ihzerrors.NewSerializationError("this identified data serializer is already in the registry", nil)
 		}
 		fs[fid] = f
 	}
@@ -442,3 +391,41 @@ var javaLocalTimeSerializer = &JavaLocalTimeSerializer{}
 var javaLocalDateTimeSerializer = &JavaLocalDateTimeSerializer{}
 var javaOffsetDateTimeSerializer = &JavaOffsetDateTimeSerializer{}
 var gobSerializer = &GobSerializer{}
+
+func init() {
+	BuiltinDeserializers = map[int32]pubserialization.Serializer{
+		TypeNil:                nilSerializer,
+		TypeBool:               boolSerializer,
+		TypeString:             stringSerializer,
+		TypeByte:               uint8Serializer,
+		TypeUInt16:             uint16Serializer,
+		TypeInt16:              int16Serializer,
+		TypeInt32:              int32Serializer,
+		TypeInt64:              int64Serializer,
+		TypeFloat32:            float32Serializer,
+		TypeFloat64:            float64Serializer,
+		TypeBoolArray:          boolArraySerializer,
+		TypeStringArray:        stringArraySerializer,
+		TypeByteArray:          uint8ArraySerializer,
+		TypeUInt16Array:        uint16ArraySerializer,
+		TypeInt16Array:         int16ArraySerializer,
+		TypeInt32Array:         int32ArraySerializer,
+		TypeInt64Array:         int64ArraySerializer,
+		TypeFloat32Array:       float32ArraySerializer,
+		TypeFloat64Array:       float64ArraySerializer,
+		TypeUUID:               uuidSerializer,
+		TypeJavaDate:           javaDateSerializer,
+		TypeJavaBigInteger:     javaBigIntegerSerializer,
+		TypeJavaDecimal:        javaDecimalSerializer,
+		TypeJSONSerialization:  jsonSerializer,
+		TypeJavaArray:          javaArraySerializer,
+		TypeJavaArrayList:      javaArrayListSerializer,
+		TypeJavaLinkedList:     javaLinkedListSerializer,
+		TypeJavaLocalDate:      javaLocalDateSerializer,
+		TypeJavaLocalTime:      javaLocalTimeSerializer,
+		TypeJavaLocalDateTime:  javaLocalDateTimeSerializer,
+		TypeJavaOffsetDateTime: javaOffsetDateTimeSerializer,
+		TypeJavaClass:          javaClassSerializer,
+		TypeGobSerialization:   gobSerializer,
+	}
+}

--- a/serialization/api.go
+++ b/serialization/api.go
@@ -46,22 +46,21 @@ type IdentifiedDataSerializable interface {
 	ReadData(input DataInput)
 }
 
-// Portable provides an alternative serialization method. Instead of relying on reflection, each Portable is
-// created by a registered PortableFactory.
-// Portable serialization has the following advantages:
-// * Supporting multiversion of the same object type.
-// * Fetching individual fields without having to rely on reflection.
-// * Querying and indexing support without deserialization and/or reflection.
+/*
+Portable provides an alternative serialization method.
+Instead of relying on reflection, each Portable is created by a registered PortableFactory.
+Portable serialization has the following advantages:
+  - Supporting multiversion of the same object type.
+  - Fetching individual fields without having to rely on reflection.
+  - Querying and indexing support without deserialization and/or reflection.
+*/
 type Portable interface {
 	// FactoryID returns PortableFactory ID for this portable struct.
 	FactoryID() int32
-
 	// ClassID returns type identifier for this portable struct. Class ID should be unique per PortableFactory.
 	ClassID() int32
-
 	// WritePortable serializes this portable object using PortableWriter.
 	WritePortable(writer PortableWriter)
-
 	// ReadPortable reads portable fields using PortableReader.
 	ReadPortable(reader PortableReader)
 }


### PR DESCRIPTION
- Enables fallback compact and portable serializers using the internal API
- Enables overriding builtin serializers using the internal API