### PR TITLE
CLC Improvements

### DIFF
--- a/client_internals_test_utils.go
+++ b/client_internals_test_utils.go
@@ -2,7 +2,7 @@
 // +build hazelcastinternal,hazelcastinternaltest
 
 /*
- * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -56,6 +56,10 @@ func (ci *ClientInternal) SerializationService() *serialization.Service {
 
 func (ci *ClientInternal) Proxies() map[string]interface{} {
 	return ci.client.proxyManager.Proxies()
+}
+
+func (ci *ClientInternal) ListenerBinder() *cluster.ConnectionListenerBinder {
+	return ci.client.proxyManager.serviceBundle.ListenerBinder
 }
 
 func (ci *ClientInternal) NewNearCacheManager(reconInterval, maxMiss int) *inearcache.Manager {

--- a/cluster/cloud_config.go
+++ b/cluster/cloud_config.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,10 @@ type CloudConfig struct {
 	Token string `json:",omitempty"`
 	// Enabled enables Hazelcast Cloud integration.
 	Enabled bool `json:",omitempty"`
+	// ExperimentalAPIBaseURL sets the Viridian API base URL.
+	// You generally should leave its value unset.
+	// Note that this configuration may be modified or removed anytime.
+	ExperimentalAPIBaseURL string `json:",omitempty"`
 }
 
 func (h CloudConfig) Clone() CloudConfig {

--- a/examples/cloud/main.go
+++ b/examples/cloud/main.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	clusterName     = "PUT-YOUR-CLUSTER-NAME-HERE!"
-	token           = "PUT-YOUR-VIRIIDAN-HERE!"
+	token           = "PUT-YOUR-VIRIDIAN-TOKEN-HERE!"
 	caFilePath      = "/PATH/ca.pem"
 	certFilePath    = "/PATH/cert.pem"
 	keyFilePath     = "/PATH/key.pem"

--- a/internal/cb/circuitbreaker.go
+++ b/internal/cb/circuitbreaker.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -113,7 +113,9 @@ loop:
 				break loop
 			}
 			if errors.As(err, &nonRetryableErr) {
-				err = nonRetryableErr.Err
+				if !nonRetryableErr.Persistent {
+					err = nonRetryableErr.Err
+				}
 				break loop
 			}
 			if attempt < cb.MaxRetries {

--- a/internal/cb/errors.go
+++ b/internal/cb/errors.go
@@ -51,3 +51,7 @@ func (e NonRetryableError) Is(target error) bool {
 	_, ok := target.(NonRetryableError)
 	return ok
 }
+
+func (e NonRetryableError) Unwrap() error {
+	return e.Err
+}

--- a/internal/cb/errors.go
+++ b/internal/cb/errors.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -22,11 +22,22 @@ var ErrCircuitOpen = errors.New("circuit open")
 var ErrDeadlineExceeded = errors.New("deadline exceeded")
 
 type NonRetryableError struct {
+	// Err is the wrapper error
 	Err error
+	// Persistent disables unwrapping the error in the CB if true
+	// This is useful to make the error non-retryable in chain of Trys
+	Persistent bool
 }
 
 func WrapNonRetryableError(err error) *NonRetryableError {
-	return &NonRetryableError{err}
+	return &NonRetryableError{Err: err}
+}
+
+func WrapNonRetryableErrorPersistent(err error) *NonRetryableError {
+	return &NonRetryableError{
+		Err:        err,
+		Persistent: true,
+	}
 }
 
 func (n NonRetryableError) Error() string {

--- a/internal/cb/errors.go
+++ b/internal/cb/errors.go
@@ -44,7 +44,7 @@ func (n NonRetryableError) Error() string {
 	return n.Err.Error()
 }
 
-func (e NonRetryableError) Is(target error) bool {
+func (n NonRetryableError) Is(target error) bool {
 	if _, ok := target.(*NonRetryableError); ok {
 		return true
 	}
@@ -52,6 +52,6 @@ func (e NonRetryableError) Is(target error) bool {
 	return ok
 }
 
-func (e NonRetryableError) Unwrap() error {
-	return e.Err
+func (n NonRetryableError) Unwrap() error {
+	return n.Err
 }

--- a/internal/cloud/cloud_discovery.go
+++ b/internal/cloud/cloud_discovery.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -46,13 +46,13 @@ func NewDiscoveryClient(config *cluster.CloudConfig, logger logger.LogAdaptor) *
 
 func (c *DiscoveryClient) DiscoverNodes(ctx context.Context) ([]Address, error) {
 	url := makeCoordinatorURL(c.token)
-	if j, err := c.httpClient.GetJSONArray(ctx, url); err != nil {
+	j, err := c.httpClient.GetJSONArray(ctx, url)
+	if err != nil {
 		return nil, err
-	} else {
-		addrs := extractAddresses(j)
-		c.logger.Trace(func() string { return fmt.Sprintf("cloud addresses: %v", addrs) })
-		return addrs, nil
 	}
+	addrs := extractAddresses(j)
+	c.logger.Trace(func() string { return fmt.Sprintf("cloud addresses: %v", addrs) })
+	return addrs, nil
 }
 
 func extractAddresses(j interface{}) []Address {

--- a/internal/cloud/cloud_discovery.go
+++ b/internal/cloud/cloud_discovery.go
@@ -40,7 +40,7 @@ type DiscoveryClient struct {
 func NewDiscoveryClient(config *cluster.CloudConfig, logger logger.LogAdaptor) *DiscoveryClient {
 	url := config.ExperimentalAPIBaseURL
 	if url == "" {
-		url = baseAPIURL()
+		url = defaultBaseAPIURL()
 	}
 	url = strings.TrimRight(url, "/")
 	return &DiscoveryClient{
@@ -80,7 +80,7 @@ func makeCoordinatorURL(baseURL, token string) string {
 	return fmt.Sprintf("%s/cluster/discovery?token=%s", baseURL, token)
 }
 
-func baseAPIURL() string {
+func defaultBaseAPIURL() string {
 	url := os.Getenv(envCoordinatorBaseURL)
 	if url == "" {
 		return "https://api.viridian.hazelcast.com"

--- a/internal/cloud/cloud_discovery_test.go
+++ b/internal/cloud/cloud_discovery_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ package cloud
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"strconv"
 	"testing"
 
@@ -96,14 +95,10 @@ func TestTranslateAddrs(t *testing.T) {
 }
 
 func TestMakeCoordinatorURL(t *testing.T) {
-	os.Setenv(envCoordinatorBaseURL, "")
-	url := makeCoordinatorURL("TOK")
+	url := makeCoordinatorURL("https://api.viridian.hazelcast.com", "TOK")
 	target := "https://api.viridian.hazelcast.com/cluster/discovery?token=TOK"
 	assert.Equal(t, target, url)
-	if err := os.Setenv(envCoordinatorBaseURL, "http://test.dev"); err != nil {
-		t.Fatal(err)
-	}
-	url = makeCoordinatorURL("TOK")
+	url = makeCoordinatorURL("http://test.dev", "TOK")
 	target = "http://test.dev/cluster/discovery?token=TOK"
 	assert.Equal(t, target, url)
 }

--- a/internal/cluster/connection.go
+++ b/internal/cluster/connection.go
@@ -89,6 +89,10 @@ func (c *Connection) SetEndpoint(addr pubcluster.Address) {
 	c.endpoint.Store(addr)
 }
 
+func (c *Connection) ServerVersion() string {
+	return c.connectedServerVersionStr
+}
+
 func (c *Connection) MemberUUID() types.UUID {
 	v := c.memberUUID.Load()
 	if v == nil {

--- a/internal/rest/http_client.go
+++ b/internal/rest/http_client.go
@@ -91,7 +91,7 @@ func (c *HTTPClient) Get(ctx context.Context, uri string, headers ...HTTPHeader)
 	}
 	// error is unhandled
 	resp.Body.Close()
-	return b, err
+	return b, nil
 }
 
 func (c *HTTPClient) GetJSONObject(ctx context.Context, url string, headers ...HTTPHeader) (map[string]interface{}, error) {

--- a/internal/rest/http_error.go
+++ b/internal/rest/http_error.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -18,25 +18,33 @@ package rest
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
 type Error struct {
-	Text string
-	Code int
+	text string
+	code int
 }
 
 func NewError(code int, text string) *Error {
 	return &Error{
-		Code: code,
-		Text: text,
+		code: code,
+		text: text,
 	}
+}
+
+func (e Error) Text() string {
+	return e.text
+}
+
+func (e Error) Code() int {
+	return e.code
 }
 
 func NewErrorFromResponse(resp *http.Response) *Error {
 	code := resp.StatusCode
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return NewError(code, "(cannot read error message)")
 	}
@@ -47,5 +55,5 @@ func NewErrorFromResponse(resp *http.Response) *Error {
 }
 
 func (e Error) Error() string {
-	return fmt.Sprintf("HTTP error: %d, %s", e.Code, e.Text)
+	return fmt.Sprintf("HTTP error: %d, %s", e.code, e.text)
 }

--- a/internal/serialization/compact_test.go
+++ b/internal/serialization/compact_test.go
@@ -18,14 +18,18 @@ package serialization_test
 
 import (
 	"errors"
+	"math"
+	"math/big"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/hazelcast/hazelcast-go-client/hzerrors"
+	"github.com/hazelcast/hazelcast-go-client/internal/it"
 	"github.com/hazelcast/hazelcast-go-client/internal/serialization"
 	pubserialization "github.com/hazelcast/hazelcast-go-client/serialization"
+	"github.com/hazelcast/hazelcast-go-client/types"
 )
 
 func TestCompactSerializer(t *testing.T) {
@@ -34,6 +38,9 @@ func TestCompactSerializer(t *testing.T) {
 		f    func(t *testing.T)
 	}{
 		{name: "AddDuplicateField", f: addDuplicateFieldTest},
+		{name: "NullableSerializer", f: nullableSerializerTest},
+		{name: "PrimitiveArraySerializer", f: primitiveArraySerializerTest},
+		{name: "OtherArraySerializer", f: otherArraySerializerTest},
 		{name: "SliceWithDifferentTypes", f: sliceWithDifferentTypesTest},
 	}
 	for _, tc := range testCases {
@@ -100,4 +107,194 @@ func (s sliceWithDifferentTypesSerializer) Read(reader pubserialization.CompactR
 func (s sliceWithDifferentTypesSerializer) Write(writer pubserialization.CompactWriter, value interface{}) {
 	v := []interface{}(value.(sliceWithDifferentTypes))
 	writer.WriteArrayOfCompact("f", v)
+}
+
+type primitiveArrays struct {
+	emptyBoolArray         []bool
+	fullBoolArray          []bool
+	emptyInt8Array         []int8
+	fullInt8Array          []int8
+	emptyInt16Array        []int16
+	fullInt16Array         []int16
+	emptyInt32Array        []int32
+	fullInt32Array         []int32
+	emptyInt64Array        []int64
+	fullInt64Array         []int64
+	emptyFloat32Array      []float32
+	fullFloat32Array       []float32
+	emptyFloat64Array      []float64
+	fullFloat64Array       []float64
+	emptyNullableBoolArray []*bool
+	fullNullableBoolArray  []*bool
+	emptyNullableInt8Array []*int8
+	fullNullableInt8Array  []*int8
+}
+
+type primitiveArraysSerializer struct{}
+
+func (s primitiveArraysSerializer) Type() reflect.Type {
+	return reflect.TypeOf(primitiveArrays{})
+}
+
+func (s primitiveArraysSerializer) TypeName() string {
+	return "primitiveArrays"
+}
+
+func (s primitiveArraysSerializer) Read(r pubserialization.CompactReader) interface{} {
+	return primitiveArrays{
+		emptyBoolArray:         r.ReadArrayOfBoolean("emptyBoolArray"),
+		fullBoolArray:          r.ReadArrayOfBoolean("fullBoolArray"),
+		emptyInt8Array:         r.ReadArrayOfInt8("emptyInt8Array"),
+		fullInt8Array:          r.ReadArrayOfInt8("fullInt8Array"),
+		emptyInt16Array:        r.ReadArrayOfInt16("emptyInt16Array"),
+		fullInt16Array:         r.ReadArrayOfInt16("fullInt16Array"),
+		emptyInt32Array:        r.ReadArrayOfInt32("emptyInt32Array"),
+		fullInt32Array:         r.ReadArrayOfInt32("fullInt32Array"),
+		emptyInt64Array:        r.ReadArrayOfInt64("emptyInt64Array"),
+		fullInt64Array:         r.ReadArrayOfInt64("fullInt64Array"),
+		emptyFloat32Array:      r.ReadArrayOfFloat32("emptyFloat32Array"),
+		fullFloat32Array:       r.ReadArrayOfFloat32("fullFloat32Array"),
+		emptyFloat64Array:      r.ReadArrayOfFloat64("emptyFloat64Array"),
+		fullFloat64Array:       r.ReadArrayOfFloat64("fullFloat64Array"),
+		emptyNullableBoolArray: r.ReadArrayOfNullableBoolean("emptyNullableBoolArray"),
+		fullNullableBoolArray:  r.ReadArrayOfNullableBoolean("fullNullableBoolArray"),
+		emptyNullableInt8Array: r.ReadArrayOfNullableInt8("emptyNullableInt8Array"),
+		fullNullableInt8Array:  r.ReadArrayOfNullableInt8("fullNullableInt8Array"),
+	}
+}
+
+func (s primitiveArraysSerializer) Write(w pubserialization.CompactWriter, v interface{}) {
+	vv := v.(primitiveArrays)
+	w.WriteArrayOfBoolean("emptyBoolArray", vv.emptyBoolArray)
+	w.WriteArrayOfBoolean("fullBoolArray", vv.fullBoolArray)
+	w.WriteArrayOfInt8("emptyInt8Array", vv.emptyInt8Array)
+	w.WriteArrayOfInt8("fullInt8Array", vv.fullInt8Array)
+	w.WriteArrayOfInt16("emptyInt16Array", vv.emptyInt16Array)
+	w.WriteArrayOfInt16("fullInt16Array", vv.fullInt16Array)
+	w.WriteArrayOfInt32("emptyInt32Array", vv.emptyInt32Array)
+	w.WriteArrayOfInt32("fullInt32Array", vv.fullInt32Array)
+	w.WriteArrayOfInt64("emptyInt64Array", vv.emptyInt64Array)
+	w.WriteArrayOfInt64("fullInt64Array", vv.fullInt64Array)
+	w.WriteArrayOfFloat32("emptyFloat32Array", vv.emptyFloat32Array)
+	w.WriteArrayOfFloat32("fullFloat32Array", vv.fullFloat32Array)
+	w.WriteArrayOfFloat64("emptyFloat64Array", vv.emptyFloat64Array)
+	w.WriteArrayOfFloat64("fullFloat64Array", vv.fullFloat64Array)
+	w.WriteArrayOfNullableBoolean("fullNullableBoolArray", vv.fullNullableBoolArray)
+	w.WriteArrayOfNullableBoolean("emptyNullableBoolArray", vv.emptyNullableBoolArray)
+	w.WriteArrayOfNullableInt8("emptyNullableInt8Array", vv.emptyNullableInt8Array)
+	w.WriteArrayOfNullableInt8("fullNullableInt8Array", vv.fullNullableInt8Array)
+}
+
+func primitiveArraySerializerTest(t *testing.T) {
+	var cfg pubserialization.Config
+	cfg.Compact.SetSerializers(&primitiveArraysSerializer{})
+	ss := mustSerializationService(serialization.NewService(&cfg, nil))
+	b := true
+	i8 := int8(8)
+	target := primitiveArrays{
+		fullBoolArray:         []bool{true, false},
+		fullInt8Array:         []int8{math.MinInt8, 0, math.MaxInt8},
+		fullInt16Array:        []int16{math.MinInt16, 0, math.MaxInt16},
+		fullInt32Array:        []int32{math.MinInt32, 0, math.MaxInt32},
+		fullInt64Array:        []int64{math.MinInt64, 0, math.MinInt64},
+		fullNullableBoolArray: []*bool{&b},
+		fullNullableInt8Array: []*int8{&i8},
+	}
+	data := mustData(ss.ToData(target))
+	v := it.MustValue(ss.ToObject(data))
+	require.Equal(t, target, v)
+}
+
+type otherArrays struct {
+	emptyDecimalArray []*types.Decimal
+	fullDecimalArray  []*types.Decimal
+}
+
+type otherArraysSerializer struct{}
+
+func (s otherArraysSerializer) Type() reflect.Type {
+	return reflect.TypeOf(otherArrays{})
+}
+
+func (s otherArraysSerializer) TypeName() string {
+	return "otherArrays"
+}
+
+func (s otherArraysSerializer) Read(r pubserialization.CompactReader) interface{} {
+	return otherArrays{
+		emptyDecimalArray: r.ReadArrayOfDecimal("emptyDecimalArray"),
+		fullDecimalArray:  r.ReadArrayOfDecimal("fullDecimalArray"),
+	}
+}
+
+func (s otherArraysSerializer) Write(w pubserialization.CompactWriter, v interface{}) {
+	vv := v.(otherArrays)
+	w.WriteArrayOfDecimal("emptyDecimalArray", vv.emptyDecimalArray)
+	w.WriteArrayOfDecimal("fullDecimalArray", vv.fullDecimalArray)
+}
+
+func otherArraySerializerTest(t *testing.T) {
+	var cfg pubserialization.Config
+	cfg.Compact.SetSerializers(&otherArraysSerializer{})
+	ss := mustSerializationService(serialization.NewService(&cfg, nil))
+	decimal := types.NewDecimal(big.NewInt(100), 10)
+	target := otherArrays{
+		fullDecimalArray: []*types.Decimal{&decimal},
+	}
+	data := mustData(ss.ToData(target))
+	v := it.MustValue(ss.ToObject(data))
+	require.Equal(t, target, v)
+}
+
+type nullables struct {
+	nilBool    *bool
+	nilInt8    *int8
+	nilInt16   *int16
+	nilInt32   *int32
+	nilInt64   *int64
+	nilFloat32 *float32
+	nilFloat64 *float64
+}
+
+type nullablesSerializer struct{}
+
+func (s nullablesSerializer) Type() reflect.Type {
+	return reflect.TypeOf(nullables{})
+}
+
+func (s nullablesSerializer) TypeName() string {
+	return "nullables"
+}
+
+func (s nullablesSerializer) Read(r pubserialization.CompactReader) interface{} {
+	return nullables{
+		nilBool:    r.ReadNullableBoolean("nilBool"),
+		nilInt8:    r.ReadNullableInt8("nilInt8"),
+		nilInt16:   r.ReadNullableInt16("nilInt16"),
+		nilInt32:   r.ReadNullableInt32("nilInt32"),
+		nilInt64:   r.ReadNullableInt64("nilInt64"),
+		nilFloat32: r.ReadNullableFloat32("nilFloat32"),
+		nilFloat64: r.ReadNullableFloat64("nilFloat64"),
+	}
+}
+
+func (s nullablesSerializer) Write(w pubserialization.CompactWriter, v interface{}) {
+	vv := v.(nullables)
+	w.WriteNullableBoolean("nilBool", vv.nilBool)
+	w.WriteNullableInt8("nilInt8", vv.nilInt8)
+	w.WriteNullableInt16("nilInt16", vv.nilInt16)
+	w.WriteNullableInt32("nilInt32", vv.nilInt32)
+	w.WriteNullableInt64("nilInt64", vv.nilInt64)
+	w.WriteNullableFloat32("nilFloat32", vv.nilFloat32)
+	w.WriteNullableFloat64("nilFloat64", vv.nilFloat64)
+}
+
+func nullableSerializerTest(t *testing.T) {
+	var cfg pubserialization.Config
+	cfg.Compact.SetSerializers(&nullablesSerializer{})
+	ss := mustSerializationService(serialization.NewService(&cfg, nil))
+	target := nullables{}
+	data := mustData(ss.ToData(target))
+	v := it.MustValue(ss.ToObject(data))
+	require.Equal(t, target, v)
 }

--- a/internal/serialization/compact_test.go
+++ b/internal/serialization/compact_test.go
@@ -247,13 +247,19 @@ func otherArraySerializerTest(t *testing.T) {
 }
 
 type nullables struct {
-	nilBool    *bool
-	nilInt8    *int8
-	nilInt16   *int16
-	nilInt32   *int32
-	nilInt64   *int64
-	nilFloat32 *float32
-	nilFloat64 *float64
+	nilBool           *bool
+	nilInt8           *int8
+	nilInt16          *int16
+	nilInt32          *int32
+	nilInt64          *int64
+	nilFloat32        *float32
+	nilFloat64        *float64
+	nilString         *string
+	nilDecimal        *types.Decimal
+	nilLocalTime      *types.LocalTime
+	nilLocalDate      *types.LocalDate
+	nilLocalDateTime  *types.LocalDateTime
+	nilOffsetDateTime *types.OffsetDateTime
 }
 
 type nullablesSerializer struct{}
@@ -268,13 +274,19 @@ func (s nullablesSerializer) TypeName() string {
 
 func (s nullablesSerializer) Read(r pubserialization.CompactReader) interface{} {
 	return nullables{
-		nilBool:    r.ReadNullableBoolean("nilBool"),
-		nilInt8:    r.ReadNullableInt8("nilInt8"),
-		nilInt16:   r.ReadNullableInt16("nilInt16"),
-		nilInt32:   r.ReadNullableInt32("nilInt32"),
-		nilInt64:   r.ReadNullableInt64("nilInt64"),
-		nilFloat32: r.ReadNullableFloat32("nilFloat32"),
-		nilFloat64: r.ReadNullableFloat64("nilFloat64"),
+		nilBool:           r.ReadNullableBoolean("nilBool"),
+		nilInt8:           r.ReadNullableInt8("nilInt8"),
+		nilInt16:          r.ReadNullableInt16("nilInt16"),
+		nilInt32:          r.ReadNullableInt32("nilInt32"),
+		nilInt64:          r.ReadNullableInt64("nilInt64"),
+		nilFloat32:        r.ReadNullableFloat32("nilFloat32"),
+		nilFloat64:        r.ReadNullableFloat64("nilFloat64"),
+		nilString:         r.ReadString("nilString"),
+		nilDecimal:        r.ReadDecimal("nilDecimal"),
+		nilLocalTime:      r.ReadTime("nilLocalTime"),
+		nilLocalDate:      r.ReadDate("nilLocalDate"),
+		nilLocalDateTime:  r.ReadTimestamp("nilLocalDateTime"),
+		nilOffsetDateTime: r.ReadTimestampWithTimezone("nilOffsetDateTime"),
 	}
 }
 
@@ -287,6 +299,12 @@ func (s nullablesSerializer) Write(w pubserialization.CompactWriter, v interface
 	w.WriteNullableInt64("nilInt64", vv.nilInt64)
 	w.WriteNullableFloat32("nilFloat32", vv.nilFloat32)
 	w.WriteNullableFloat64("nilFloat64", vv.nilFloat64)
+	w.WriteString("nilString", vv.nilString)
+	w.WriteDecimal("nilDecimal", vv.nilDecimal)
+	w.WriteTime("nilLocalTime", vv.nilLocalTime)
+	w.WriteDate("nilLocalDate", vv.nilLocalDate)
+	w.WriteTimestamp("nilLocalDateTime", vv.nilLocalDateTime)
+	w.WriteTimestampWithTimezone("nilOffsetDateTime", vv.nilOffsetDateTime)
 }
 
 func nullableSerializerTest(t *testing.T) {

--- a/internal/serialization/default_compact_reader.go
+++ b/internal/serialization/default_compact_reader.go
@@ -217,56 +217,64 @@ func (d *DefaultCompactReader) ReadFloat64(fieldName string) float64 {
 
 func (d *DefaultCompactReader) ReadString(fieldName string) *string {
 	fd := d.getFieldDefinitionChecked(fieldName, pubserialization.FieldKindString)
-	value := d.readVariableSizeField(fd, func(in *ObjectDataInput) interface{} {
+	v := d.readVariableSizeField(fd, func(in *ObjectDataInput) interface{} {
 		str := in.ReadString()
 		return &str
 	})
-	if value == nil {
-		return nil
-	}
-	return value.(*string)
+	vv, _ := v.(*string)
+	return vv
 }
 
 func (d *DefaultCompactReader) ReadDecimal(fieldName string) *types.Decimal {
 	fd := d.getFieldDefinitionChecked(fieldName, pubserialization.FieldKindDecimal)
-	return d.readVariableSizeField(fd, func(inp *ObjectDataInput) interface{} {
+	v := d.readVariableSizeField(fd, func(inp *ObjectDataInput) interface{} {
 		dec := ReadDecimal(inp)
 		return &dec
-	}).(*types.Decimal)
+	})
+	vv, _ := v.(*types.Decimal)
+	return vv
 }
 
 func (d *DefaultCompactReader) ReadTime(fieldName string) *types.LocalTime {
 	fd := d.getFieldDefinitionChecked(fieldName, pubserialization.FieldKindTime)
-	return d.readVariableSizeField(fd, func(inp *ObjectDataInput) interface{} {
-		time := types.LocalTime(ReadTime(inp))
-		return &time
-	}).(*types.LocalTime)
+	v := d.readVariableSizeField(fd, func(inp *ObjectDataInput) interface{} {
+		t := types.LocalTime(ReadTime(inp))
+		return &t
+	})
+	vv, _ := v.(*types.LocalTime)
+	return vv
 }
 
 func (d *DefaultCompactReader) ReadDate(fieldName string) *types.LocalDate {
 	fd := d.getFieldDefinitionChecked(fieldName, pubserialization.FieldKindDate)
-	return d.readVariableSizeField(fd, func(inp *ObjectDataInput) interface{} {
+	v := d.readVariableSizeField(fd, func(inp *ObjectDataInput) interface{} {
 		date := types.LocalDate(ReadDate(inp))
 		return &date
-	}).(*types.LocalDate)
+	})
+	vv, _ := v.(*types.LocalDate)
+	return vv
 }
 
 func (d *DefaultCompactReader) ReadTimestamp(fieldName string) *types.LocalDateTime {
 	fd := d.getFieldDefinitionChecked(fieldName, pubserialization.FieldKindTimestamp)
-	return d.readVariableSizeField(fd, func(inp *ObjectDataInput) interface{} {
+	v := d.readVariableSizeField(fd, func(inp *ObjectDataInput) interface{} {
 		timestamp := types.LocalDateTime(ReadTimestamp(inp))
 		return &timestamp
-	}).(*types.LocalDateTime)
+	})
+	vv, _ := v.(*types.LocalDateTime)
+	return vv
 }
 
 func (d *DefaultCompactReader) ReadTimestampWithTimezone(fieldName string) *types.OffsetDateTime {
 	fd := d.getFieldDefinitionChecked(fieldName, pubserialization.FieldKindTimestampWithTimezone)
-	return d.readVariableSizeField(fd, func(inp *ObjectDataInput) interface{} {
+	v := d.readVariableSizeField(fd, func(inp *ObjectDataInput) interface{} {
 		timestampWithTimezone := types.OffsetDateTime(ReadTimestampWithTimezone(inp))
 		a := time.Time(timestampWithTimezone).String()
 		println(a)
 		return &timestampWithTimezone
-	}).(*types.OffsetDateTime)
+	})
+	vv, _ := v.(*types.OffsetDateTime)
+	return vv
 }
 
 func (d *DefaultCompactReader) ReadCompact(fieldName string) interface{} {

--- a/internal/serialization/default_compact_reader.go
+++ b/internal/serialization/default_compact_reader.go
@@ -279,59 +279,74 @@ func (d *DefaultCompactReader) ReadCompact(fieldName string) interface{} {
 func (d *DefaultCompactReader) ReadArrayOfBoolean(fieldName string) []bool {
 	fd := d.getFieldDefinition(fieldName)
 	fieldKind := fd.Kind
+	var v interface{}
 	switch fieldKind {
 	case pubserialization.FieldKindArrayOfBoolean:
-		return d.readVariableSizeField(fd, func(inp *ObjectDataInput) interface{} {
+		v = d.readVariableSizeField(fd, func(inp *ObjectDataInput) interface{} {
 			return d.readBooleanBits(inp)
-		}).([]bool)
+		})
 	case pubserialization.FieldKindArrayOfNullableBoolean:
-		return d.readNullableArrayAsPrimitiveArray(fd, func(inp *ObjectDataInput) interface{} {
+		v = d.readNullableArrayAsPrimitiveArray(fd, func(inp *ObjectDataInput) interface{} {
 			return d.readBooleanBits(inp)
 		}, "Boolean").([]bool)
 	default:
 		panic(newUnexpectedFieldKind(fieldKind, fieldName))
 	}
+	vv, _ := v.([]bool)
+	return vv
 }
 
 func (d *DefaultCompactReader) ReadArrayOfInt8(fieldName string) []int8 {
-	return d.readArrayOfPrimitive(fieldName, func(inp *ObjectDataInput) interface{} {
+	v := d.readArrayOfPrimitive(fieldName, func(inp *ObjectDataInput) interface{} {
 		return inp.ReadInt8Array()
-	}, pubserialization.FieldKindArrayOfInt8, pubserialization.FieldKindArrayOfNullableInt8, "Int8").([]int8)
+	}, pubserialization.FieldKindArrayOfInt8, pubserialization.FieldKindArrayOfNullableInt8, "Int8")
+	vv, _ := v.([]int8)
+	return vv
 }
 
 func (d *DefaultCompactReader) ReadArrayOfInt16(fieldName string) []int16 {
-	return d.readArrayOfPrimitive(fieldName, func(inp *ObjectDataInput) interface{} {
+	v := d.readArrayOfPrimitive(fieldName, func(inp *ObjectDataInput) interface{} {
 		return inp.ReadInt16Array()
-	}, pubserialization.FieldKindArrayOfInt16, pubserialization.FieldKindArrayOfNullableInt16, "Int16").([]int16)
+	}, pubserialization.FieldKindArrayOfInt16, pubserialization.FieldKindArrayOfNullableInt16, "Int16")
+	vv, _ := v.([]int16)
+	return vv
 }
 
 func (d *DefaultCompactReader) ReadArrayOfInt32(fieldName string) []int32 {
-	return d.readArrayOfPrimitive(fieldName, func(inp *ObjectDataInput) interface{} {
+	v := d.readArrayOfPrimitive(fieldName, func(inp *ObjectDataInput) interface{} {
 		return inp.ReadInt32Array()
-	}, pubserialization.FieldKindArrayOfInt32, pubserialization.FieldKindArrayOfNullableInt32, "Int32").([]int32)
+	}, pubserialization.FieldKindArrayOfInt32, pubserialization.FieldKindArrayOfNullableInt32, "Int32")
+	vv, _ := v.([]int32)
+	return vv
 }
 
 func (d *DefaultCompactReader) ReadArrayOfInt64(fieldName string) []int64 {
-	return d.readArrayOfPrimitive(fieldName, func(inp *ObjectDataInput) interface{} {
+	v := d.readArrayOfPrimitive(fieldName, func(inp *ObjectDataInput) interface{} {
 		return inp.ReadInt64Array()
-	}, pubserialization.FieldKindArrayOfInt64, pubserialization.FieldKindArrayOfNullableInt64, "Int64").([]int64)
+	}, pubserialization.FieldKindArrayOfInt64, pubserialization.FieldKindArrayOfNullableInt64, "Int64")
+	vv, _ := v.([]int64)
+	return vv
 }
 
 func (d *DefaultCompactReader) ReadArrayOfFloat32(fieldName string) []float32 {
-	return d.readArrayOfPrimitive(fieldName, func(inp *ObjectDataInput) interface{} {
+	v := d.readArrayOfPrimitive(fieldName, func(inp *ObjectDataInput) interface{} {
 		return inp.ReadFloat32Array()
-	}, pubserialization.FieldKindArrayOfFloat32, pubserialization.FieldKindArrayOfNullableFloat32, "Float32").([]float32)
+	}, pubserialization.FieldKindArrayOfFloat32, pubserialization.FieldKindArrayOfNullableFloat32, "Float32")
+	vv, _ := v.([]float32)
+	return vv
 }
 
 func (d *DefaultCompactReader) ReadArrayOfFloat64(fieldName string) []float64 {
-	return d.readArrayOfPrimitive(fieldName, func(inp *ObjectDataInput) interface{} {
+	v := d.readArrayOfPrimitive(fieldName, func(inp *ObjectDataInput) interface{} {
 		return inp.ReadFloat64Array()
-	}, pubserialization.FieldKindArrayOfFloat64, pubserialization.FieldKindArrayOfNullableFloat64, "Float64").([]float64)
+	}, pubserialization.FieldKindArrayOfFloat64, pubserialization.FieldKindArrayOfNullableFloat64, "Float64")
+	vv, _ := v.([]float64)
+	return vv
 }
 
 func (d *DefaultCompactReader) ReadArrayOfString(fieldName string) []*string {
 	var values []*string
-	d.readArrayOfVariableSize(fieldName, pubserialization.FieldKindArrayOfString, func(inp *ObjectDataInput, i int32, isNil bool) {
+	d.readArrayOfVariableSize(fieldName, func(inp *ObjectDataInput, i int32, isNil bool) {
 		if !isNil {
 			str := inp.ReadString()
 			values[i] = &str
@@ -344,7 +359,7 @@ func (d *DefaultCompactReader) ReadArrayOfString(fieldName string) []*string {
 
 func (d *DefaultCompactReader) ReadArrayOfDecimal(fieldName string) []*types.Decimal {
 	var values []*types.Decimal
-	d.readArrayOfVariableSize(fieldName, pubserialization.FieldKindArrayOfDecimal, func(inp *ObjectDataInput, i int32, isNil bool) {
+	d.readArrayOfVariableSize(fieldName, func(inp *ObjectDataInput, i int32, isNil bool) {
 		if !isNil {
 			dec := ReadDecimal(inp)
 			values[i] = &dec
@@ -357,7 +372,7 @@ func (d *DefaultCompactReader) ReadArrayOfDecimal(fieldName string) []*types.Dec
 
 func (d *DefaultCompactReader) ReadArrayOfTime(fieldName string) []*types.LocalTime {
 	var values []*types.LocalTime
-	d.readArrayOfVariableSize(fieldName, pubserialization.FieldKindArrayOfTime, func(inp *ObjectDataInput, i int32, isNil bool) {
+	d.readArrayOfVariableSize(fieldName, func(inp *ObjectDataInput, i int32, isNil bool) {
 		if !isNil {
 			lt := types.LocalTime(ReadTime(inp))
 			values[i] = &lt
@@ -370,7 +385,7 @@ func (d *DefaultCompactReader) ReadArrayOfTime(fieldName string) []*types.LocalT
 
 func (d *DefaultCompactReader) ReadArrayOfDate(fieldName string) []*types.LocalDate {
 	var values []*types.LocalDate
-	d.readArrayOfVariableSize(fieldName, pubserialization.FieldKindArrayOfDate, func(inp *ObjectDataInput, i int32, isNil bool) {
+	d.readArrayOfVariableSize(fieldName, func(inp *ObjectDataInput, i int32, isNil bool) {
 		if !isNil {
 			ld := types.LocalDate(ReadDate(inp))
 			values[i] = &ld
@@ -383,7 +398,7 @@ func (d *DefaultCompactReader) ReadArrayOfDate(fieldName string) []*types.LocalD
 
 func (d *DefaultCompactReader) ReadArrayOfTimestamp(fieldName string) []*types.LocalDateTime {
 	var values []*types.LocalDateTime
-	d.readArrayOfVariableSize(fieldName, pubserialization.FieldKindArrayOfTimestamp, func(inp *ObjectDataInput, i int32, isNil bool) {
+	d.readArrayOfVariableSize(fieldName, func(inp *ObjectDataInput, i int32, isNil bool) {
 		if !isNil {
 			ldt := types.LocalDateTime(ReadTimestamp(inp))
 			values[i] = &ldt
@@ -396,7 +411,7 @@ func (d *DefaultCompactReader) ReadArrayOfTimestamp(fieldName string) []*types.L
 
 func (d *DefaultCompactReader) ReadArrayOfTimestampWithTimezone(fieldName string) []*types.OffsetDateTime {
 	var values []*types.OffsetDateTime
-	d.readArrayOfVariableSize(fieldName, pubserialization.FieldKindArrayOfTimestampWithTimezone, func(inp *ObjectDataInput, i int32, isNil bool) {
+	d.readArrayOfVariableSize(fieldName, func(inp *ObjectDataInput, i int32, isNil bool) {
 		if !isNil {
 			odt := types.OffsetDateTime(ReadTimestampWithTimezone(inp))
 			values[i] = &odt
@@ -442,10 +457,12 @@ func (d *DefaultCompactReader) ReadNullableBoolean(fieldName string) *bool {
 		b := d.readBoolean(fd)
 		return &b
 	case pubserialization.FieldKindNullableBoolean:
-		return d.readVariableSizeField(fd, func(inp *ObjectDataInput) interface{} {
+		v := d.readVariableSizeField(fd, func(inp *ObjectDataInput) interface{} {
 			b := inp.ReadBool()
 			return &b
-		}).(*bool)
+		})
+		vv, _ := v.(*bool)
+		return vv
 	default:
 		panic(newUnexpectedFieldKind(fd.Kind, fieldName))
 	}
@@ -453,98 +470,116 @@ func (d *DefaultCompactReader) ReadNullableBoolean(fieldName string) *bool {
 
 func (d *DefaultCompactReader) ReadNullableInt8(fieldName string) *int8 {
 	fd := d.getFieldDefinition(fieldName)
+	var v interface{}
 	switch fd.Kind {
 	case pubserialization.FieldKindInt8:
 		b := d.in.ReadSignedByteAtPosition(d.getFixedSizePosition(fd))
-		return &b
+		v = &b
 	case pubserialization.FieldKindNullableInt8:
-		return d.readVariableSizeField(fd, func(inp *ObjectDataInput) interface{} {
+		v = d.readVariableSizeField(fd, func(inp *ObjectDataInput) interface{} {
 			b := inp.ReadSignedByte()
 			return &b
-		}).(*int8)
+		})
 	default:
 		panic(newUnexpectedFieldKind(fd.Kind, fieldName))
 	}
+	vv, _ := v.(*int8)
+	return vv
 }
 
 func (d *DefaultCompactReader) ReadNullableInt16(fieldName string) *int16 {
 	fd := d.getFieldDefinition(fieldName)
+	var v interface{}
 	switch fd.Kind {
 	case pubserialization.FieldKindInt16:
 		b := d.in.ReadInt16AtPosition(d.getFixedSizePosition(fd))
-		return &b
+		v = &b
 	case pubserialization.FieldKindNullableInt16:
-		return d.readVariableSizeField(fd, func(inp *ObjectDataInput) interface{} {
+		v = d.readVariableSizeField(fd, func(inp *ObjectDataInput) interface{} {
 			short := inp.ReadInt16()
 			return &short
-		}).(*int16)
+		})
 	default:
 		panic(newUnexpectedFieldKind(fd.Kind, fieldName))
 	}
+	vv, _ := v.(*int16)
+	return vv
 }
 
 func (d *DefaultCompactReader) ReadNullableInt32(fieldName string) *int32 {
 	fd := d.getFieldDefinition(fieldName)
+	var v interface{}
 	switch fd.Kind {
 	case pubserialization.FieldKindInt32:
 		b := d.in.ReadInt32AtPosition(d.getFixedSizePosition(fd))
-		return &b
+		v = &b
 	case pubserialization.FieldKindNullableInt32:
-		return d.readVariableSizeField(fd, func(inp *ObjectDataInput) interface{} {
+		v = d.readVariableSizeField(fd, func(inp *ObjectDataInput) interface{} {
 			i := inp.readInt32()
 			return &i
-		}).(*int32)
+		})
 	default:
 		panic(newUnexpectedFieldKind(fd.Kind, fieldName))
 	}
+	vv, _ := v.(*int32)
+	return vv
 }
 
 func (d *DefaultCompactReader) ReadNullableInt64(fieldName string) *int64 {
 	fd := d.getFieldDefinition(fieldName)
+	var v interface{}
 	switch fd.Kind {
 	case pubserialization.FieldKindInt64:
 		long := d.in.ReadInt64AtPosition(d.getFixedSizePosition(fd))
-		return &long
+		v = &long
 	case pubserialization.FieldKindNullableInt64:
-		return d.readVariableSizeField(fd, func(inp *ObjectDataInput) interface{} {
+		v = d.readVariableSizeField(fd, func(inp *ObjectDataInput) interface{} {
 			long := inp.ReadInt64()
 			return &long
-		}).(*int64)
+		})
 	default:
 		panic(newUnexpectedFieldKind(fd.Kind, fieldName))
 	}
+	vv, _ := v.(*int64)
+	return vv
 }
 
 func (d *DefaultCompactReader) ReadNullableFloat32(fieldName string) *float32 {
 	fd := d.getFieldDefinition(fieldName)
+	var v interface{}
 	switch fd.Kind {
 	case pubserialization.FieldKindFloat32:
 		f := d.in.ReadFloat32AtPosition(d.getFixedSizePosition(fd))
-		return &f
+		v = &f
 	case pubserialization.FieldKindNullableFloat32:
-		return d.readVariableSizeField(fd, func(inp *ObjectDataInput) interface{} {
+		v = d.readVariableSizeField(fd, func(inp *ObjectDataInput) interface{} {
 			f := inp.ReadFloat32()
 			return &f
-		}).(*float32)
+		})
 	default:
 		panic(newUnexpectedFieldKind(fd.Kind, fieldName))
 	}
+	vv, _ := v.(*float32)
+	return vv
 }
 
 func (d *DefaultCompactReader) ReadNullableFloat64(fieldName string) *float64 {
 	fd := d.getFieldDefinition(fieldName)
+	var v interface{}
 	switch fd.Kind {
 	case pubserialization.FieldKindFloat64:
 		f := d.in.ReadFloat64AtPosition(d.getFixedSizePosition(fd))
-		return &f
+		v = &f
 	case pubserialization.FieldKindNullableFloat64:
-		return d.readVariableSizeField(fd, func(inp *ObjectDataInput) interface{} {
+		v = d.readVariableSizeField(fd, func(inp *ObjectDataInput) interface{} {
 			f := inp.ReadFloat64()
 			return &f
-		}).(*float64)
+		})
 	default:
 		panic(newUnexpectedFieldKind(fd.Kind, fieldName))
 	}
+	vv, _ := v.(*float64)
+	return vv
 }
 
 func (d *DefaultCompactReader) ReadArrayOfNullableBoolean(fieldName string) []*bool {
@@ -556,7 +591,7 @@ func (d *DefaultCompactReader) ReadArrayOfNullableBoolean(fieldName string) []*b
 		}).([]*bool)
 	case pubserialization.FieldKindArrayOfNullableBoolean:
 		var values []*bool
-		d.readArrayOfVariableSize(fieldName, fd.Kind, func(inp *ObjectDataInput, i int32, isNil bool) {
+		d.readArrayOfVariableSize(fieldName, func(inp *ObjectDataInput, i int32, isNil bool) {
 			if !isNil {
 				b := inp.readBool()
 				values[i] = &b
@@ -805,7 +840,7 @@ func (d *DefaultCompactReader) readArrayOfPrimitive(fieldName string, r Reader, 
 	}
 }
 
-func (d *DefaultCompactReader) readArrayOfVariableSize(fieldName string, fieldKind pubserialization.FieldKind, sr SliceReader, sc SliceConstructor) {
+func (d *DefaultCompactReader) readArrayOfVariableSize(fieldName string, sr SliceReader, sc SliceConstructor) {
 	fd := d.getFieldDefinition(fieldName)
 	currentPos := d.in.position
 	defer d.in.SetPosition(currentPos)
@@ -837,7 +872,7 @@ func (d *DefaultCompactReader) readArrayOfNullable(fieldName string, primitiveKi
 	if fieldKind == primitiveKind {
 		d.readPrimitiveArrayAsNullableArray(fd, sr, sc)
 	} else if fieldKind == nullableKind {
-		d.readArrayOfVariableSize(fieldName, fieldKind, sr, sc)
+		d.readArrayOfVariableSize(fieldName, sr, sc)
 	} else {
 		panic(newUnexpectedFieldKind(fieldKind, fieldName))
 	}

--- a/internal/serialization/default_compact_reader.go
+++ b/internal/serialization/default_compact_reader.go
@@ -18,7 +18,6 @@ package serialization
 
 import (
 	"fmt"
-	"time"
 
 	ihzerrors "github.com/hazelcast/hazelcast-go-client/internal/hzerrors"
 	pubserialization "github.com/hazelcast/hazelcast-go-client/serialization"
@@ -269,8 +268,6 @@ func (d *DefaultCompactReader) ReadTimestampWithTimezone(fieldName string) *type
 	fd := d.getFieldDefinitionChecked(fieldName, pubserialization.FieldKindTimestampWithTimezone)
 	v := d.readVariableSizeField(fd, func(inp *ObjectDataInput) interface{} {
 		timestampWithTimezone := types.OffsetDateTime(ReadTimestampWithTimezone(inp))
-		a := time.Time(timestampWithTimezone).String()
-		println(a)
 		return &timestampWithTimezone
 	})
 	vv, _ := v.(*types.OffsetDateTime)

--- a/internal/serialization/default_compact_writer.go
+++ b/internal/serialization/default_compact_writer.go
@@ -97,126 +97,210 @@ func (r *DefaultCompactWriter) WriteFloat64(fieldName string, value float64) {
 }
 
 func (r *DefaultCompactWriter) WriteString(fieldName string, value *string) {
+	if value == nil {
+		r.setPositionAsNull(fieldName, pubserialization.FieldKindString)
+		return
+	}
 	r.writeVariableSizeField(fieldName, pubserialization.FieldKindString, value, func(out *PositionalObjectDataOutput, v interface{}) {
 		out.WriteString(*v.(*string))
 	})
 }
 
 func (r *DefaultCompactWriter) WriteDecimal(fieldName string, value *types.Decimal) {
+	if value == nil {
+		r.setPositionAsNull(fieldName, pubserialization.FieldKindDecimal)
+		return
+	}
 	r.writeVariableSizeField(fieldName, pubserialization.FieldKindDecimal, value, func(out *PositionalObjectDataOutput, v interface{}) {
 		WriteDecimal(out, *v.(*types.Decimal))
 	})
 }
 
 func (r *DefaultCompactWriter) WriteTime(fieldName string, value *types.LocalTime) {
+	if value == nil {
+		r.setPositionAsNull(fieldName, pubserialization.FieldKindTime)
+		return
+	}
 	r.writeVariableSizeField(fieldName, pubserialization.FieldKindTime, value, func(out *PositionalObjectDataOutput, v interface{}) {
 		WriteTime(out, time.Time(*v.(*types.LocalTime)))
 	})
 }
 
 func (r *DefaultCompactWriter) WriteDate(fieldName string, value *types.LocalDate) {
+	if value == nil {
+		r.setPositionAsNull(fieldName, pubserialization.FieldKindDate)
+		return
+	}
 	r.writeVariableSizeField(fieldName, pubserialization.FieldKindDate, value, func(out *PositionalObjectDataOutput, v interface{}) {
 		WriteDate(out, time.Time(*v.(*types.LocalDate)))
 	})
 }
 
 func (r *DefaultCompactWriter) WriteTimestamp(fieldName string, value *types.LocalDateTime) {
+	if value == nil {
+		r.setPositionAsNull(fieldName, pubserialization.FieldKindTimestamp)
+		return
+	}
 	r.writeVariableSizeField(fieldName, pubserialization.FieldKindTimestamp, value, func(out *PositionalObjectDataOutput, v interface{}) {
 		WriteTimestamp(out, time.Time(*v.(*types.LocalDateTime)))
 	})
 }
 
 func (r *DefaultCompactWriter) WriteTimestampWithTimezone(fieldName string, value *types.OffsetDateTime) {
+	if value == nil {
+		r.setPositionAsNull(fieldName, pubserialization.FieldKindTimestampWithTimezone)
+		return
+	}
 	r.writeVariableSizeField(fieldName, pubserialization.FieldKindTimestampWithTimezone, value, func(out *PositionalObjectDataOutput, v interface{}) {
 		WriteTimestampWithTimezone(out, time.Time(*v.(*types.OffsetDateTime)))
 	})
 }
 
 func (r *DefaultCompactWriter) WriteCompact(fieldName string, value interface{}) {
+	if value == nil {
+		r.setPositionAsNull(fieldName, pubserialization.FieldKindCompact)
+		return
+	}
 	r.writeVariableSizeField(fieldName, pubserialization.FieldKindCompact, value, func(out *PositionalObjectDataOutput, v interface{}) {
 		r.serializer.Write(out, reflect.ValueOf(v).Interface())
 	})
 }
 
 func (r *DefaultCompactWriter) WriteArrayOfBoolean(fieldName string, value []bool) {
+	if value == nil {
+		r.setPositionAsNull(fieldName, pubserialization.FieldKindArrayOfBoolean)
+		return
+	}
 	r.writeVariableSizeField(fieldName, pubserialization.FieldKindArrayOfBoolean, value, func(out *PositionalObjectDataOutput, v interface{}) {
 		r.writeBooleanBits(out, v.([]bool))
 	})
 }
 
 func (r *DefaultCompactWriter) WriteArrayOfInt8(fieldName string, value []int8) {
+	if value == nil {
+		r.setPositionAsNull(fieldName, pubserialization.FieldKindArrayOfInt8)
+		return
+	}
 	r.writeVariableSizeField(fieldName, pubserialization.FieldKindArrayOfInt8, value, func(out *PositionalObjectDataOutput, v interface{}) {
 		out.WriteInt8Array(v.([]int8))
 	})
 }
 
 func (r *DefaultCompactWriter) WriteArrayOfInt16(fieldName string, value []int16) {
+	if value == nil {
+		r.setPositionAsNull(fieldName, pubserialization.FieldKindArrayOfInt16)
+		return
+	}
 	r.writeVariableSizeField(fieldName, pubserialization.FieldKindArrayOfInt16, value, func(out *PositionalObjectDataOutput, v interface{}) {
 		out.WriteInt16Array(v.([]int16))
 	})
 }
 
 func (r *DefaultCompactWriter) WriteArrayOfInt32(fieldName string, value []int32) {
+	if value == nil {
+		r.setPositionAsNull(fieldName, pubserialization.FieldKindArrayOfInt32)
+		return
+	}
 	r.writeVariableSizeField(fieldName, pubserialization.FieldKindArrayOfInt32, value, func(out *PositionalObjectDataOutput, v interface{}) {
 		out.WriteInt32Array(v.([]int32))
 	})
 }
 
 func (r *DefaultCompactWriter) WriteArrayOfInt64(fieldName string, value []int64) {
+	if value == nil {
+		r.setPositionAsNull(fieldName, pubserialization.FieldKindArrayOfInt64)
+		return
+	}
 	r.writeVariableSizeField(fieldName, pubserialization.FieldKindArrayOfInt64, value, func(out *PositionalObjectDataOutput, v interface{}) {
 		out.WriteInt64Array(v.([]int64))
 	})
 }
 
 func (r *DefaultCompactWriter) WriteArrayOfFloat32(fieldName string, value []float32) {
+	if value == nil {
+		r.setPositionAsNull(fieldName, pubserialization.FieldKindArrayOfFloat32)
+		return
+	}
 	r.writeVariableSizeField(fieldName, pubserialization.FieldKindArrayOfFloat32, value, func(out *PositionalObjectDataOutput, v interface{}) {
 		out.WriteFloat32Array(v.([]float32))
 	})
 }
 
 func (r *DefaultCompactWriter) WriteArrayOfFloat64(fieldName string, value []float64) {
+	if value == nil {
+		r.setPositionAsNull(fieldName, pubserialization.FieldKindArrayOfFloat64)
+		return
+	}
 	r.writeVariableSizeField(fieldName, pubserialization.FieldKindArrayOfFloat64, value, func(out *PositionalObjectDataOutput, v interface{}) {
 		out.WriteFloat64Array(v.([]float64))
 	})
 }
 
 func (r *DefaultCompactWriter) WriteArrayOfString(fieldName string, value []*string) {
+	if value == nil {
+		r.setPositionAsNull(fieldName, pubserialization.FieldKindArrayOfString)
+		return
+	}
 	r.writeArrayOfVariableSize(fieldName, pubserialization.FieldKindArrayOfString, value, func(out *PositionalObjectDataOutput, v interface{}) {
 		out.WriteString(*v.(*string))
 	})
 }
 
 func (r *DefaultCompactWriter) WriteArrayOfDecimal(fieldName string, value []*types.Decimal) {
+	if value == nil {
+		r.setPositionAsNull(fieldName, pubserialization.FieldKindArrayOfDecimal)
+		return
+	}
 	r.writeArrayOfVariableSize(fieldName, pubserialization.FieldKindArrayOfDecimal, value, func(out *PositionalObjectDataOutput, v interface{}) {
 		WriteDecimal(out, *v.(*types.Decimal))
 	})
 }
 
 func (r *DefaultCompactWriter) WriteArrayOfTime(fieldName string, value []*types.LocalTime) {
+	if value == nil {
+		r.setPositionAsNull(fieldName, pubserialization.FieldKindArrayOfTime)
+		return
+	}
 	r.writeArrayOfVariableSize(fieldName, pubserialization.FieldKindArrayOfTime, value, func(out *PositionalObjectDataOutput, v interface{}) {
 		WriteTime(out, time.Time(*v.(*types.LocalTime)))
 	})
 }
 
 func (r *DefaultCompactWriter) WriteArrayOfDate(fieldName string, value []*types.LocalDate) {
+	if value == nil {
+		r.setPositionAsNull(fieldName, pubserialization.FieldKindArrayOfDate)
+		return
+	}
 	r.writeArrayOfVariableSize(fieldName, pubserialization.FieldKindArrayOfDate, value, func(out *PositionalObjectDataOutput, v interface{}) {
 		WriteDate(out, time.Time(*v.(*types.LocalDate)))
 	})
 }
 
 func (r *DefaultCompactWriter) WriteArrayOfTimestamp(fieldName string, value []*types.LocalDateTime) {
+	if value == nil {
+		r.setPositionAsNull(fieldName, pubserialization.FieldKindArrayOfTimestamp)
+		return
+	}
 	r.writeArrayOfVariableSize(fieldName, pubserialization.FieldKindArrayOfTimestamp, value, func(out *PositionalObjectDataOutput, v interface{}) {
 		WriteTimestamp(out, time.Time(*v.(*types.LocalDateTime)))
 	})
 }
 
 func (r *DefaultCompactWriter) WriteArrayOfTimestampWithTimezone(fieldName string, value []*types.OffsetDateTime) {
+	if value == nil {
+		r.setPositionAsNull(fieldName, pubserialization.FieldKindArrayOfTimestampWithTimezone)
+		return
+	}
 	r.writeArrayOfVariableSize(fieldName, pubserialization.FieldKindArrayOfTimestampWithTimezone, value, func(out *PositionalObjectDataOutput, v interface{}) {
 		WriteTimestampWithTimezone(out, time.Time(*v.(*types.OffsetDateTime)))
 	})
 }
 
 func (r *DefaultCompactWriter) WriteArrayOfCompact(fieldName string, value []interface{}) {
+	if value == nil {
+		r.setPositionAsNull(fieldName, pubserialization.FieldKindArrayOfCompact)
+		return
+	}
 	var t reflect.Type
 	r.writeArrayOfVariableSize(fieldName, pubserialization.FieldKindArrayOfCompact, value, func(out *PositionalObjectDataOutput, v interface{}) {
 		if t == nil {
@@ -229,84 +313,140 @@ func (r *DefaultCompactWriter) WriteArrayOfCompact(fieldName string, value []int
 }
 
 func (r *DefaultCompactWriter) WriteNullableBoolean(fieldName string, value *bool) {
+	if value == nil {
+		r.setPositionAsNull(fieldName, pubserialization.FieldKindNullableBoolean)
+		return
+	}
 	r.writeVariableSizeField(fieldName, pubserialization.FieldKindNullableBoolean, value, func(out *PositionalObjectDataOutput, v interface{}) {
 		out.WriteBool(*v.(*bool))
 	})
 }
 
 func (r *DefaultCompactWriter) WriteNullableInt8(fieldName string, value *int8) {
+	if value == nil {
+		r.setPositionAsNull(fieldName, pubserialization.FieldKindNullableInt8)
+		return
+	}
 	r.writeVariableSizeField(fieldName, pubserialization.FieldKindNullableInt8, value, func(out *PositionalObjectDataOutput, v interface{}) {
 		out.WriteSignedByte(*v.(*int8))
 	})
 }
 
 func (r *DefaultCompactWriter) WriteNullableInt16(fieldName string, value *int16) {
+	if value == nil {
+		r.setPositionAsNull(fieldName, pubserialization.FieldKindNullableInt16)
+		return
+	}
 	r.writeVariableSizeField(fieldName, pubserialization.FieldKindNullableInt16, value, func(out *PositionalObjectDataOutput, v interface{}) {
 		out.WriteInt16(*v.(*int16))
 	})
 }
 
 func (r *DefaultCompactWriter) WriteNullableInt32(fieldName string, value *int32) {
+	if value == nil {
+		r.setPositionAsNull(fieldName, pubserialization.FieldKindNullableInt32)
+		return
+	}
 	r.writeVariableSizeField(fieldName, pubserialization.FieldKindNullableInt32, value, func(out *PositionalObjectDataOutput, v interface{}) {
 		out.WriteInt32(*v.(*int32))
 	})
 }
 
 func (r *DefaultCompactWriter) WriteNullableInt64(fieldName string, value *int64) {
+	if value == nil {
+		r.setPositionAsNull(fieldName, pubserialization.FieldKindNullableInt64)
+		return
+	}
 	r.writeVariableSizeField(fieldName, pubserialization.FieldKindNullableInt64, value, func(out *PositionalObjectDataOutput, v interface{}) {
 		out.WriteInt64(*v.(*int64))
 	})
 }
 
 func (r *DefaultCompactWriter) WriteNullableFloat32(fieldName string, value *float32) {
+	if value == nil {
+		r.setPositionAsNull(fieldName, pubserialization.FieldKindNullableFloat32)
+		return
+	}
 	r.writeVariableSizeField(fieldName, pubserialization.FieldKindNullableFloat32, value, func(out *PositionalObjectDataOutput, v interface{}) {
 		out.WriteFloat32(*v.(*float32))
 	})
 }
 
 func (r *DefaultCompactWriter) WriteNullableFloat64(fieldName string, value *float64) {
+	if value == nil {
+		r.setPositionAsNull(fieldName, pubserialization.FieldKindNullableFloat64)
+		return
+	}
 	r.writeVariableSizeField(fieldName, pubserialization.FieldKindNullableFloat64, value, func(out *PositionalObjectDataOutput, v interface{}) {
 		out.WriteFloat64(*v.(*float64))
 	})
 }
 
 func (r *DefaultCompactWriter) WriteArrayOfNullableBoolean(fieldName string, value []*bool) {
+	if value == nil {
+		r.setPositionAsNull(fieldName, pubserialization.FieldKindArrayOfNullableBoolean)
+		return
+	}
 	r.writeArrayOfVariableSize(fieldName, pubserialization.FieldKindArrayOfNullableBoolean, value, func(out *PositionalObjectDataOutput, v interface{}) {
 		out.WriteBool(*v.(*bool))
 	})
 }
 
 func (r *DefaultCompactWriter) WriteArrayOfNullableInt8(fieldName string, value []*int8) {
+	if value == nil {
+		r.setPositionAsNull(fieldName, pubserialization.FieldKindArrayOfNullableInt8)
+		return
+	}
 	r.writeArrayOfVariableSize(fieldName, pubserialization.FieldKindArrayOfNullableInt8, value, func(out *PositionalObjectDataOutput, v interface{}) {
 		out.WriteSignedByte(*v.(*int8))
 	})
 }
 
 func (r *DefaultCompactWriter) WriteArrayOfNullableInt16(fieldName string, value []*int16) {
+	if value == nil {
+		r.setPositionAsNull(fieldName, pubserialization.FieldKindArrayOfNullableInt16)
+		return
+	}
 	r.writeArrayOfVariableSize(fieldName, pubserialization.FieldKindArrayOfNullableInt16, value, func(out *PositionalObjectDataOutput, v interface{}) {
 		out.WriteInt16(*v.(*int16))
 	})
 }
 
 func (r *DefaultCompactWriter) WriteArrayOfNullableInt32(fieldName string, value []*int32) {
+	if value == nil {
+		r.setPositionAsNull(fieldName, pubserialization.FieldKindArrayOfNullableInt32)
+		return
+	}
 	r.writeArrayOfVariableSize(fieldName, pubserialization.FieldKindArrayOfNullableInt32, value, func(out *PositionalObjectDataOutput, v interface{}) {
 		out.WriteInt32(*v.(*int32))
 	})
 }
 
 func (r *DefaultCompactWriter) WriteArrayOfNullableInt64(fieldName string, value []*int64) {
+	if value == nil {
+		r.setPositionAsNull(fieldName, pubserialization.FieldKindArrayOfNullableInt64)
+		return
+	}
 	r.writeArrayOfVariableSize(fieldName, pubserialization.FieldKindArrayOfNullableInt64, value, func(out *PositionalObjectDataOutput, v interface{}) {
 		out.WriteInt64(*v.(*int64))
 	})
 }
 
 func (r *DefaultCompactWriter) WriteArrayOfNullableFloat32(fieldName string, value []*float32) {
+	if value == nil {
+		r.setPositionAsNull(fieldName, pubserialization.FieldKindArrayOfNullableFloat32)
+		return
+	}
 	r.writeArrayOfVariableSize(fieldName, pubserialization.FieldKindArrayOfNullableFloat32, value, func(out *PositionalObjectDataOutput, v interface{}) {
 		out.WriteFloat32(*v.(*float32))
 	})
 }
 
 func (r *DefaultCompactWriter) WriteArrayOfNullableFloat64(fieldName string, value []*float64) {
+	if value == nil {
+		r.setPositionAsNull(fieldName, pubserialization.FieldKindArrayOfNullableFloat64)
+		return
+	}
 	r.writeArrayOfVariableSize(fieldName, pubserialization.FieldKindArrayOfNullableFloat64, value, func(out *PositionalObjectDataOutput, v interface{}) {
 		out.WriteFloat64(*v.(*float64))
 	})
@@ -354,19 +494,11 @@ func (r *DefaultCompactWriter) setPositionAsNull(fieldName string, fieldKind pub
 }
 
 func (r *DefaultCompactWriter) writeVariableSizeField(fieldName string, fieldKind pubserialization.FieldKind, value interface{}, writer func(*PositionalObjectDataOutput, interface{})) {
-	if check.Nil(value) {
-		r.setPositionAsNull(fieldName, fieldKind)
-	} else {
-		r.setPosition(fieldName, fieldKind)
-		writer(r.out, value)
-	}
+	r.setPosition(fieldName, fieldKind)
+	writer(r.out, value)
 }
 
 func (r *DefaultCompactWriter) writeArrayOfVariableSize(fieldName string, fieldKind pubserialization.FieldKind, values interface{}, writer func(*PositionalObjectDataOutput, interface{})) {
-	if values == nil {
-		r.setPositionAsNull(fieldName, fieldKind)
-		return
-	}
 	value := reflect.ValueOf(values)
 	r.setPosition(fieldName, fieldKind)
 	dataLengthOffset := r.out.position

--- a/internal/serialization/default_serializer.go
+++ b/internal/serialization/default_serializer.go
@@ -398,12 +398,12 @@ func (JavaDateSerializer) ID() int32 {
 }
 
 func (JavaDateSerializer) Read(input serialization.DataInput) interface{} {
-	return time.Unix(0, input.ReadInt64()*1_000)
+	return time.Unix(0, input.ReadInt64()*1_000_000)
 }
 
 func (JavaDateSerializer) Write(output serialization.DataOutput, i interface{}) {
 	t := i.(time.Time)
-	output.WriteInt64(t.UnixNano() / 1000)
+	output.WriteInt64(t.UnixNano() / 1_000_000)
 }
 
 type JavaBigIntegerSerializer struct{}

--- a/internal/serialization/serialization_improvements_test.go
+++ b/internal/serialization/serialization_improvements_test.go
@@ -67,7 +67,7 @@ func TestSerializationImprovements_JavaDate(t *testing.T) {
 	config := &serialization.Config{}
 	config.SetGlobalSerializer(&PanicingGlobalSerializer{})
 	ss := mustSerializationService(iserialization.NewService(config, nil))
-	target := time.Date(2021, 2, 1, 9, 1, 15, 11000, time.Local)
+	target := time.Date(2021, 2, 1, 9, 1, 15, 0, time.Local)
 	data := mustData(ss.ToData(target))
 	value := it.MustValue(ss.ToObject(data))
 	assert.Equal(t, target, value)

--- a/internal/sql/driver/result.go
+++ b/internal/sql/driver/result.go
@@ -131,8 +131,10 @@ func (r *QueryResult) Next(dest []driver.Value) error {
 	}
 	for i := 0; i < len(r.page.Columns); i++ {
 		col := r.page.Columns[i]
+		// TODO: find out the reason for requiring the following fix
 		if len(col) <= int(r.index) {
-			break
+			r.close()
+			return io.EOF
 		}
 		dest[i] = col[r.index]
 	}

--- a/internal/sql/driver/result.go
+++ b/internal/sql/driver/result.go
@@ -114,6 +114,7 @@ func (r *QueryResult) Close() error {
 // InvocationTimeout field of hazelcast.Config is respected for timeout.
 func (r *QueryResult) Next(dest []driver.Value) error {
 	if len(r.page.Columns) == 0 {
+		r.close()
 		return io.EOF
 	}
 	rowCount := int32(len(r.page.Columns[0]))
@@ -129,7 +130,11 @@ func (r *QueryResult) Next(dest []driver.Value) error {
 		}
 	}
 	for i := 0; i < len(r.page.Columns); i++ {
-		dest[i] = r.page.Columns[i][r.index]
+		col := r.page.Columns[i]
+		if len(col) <= int(r.index) {
+			break
+		}
+		dest[i] = col[r.index]
 	}
 	r.index++
 	return nil

--- a/rc.sh
+++ b/rc.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+# Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License")
 # you may not use this file except in compliance with the License.
@@ -170,7 +170,7 @@ help () {
 
 TIMESTAMP_FMT="+%Y-%m-%d %H:%M:%S"
 PID_FILE="test.pid"
-HZ_VERSION="${HZ_VERSION:-5.1-SNAPSHOT}"
+HZ_VERSION="${HZ_VERSION:-5.3.1}"
 HAZELCAST_TEST_VERSION=${HZ_VERSION}
 HAZELCAST_ENTERPRISE_VERSION=${HZ_VERSION}
 HAZELCAST_RC_VERSION="0.8-SNAPSHOT"


### PR DESCRIPTION
This PR:
* Makes the listener binder internal
* Adds the `Cloud.ExperimentalBaseURL` config
* Enables making a `NonRetryableError` persistent or not
* Adds `ServerVersion` method to `Connection` type.
* Fixes compact serialization
* Fixes iteration on SQL result 