### PR TITLE
Relocate `hazelcast-remote-controller` [DI-639]

### DIFF
--- a/internal/soak_tests/hz.sh
+++ b/internal/soak_tests/hz.sh
@@ -145,7 +145,7 @@ HZ_VERSION="${HZ_VERSION:-4.2}"
 HAZELCAST_TEST_VERSION=${HZ_VERSION}
 HAZELCAST_ENTERPRISE_VERSION=${HZ_VERSION}
 SNAPSHOT_REPO="https://oss.sonatype.org/content/repositories/snapshots"
-RELEASE_REPO="http://repo1.maven.apache.org/maven2"
+RELEASE_REPO="https://repo.maven.apache.org/maven2"
 ENTERPRISE_RELEASE_REPO="https://repository.hazelcast.com/release/"
 ENTERPRISE_SNAPSHOT_REPO="https://repository.hazelcast.com/snapshot/"
 

--- a/rc.sh
+++ b/rc.sh
@@ -74,7 +74,7 @@ download () {
 downloadRC () {
   local jar_path="hazelcast-remote-controller-${HAZELCAST_RC_VERSION}.jar"
   local artifact="com.hazelcast:hazelcast-remote-controller:${HAZELCAST_RC_VERSION}"
-  download "$SNAPSHOT_REPO" "$jar_path" "$artifact"
+  download "$ENTERPRISE_SNAPSHOT_REPO" "$jar_path" "$artifact"
   classpath="$classpath:$jar_path"
 }
 
@@ -175,7 +175,7 @@ HAZELCAST_TEST_VERSION=${HZ_VERSION}
 HAZELCAST_ENTERPRISE_VERSION=${HZ_VERSION}
 HAZELCAST_RC_VERSION="0.8-SNAPSHOT"
 SNAPSHOT_REPO="https://oss.sonatype.org/content/repositories/snapshots"
-RELEASE_REPO="http://repo1.maven.apache.org/maven2"
+RELEASE_REPO="https://repo.maven.apache.org/maven2"
 ENTERPRISE_RELEASE_REPO="https://repository.hazelcast.com/release/"
 ENTERPRISE_SNAPSHOT_REPO="https://repository.hazelcast.com/snapshot/"
 


### PR DESCRIPTION
In https://github.com/hazelcast/hazelcast-remote-controller/pull/75, `hazelcast-remote-controller` is deployed to a different repository to address build issues. Update the paths to suit.

Also updated Maven central URL as per https://github.com/hazelcast/hazelcast-mono/pull/4897

Fixes: [DI-639](https://hazelcast.atlassian.net/browse/DI-639)

[DI-639]: https://hazelcast.atlassian.net/browse/DI-639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ