### PR TITLE
Update Hazelcast documentation link version

### DIFF
--- a/internal/cp/proxy_atomic_long.go
+++ b/internal/cp/proxy_atomic_long.go
@@ -37,7 +37,7 @@ If a network partition occurs, it remains available on at most one side of the p
 AtomicLong implementation does not offer exactly-once / effectively-once execution semantics.
 It goes with at-least-once execution semantics by default and can cause an API call to be committed multiple times in case of CP member failures.
 It can be tuned to offer at-most-once execution semantics.
-See fail-on-indeterminate-operation-state server-side setting: https://docs.hazelcast.com/hazelcast/5.2/cp-subsystem/configuration#global-configuration-options
+See fail-on-indeterminate-operation-state server-side setting: https://docs.hazelcast.com/hazelcast/latest/cp-subsystem/configuration#global-configuration-options
 */
 type AtomicLong struct {
 	*proxy

--- a/serialization/doc.go
+++ b/serialization/doc.go
@@ -178,7 +178,7 @@ The table of supported types in compact serialization and their Java counterpart
 	*types.OffsetDateTime     OffsetDateTime
 	[]*types.OffsetDateTime   OffsetDateTime[]
 
-See https://docs.hazelcast.com/hazelcast/5.2/serialization/compact-serialization#supported-types for more information.
+See https://docs.hazelcast.com/hazelcast/latest/serialization/compact-serialization#supported-types for more information.
 
 Compact serialized objects can be used in SQL statements, provided that mappings are created, similar to other serialization formats.
 
@@ -241,7 +241,7 @@ One thing to be careful while evolving the class is to not have any conditional 
 That method must write all the fields available in the current version of the class to the writer, with appropriate field names and types.
 Write method of the serializer is used to extract a schema out of the object, hence any conditional code that may or may not run depending on the object in that method might result in an undefined behavior.
 
-For more information about compact serialization, check out https://docs.hazelcast.com/hazelcast/5.2/serialization/compact-serialization.
+For more information about compact serialization, check out https://docs.hazelcast.com/hazelcast/latest/serialization/compact-serialization.
 
 # Identified Data Serialization
 

--- a/sql/driver/doc.go
+++ b/sql/driver/doc.go
@@ -217,7 +217,7 @@ Using JSON
 
 Two different JSON types are supported, namely "json-flat" and "json"
 
-Checkout https://docs.hazelcast.com/hazelcast/5.1-beta-1/sql/working-with-json for more details.
+Checkout https://docs.hazelcast.com/hazelcast/latest/sql/working-with-json for more details.
 
 1) "json-flat" value format treats top level fields of the json object as separate columns. It does not support nested JSON values.
 


### PR DESCRIPTION
Replace any references to `https://docs.hazelcast.com/hazelcast/5.x` with `https://docs.hazelcast.com/hazelcast/latest`