### PR TITLE
Made mapSetWithTTL test more robust

### DIFF
--- a/map_it_test.go
+++ b/map_it_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2025, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2026, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/map_it_test.go
+++ b/map_it_test.go
@@ -304,10 +304,12 @@ func mapSetWithTTL(t *testing.T) {
 	it.MapTester(t, func(t *testing.T, m *hz.Map) {
 		ctx := context.Background()
 		targetValue := "value"
-		if err := m.SetWithTTL(ctx, "key", targetValue, 3*time.Second); err != nil {
-			t.Fatal(err)
-		}
-		assert.Equal(t, targetValue, it.MustValue(m.Get(ctx, "key")))
+		it.Eventually(t, func() bool {
+			if err := m.SetWithTTL(ctx, "key", targetValue, 3*time.Second); err != nil {
+				t.Fatal(err)
+			}
+			return it.MustValue(m.Get(ctx, "key")) == targetValue
+		})
 		it.Eventually(t, func() bool {
 			return it.MustValue(m.Get(ctx, "key")) == nil
 		})

--- a/map_it_test.go
+++ b/map_it_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2025, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -304,7 +304,7 @@ func mapSetWithTTL(t *testing.T) {
 	it.MapTester(t, func(t *testing.T, m *hz.Map) {
 		ctx := context.Background()
 		targetValue := "value"
-		if err := m.SetWithTTL(ctx, "key", targetValue, 1*time.Second); err != nil {
+		if err := m.SetWithTTL(ctx, "key", targetValue, 3*time.Second); err != nil {
 			t.Fatal(err)
 		}
 		assert.Equal(t, targetValue, it.MustValue(m.Get(ctx, "key")))


### PR DESCRIPTION
This test failed in one of the test runs.
Full log is here: https://github.com/hazelcast/hazelcast-go-client/actions/runs/23649488017/job/68890211081
```
2026-03-27T13:58:11.0010328Z     map_it_test.go:310: 
2026-03-27T13:58:11.0010954Z            Error Trace:    map_it_test.go:310
2026-03-27T13:58:11.0011420Z                                                    map.go:154
2026-03-27T13:58:11.0011835Z                                                    map.go:96
2026-03-27T13:58:11.0012261Z                                                    map.go:109
2026-03-27T13:58:11.0012576Z            Error:          Not equal: 
2026-03-27T13:58:11.0013015Z                            expected: string("value")
2026-03-27T13:58:11.0013463Z                            actual  : <nil>(<nil>)
2026-03-27T13:58:11.0014167Z            Test:           TestMap/SetWithTTL/Smart_Client
2026-03-27T13:58:11.2044462Z === RUN   TestMap/SetWithTTL/Non-Smart_Client
```

This failure is likely due to the expiry of the entry before there is a chance to verify the value is correctly set.
Ensured the value is set before the expired value is checked.
