### PR TITLE
HZC-7235: change-cloud-url

### DIFF
--- a/internal/cloud/cloud_discovery.go
+++ b/internal/cloud/cloud_discovery.go
@@ -83,7 +83,7 @@ func makeCoordinatorURL(baseURL, token string) string {
 func defaultBaseAPIURL() string {
 	url := os.Getenv(envCoordinatorBaseURL)
 	if url == "" {
-		return "https://api.viridian.hazelcast.com"
+		return "https://api.cloud.hazelcast.com"
 	}
 	return url
 }

--- a/internal/cloud/cloud_discovery_test.go
+++ b/internal/cloud/cloud_discovery_test.go
@@ -95,8 +95,8 @@ func TestTranslateAddrs(t *testing.T) {
 }
 
 func TestMakeCoordinatorURL(t *testing.T) {
-	url := makeCoordinatorURL("https://api.viridian.hazelcast.com", "TOK")
-	target := "https://api.viridian.hazelcast.com/cluster/discovery?token=TOK"
+	url := makeCoordinatorURL("https://api.cloud.hazelcast.com", "TOK")
+	target := "https://api.cloud.hazelcast.com/cluster/discovery?token=TOK"
 	assert.Equal(t, target, url)
 	url = makeCoordinatorURL("http://test.dev", "TOK")
 	target = "http://test.dev/cluster/discovery?token=TOK"


### PR DESCRIPTION
chore: update cloud url to api.cloud.hazelcast.com as part of deprecation of using viridian