### PR TITLE
Fix Java installation [1.4.z]

### DIFF
--- a/.github/workflows/benchmark-all.yaml
+++ b/.github/workflows/benchmark-all.yaml
@@ -16,10 +16,11 @@ jobs:
         with:
           path: "$HOME/hazelcast-go-client"
 
-      - name: "Install Dependencies"
-        run: |
-          sudo apt-get update &&\
-          sudo apt-get install -y openjdk-17-jdk-headless maven
+      - name: "Setup JRE"
+        uses: "actions/setup-java@v4"
+        with:
+          distribution: "zulu"
+          java-version: "17"
 
       - name: "Start Hazelcast Remote Controller"
         run: |

--- a/.github/workflows/test-all-32bits.yaml
+++ b/.github/workflows/test-all-32bits.yaml
@@ -16,11 +16,12 @@ jobs:
         uses: "actions/checkout@v2"
         with:
           path: "$HOME/hazelcast-go-client"
-
-      - name: "Install Dependencies"
-        run: |
-          sudo apt-get update &&\
-          sudo apt-get install -y openjdk-17-jdk-headless maven
+      
+      - name: "Setup JRE"
+        uses: "actions/setup-java@v4"
+        with:
+          distribution: "zulu"
+          java-version: "17"
 
       - name: "Start Hazelcast Remote Controller"
         run: |

--- a/.github/workflows/test-all.yaml
+++ b/.github/workflows/test-all.yaml
@@ -17,10 +17,11 @@ jobs:
         with:
           path: "$HOME/hazelcast-go-client"
 
-      - name: "Install Dependencies"
-        run: |
-          sudo apt-get update &&\
-          sudo apt-get install -y openjdk-17-jdk-headless maven
+      - name: "Setup JRE"
+        uses: "actions/setup-java@v4"
+        with:
+          distribution: "zulu"
+          java-version: "17"
 
       - name: "Start Hazelcast Remote Controller"
         run: |

--- a/.github/workflows/test-race.yaml
+++ b/.github/workflows/test-race.yaml
@@ -16,10 +16,11 @@ jobs:
         with:
           path: "$HOME/hazelcast-go-client"
 
-      - name: "Install Dependencies"
-        run: |
-          sudo apt-get update &&\
-          sudo apt-get install -y openjdk-17-jdk-headless maven
+      - name: "Setup JRE"
+        uses: "actions/setup-java@v4"
+        with:
+          distribution: "zulu"
+          java-version: "17"
 
       - name: "Start Hazelcast Remote Controller"
         run: |

--- a/rc.sh
+++ b/rc.sh
@@ -183,15 +183,6 @@ echo "Java version:"
 java -version
 which java
 echo "JAVA_HOME: $JAVA_HOME"
-echo
-
-echo "Use Java 17"
-export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
-export PATH=$JAVA_HOME/bin:$PATH
-java -version
-which java
-echo "JAVA_HOME: $JAVA_HOME"
-echo
 
 
 case "${1:-}" in


### PR DESCRIPTION
The [tests are failing](https://github.com/hazelcast/hazelcast-go-client/actions/runs/10175906206/job/28144201884) because of a conflict between:
- `JAVA_HOME`
- Multiple Java installations on the runner

Based on my [investigation and testing](https://github.com/hazelcast/client-compatibility-suites/pull/127#issuecomment-2272140720) using `setup-java`, and avoiding hardcoding, resolves these issues.