### PR TITLE
Discovery strategy priority

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -337,13 +337,13 @@ func (c *Client) addDiscoveryDestroyer() {
 }
 
 func addrProviderTranslator(config *cluster.Config, logger ilogger.LogAdaptor) (icluster.AddressProvider, icluster.AddressTranslator) {
-	if config.Cloud.Enabled {
-		dc := cloud.NewDiscoveryClient(&config.Cloud, logger)
-		return cloud.NewAddressProvider(dc), cloud.NewAddressTranslator(dc)
-	}
 	if config.Discovery.Strategy != nil {
 		a := icluster.NewDiscoveryStrategyAdapter(config.Discovery, logger)
 		return a, a
+	}
+	if config.Cloud.Enabled {
+		dc := cloud.NewDiscoveryClient(&config.Cloud, logger)
+		return cloud.NewAddressProvider(dc), cloud.NewAddressTranslator(dc)
 	}
 	pr := icluster.NewDefaultAddressProvider(&config.Network)
 	if config.Discovery.UsePublicIP {


### PR DESCRIPTION
Changed the discovery strategy priority so if a discovery strategy is provided, it overrides Cloud discovery strategy.