### PR TITLE
Fix failover (Backport to v1.4.z)

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2025, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -300,6 +300,14 @@ func (c *Client) handleClusterEvent(event event.Event) {
 		// Shutdown is blocking operation which will make sure all the event goroutines are closed.
 		// If we wait here blocking, it will be a deadlock
 		go c.Shutdown(ctx)
+		return
+	}
+	ac := len(c.ConnectionManager.ActiveConnections())
+	if ac > 0 {
+		c.Logger.Debug(func() string {
+			return fmt.Sprintf("there are %d active connections, canceled the reboot", ac)
+		})
+		c.InvocationService.Pause(false)
 		return
 	}
 	c.Logger.Debug(func() string { return "cluster disconnected, rebooting" })


### PR DESCRIPTION
The reboot is triggered with the ClusterDisconnected event, which in turn published when there are no active connections to the cluster. ClusterDisconnected events may pile up, and cause multiple reboots. With this change, the number of active connections is checked before executing the full reboot.

Also, `net.DialTimeout` which is used during the connection to a member can throw `context.DeadlineExceeded` which causes the circuitbreaker give up retrying. In this PR, I replace `context.DeadlineExceeded` returned from `net.DialTimeout` with a custom error.

(cherry picked from commit 2f8dfab5a7380408d936c2c5e64005484aff2f60)