### PR TITLE
Fix `codecov-action` [DI-520]

### DIFF
--- a/.github/workflows/coverage_runner.yaml
+++ b/.github/workflows/coverage_runner.yaml
@@ -71,20 +71,26 @@ jobs:
 
       - name: Publish results to Codecov for PR coming from hazelcast organization
         if: ${{ github.event_name == 'pull_request_target' }}
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.out
           override_pr: ${{ github.event.pull_request.number }}
+          fail_ci_if_error: true
 
       - name: Publish results to Codecov for Push
         if: ${{ github.event_name == 'push' }}
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.out
+          fail_ci_if_error: true
         
       - name: Publish result to Codecov for PR coming from community
         if: ${{ github.event_name == 'workflow_dispatch' }}
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.out
           override_pr: ${{ github.event.inputs.pr_number }}
+          fail_ci_if_error: true


### PR DESCRIPTION
The C++ coverage action has been [silently failing](https://github.com/hazelcast/hazelcast-cpp-client/actions/runs/15610247637/attempts/1).

Updated all usages to:
- supply a token to properly authenticate (the reason for the failure)
- fail the step if the upload fails (to avoid the error going unreported)
- use the latest version (consistency)

Fixes: [DI-520](https://hazelcast.atlassian.net/browse/DI-520)

[DI-520]: https://hazelcast.atlassian.net/browse/DI-520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ