### PR TITLE
Fixed Map LoadAll

### DIFF
--- a/map_it_test.go
+++ b/map_it_test.go
@@ -651,6 +651,7 @@ func mapLoadAllWithoutReplacing(t *testing.T) {
 		return "test-map"
 	}
 	it.MapTesterWithConfigAndName(t, makeMapName, nil, func(t *testing.T, m *hz.Map) {
+		it.Must(m.Destroy(context.Background()))
 		putSampleKeyValues(m, 2)
 		it.Must(m.EvictAll(context.Background()))
 		it.Must(m.PutTransient(context.Background(), "k0", "new-v0"))
@@ -675,6 +676,7 @@ func mapLoadAllReplacing(t *testing.T) {
 	}
 	it.MapTesterWithConfigAndName(t, makeMapName, nil, func(t *testing.T, m *hz.Map) {
 		ctx := context.Background()
+		it.Must(m.Destroy(ctx))
 		keys := putSampleKeyValues(m, 2)
 		// load all keys
 		it.Must(m.EvictAll(ctx))

--- a/map_it_test.go
+++ b/map_it_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -674,20 +674,23 @@ func mapLoadAllReplacing(t *testing.T) {
 		return "test-map"
 	}
 	it.MapTesterWithConfigAndName(t, makeMapName, nil, func(t *testing.T, m *hz.Map) {
-		keys := putSampleKeyValues(m, 10)
-		it.Must(m.EvictAll(context.Background()))
-		it.Must(m.LoadAllReplacing(context.Background()))
-		entrySet := it.MustValue(m.GetAll(context.Background(), keys...)).([]types.Entry)
-		if len(keys) != len(entrySet) {
-			t.Fatalf("target len: %d != %d", len(keys), len(entrySet))
-		}
-		it.Must(m.EvictAll(context.Background()))
-		keys = keys[:5]
-		it.Must(m.LoadAllReplacing(context.Background(), keys...))
-		entrySet = it.MustValue(m.GetAll(context.Background(), keys...)).([]types.Entry)
-		if len(keys) != len(entrySet) {
-			t.Fatalf("target len: %d != %d", len(keys), len(entrySet))
-		}
+		ctx := context.Background()
+		keys := putSampleKeyValues(m, 2)
+		// load all keys
+		it.Must(m.EvictAll(ctx))
+		size := it.MustValue(m.Size(ctx))
+		assert.Equal(t, 0, size)
+		it.Must(m.LoadAllReplacing(ctx))
+		size = it.MustValue(m.Size(ctx))
+		assert.Equal(t, 2, size)
+		// load some keys
+		it.Must(m.EvictAll(ctx))
+		size = it.MustValue(m.Size(ctx))
+		assert.Equal(t, 0, size)
+		keys = keys[:1]
+		it.Must(m.LoadAllReplacing(ctx, keys...))
+		size = it.MustValue(m.Size(ctx))
+		assert.Equal(t, 1, size)
 	})
 }
 

--- a/proxy_map.go
+++ b/proxy_map.go
@@ -1392,12 +1392,13 @@ func (m *Map) addEntryListener(ctx context.Context, flags int32, includeValue bo
 	return subscriptionID, err
 }
 
-func (m *Map) loadAll(ctx context.Context, replaceExisting bool, keys ...interface{}) error {
-	if len(keys) == 0 {
-		return nil
-	}
+func (m *Map) loadAll(ctx context.Context, replaceExisting bool, keys ...interface{}) (err error) {
 	if m.hasNearCache {
-		return m.ncm.LoadAll(ctx, m, replaceExisting, keys)
+		defer func() {
+			if err == nil {
+				err = m.ncm.Clear(ctx, m)
+			}
+		}()
 	}
 	return m.loadAllFromRemote(ctx, replaceExisting, keys)
 }


### PR DESCRIPTION
Calling `Map.LoadAll` with no keys must load all keys.