### PR TITLE
Migrate GitHub actions from AdoptOpenJDK to Eclipse Temurin [HZ-4195]

### DIFF
--- a/.github/workflows/coverage_runner.yaml
+++ b/.github/workflows/coverage_runner.yaml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '8'
+          java-version: '11'
 
       - name: Checkout code for PR
         if: github.event_name == 'pull_request_target'

--- a/.github/workflows/coverage_runner.yaml
+++ b/.github/workflows/coverage_runner.yaml
@@ -39,9 +39,9 @@ jobs:
           go-version: "${{ matrix.go_version }}"
 
       - name: Install JDK      
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '8'
 
       - name: Checkout code for PR


### PR DESCRIPTION
The `setup-java` [documentation highlights that AdoptOpenJDK no longer receives security updates](https://github.com/actions/setup-java#:~:text=NOTE%3A%20AdoptOpenJDK%20got%20moved%20to%20Eclipse%20Temurin), and instead the Eclipse Temurin JDK should be used.

Fixes [HZ-4195](https://hazelcast.atlassian.net/browse/HZ-4195)

[HZ-4195]: https://hazelcast.atlassian.net/browse/HZ-4195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ