### PR TITLE
[HZ-5444] Improve Map.GetAll Performance

### DIFF
--- a/internal/cb/circuitbreaker.go
+++ b/internal/cb/circuitbreaker.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2025, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -82,7 +82,7 @@ func (cb *CircuitBreaker) TryContextFuture(ctx context.Context, tryHandler TryHa
 		return NewFailedFuture(ErrCircuitOpen)
 	}
 	future := NewFutureImpl()
-	cb.tryChan(ctx, future.resultCh, tryHandler)
+	go cb.tryChan(ctx, future.resultCh, tryHandler)
 	return future
 }
 

--- a/internal/cb/circuitbreaker.go
+++ b/internal/cb/circuitbreaker.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2025, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2026, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/internal/invocation/invocation.go
+++ b/internal/invocation/invocation.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2026, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -82,7 +82,7 @@ func (i *Impl) Complete(message *proto.ClientMessage) {
 }
 
 func (i *Impl) Completed() bool {
-	return i.completed != 0
+	return atomic.LoadInt32(&i.completed) != 0
 }
 
 func (i *Impl) EventHandler() proto.ClientMessageHandler {

--- a/internal/proto/codec/builtin.go
+++ b/internal/proto/codec/builtin.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2025, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -270,7 +270,7 @@ func DecodeEntryListForStringAndEntryListIntegerLong(it *proto.ForwardFrameItera
 }
 
 func DecodeEntryListForDataAndData(frameIterator *proto.ForwardFrameIterator) []proto.Pair {
-	result := make([]proto.Pair, 0)
+	result := make([]proto.Pair, 0, frameIterator.FrameCountUntilDatastructureEnd())
 	frameIterator.Next()
 	for !CodecUtil.NextFrameIsDataStructureEndFrame(frameIterator) {
 		key := DecodeData(frameIterator)

--- a/internal/proto/codec/builtin.go
+++ b/internal/proto/codec/builtin.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2025, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2026, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/internal/proto/codec/map_get_all_codec.go
+++ b/internal/proto/codec/map_get_all_codec.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2025, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ const (
 // of these request messages for filling a request for a key set if the keys belong to different partitions.
 
 func EncodeMapGetAllRequest(name string, keys []iserialization.Data) *proto.ClientMessage {
-	clientMessage := proto.NewClientMessageForEncode()
+	clientMessage := proto.NewClientMessageForEncodeWithSize(4 + len(keys))
 	clientMessage.SetRetryable(false)
 
 	initialFrame := proto.NewFrameWith(make([]byte, MapGetAllCodecRequestInitialFrameSize), proto.UnfragmentedMessage)

--- a/internal/proto/codec/map_get_all_codec.go
+++ b/internal/proto/codec/map_get_all_codec.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2025, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2026, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/internal/proto/message.go
+++ b/internal/proto/message.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2025, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -54,6 +54,10 @@ func NewClientMessageForEncode() *ClientMessage {
 	// initial backing array size is kept large enough
 	// for basic outbound messages, like map.Set()
 	return &ClientMessage{Frames: make([]Frame, 0, 4)}
+}
+
+func NewClientMessageForEncodeWithSize(size int) *ClientMessage {
+	return &ClientMessage{Frames: make([]Frame, 0, size)}
 }
 
 func NewClientMessageForDecode(frame Frame) *ClientMessage {
@@ -185,6 +189,16 @@ func (it *ForwardFrameIterator) HasNext() bool {
 
 func (it *ForwardFrameIterator) PeekNext() Frame {
 	return it.frames[it.next]
+}
+
+func (it *ForwardFrameIterator) FrameCountUntilDatastructureEnd() int {
+	for i := it.next; i < len(it.frames); i++ {
+		if it.frames[i].IsEndFrame() {
+			ret := i - it.next + 1
+			return ret
+		}
+	}
+	return 0
 }
 
 type Frame struct {

--- a/internal/proto/message.go
+++ b/internal/proto/message.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2025, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2026, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/nearcache_map.go
+++ b/nearcache_map.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2024, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2026, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -270,7 +270,7 @@ func (ncm *nearCacheMap) GetAll(ctx context.Context, m *Map, keys []interface{})
 		return nil, err
 	}
 	defer ncm.releaseRemainingReservedKeys(resMap)
-	pairs, err := m.getAllFromRemote(ctx, len(missKeys), partitionToKeys)
+	pairs, err := m.getAllPairsFromRemote(ctx, len(missKeys), partitionToKeys)
 	if err != nil {
 		return nil, fmt.Errorf("nearCacheMap.GetAll: getting keys from remote: %w", err)
 	}

--- a/proxy_map.go
+++ b/proxy_map.go
@@ -589,13 +589,19 @@ func (m *Map) getFromRemote(ctx context.Context, keyData serialization.Data) (in
 
 func (m *Map) getAllFromRemote(ctx context.Context, keyCount int, partitionToKeys map[int32][]serialization.Data) ([]proto.Pair, error) {
 	futures := make([]cb.Future, 0, len(partitionToKeys))
-	for pid, ks := range partitionToKeys {
-		request := codec.EncodeMapGetAllRequest(m.name, ks)
+	for pid := range partitionToKeys {
+		pid := pid
+		request := codec.EncodeMapGetAllRequest(m.name, partitionToKeys[pid])
 		fut := m.invoker.CB().TryContextFuture(ctx, func(ctx context.Context, attempt int) (interface{}, error) {
 			if attempt > 0 {
 				request = request.Copy()
 			}
-			return m.invokeOnPartition(ctx, request, pid)
+			res, err := m.invokeOnPartition(ctx, request, pid)
+			if err != nil {
+				return nil, err
+			}
+			pairs := codec.DecodeMapGetAllResponse(res)
+			return pairs, nil
 		})
 		futures = append(futures, fut)
 	}
@@ -605,8 +611,38 @@ func (m *Map) getAllFromRemote(ctx context.Context, keyCount int, partitionToKey
 		if err != nil {
 			return nil, err
 		}
-		pairs := codec.DecodeMapGetAllResponse(fr.(*proto.ClientMessage))
+		pairs := fr.([]proto.Pair)
 		result = append(result, pairs...)
+	}
+	return result, nil
+}
+
+func (m *Map) getAllFromRemote2(ctx context.Context, keyCount int, partitionToKeys map[int32][]serialization.Data) ([]types.Entry, error) {
+	futures := make([]cb.Future, 0, len(partitionToKeys))
+	for pid := range partitionToKeys {
+		pid := pid
+		request := codec.EncodeMapGetAllRequest(m.name, partitionToKeys[pid])
+		fut := m.invoker.CB().TryContextFuture(ctx, func(ctx context.Context, attempt int) (interface{}, error) {
+			if attempt > 0 {
+				request = request.Copy()
+			}
+			res, err := m.invokeOnPartition(ctx, request, pid)
+			if err != nil {
+				return nil, err
+			}
+			pairs := codec.DecodeMapGetAllResponse(res)
+			return m.convertPairsToEntries(pairs)
+		})
+		futures = append(futures, fut)
+	}
+	result := make([]types.Entry, 0, keyCount)
+	for _, fut := range futures {
+		fr, err := fut.Result()
+		if err != nil {
+			return nil, err
+		}
+		entries := fr.([]types.Entry)
+		result = append(result, entries...)
 	}
 	return result, nil
 }
@@ -873,11 +909,7 @@ func (m *Map) getAll(ctx context.Context, keys []interface{}) ([]types.Entry, er
 	if err != nil {
 		return nil, err
 	}
-	pairs, err := m.getAllFromRemote(ctx, len(keys), partitionToKeys)
-	if err != nil {
-		return nil, err
-	}
-	return m.convertPairsToEntries(pairs)
+	return m.getAllFromRemote2(ctx, len(keys), partitionToKeys)
 }
 
 // GetEntrySet returns a clone of the mappings contained in this map.

--- a/proxy_map.go
+++ b/proxy_map.go
@@ -591,11 +591,8 @@ func (m *Map) getAllFromRemote(ctx context.Context, keyCount int, partitionToKey
 	futures := make([]cb.Future, 0, len(partitionToKeys))
 	for pid := range partitionToKeys {
 		pid := pid
-		request := codec.EncodeMapGetAllRequest(m.name, partitionToKeys[pid])
 		fut := m.invoker.CB().TryContextFuture(ctx, func(ctx context.Context, attempt int) (interface{}, error) {
-			if attempt > 0 {
-				request = request.Copy()
-			}
+			request := codec.EncodeMapGetAllRequest(m.name, partitionToKeys[pid])
 			res, err := m.invokeOnPartition(ctx, request, pid)
 			if err != nil {
 				return nil, err
@@ -613,6 +610,33 @@ func (m *Map) getAllFromRemote(ctx context.Context, keyCount int, partitionToKey
 		}
 		pairs := fr.([]proto.Pair)
 		result = append(result, pairs...)
+	}
+	return result, nil
+}
+
+func (m *Map) getAllFromRemote2(ctx context.Context, keyCount int, partitionToKeys map[int32][]serialization.Data) ([]types.Entry, error) {
+	futures := make([]cb.Future, 0, len(partitionToKeys))
+	for pid := range partitionToKeys {
+		pid := pid
+		fut := m.invoker.CB().TryContextFuture(ctx, func(ctx context.Context, attempt int) (interface{}, error) {
+			request := codec.EncodeMapGetAllRequest(m.name, partitionToKeys[pid])
+			res, err := m.invokeOnPartition(ctx, request, pid)
+			if err != nil {
+				return nil, err
+			}
+			pairs := codec.DecodeMapGetAllResponse(res)
+			return m.convertPairsToEntries(pairs)
+		})
+		futures = append(futures, fut)
+	}
+	result := make([]types.Entry, 0, keyCount)
+	for _, fut := range futures {
+		fr, err := fut.Result()
+		if err != nil {
+			return nil, err
+		}
+		entries := fr.([]types.Entry)
+		result = append(result, entries...)
 	}
 	return result, nil
 }
@@ -879,11 +903,7 @@ func (m *Map) getAll(ctx context.Context, keys []interface{}) ([]types.Entry, er
 	if err != nil {
 		return nil, err
 	}
-	pairs, err := m.getAllFromRemote(ctx, len(keys), partitionToKeys)
-	if err != nil {
-		return nil, err
-	}
-	return m.convertPairsToEntries(pairs)
+	return m.getAllFromRemote2(ctx, len(keys), partitionToKeys)
 }
 
 // GetEntrySet returns a clone of the mappings contained in this map.

--- a/proxy_map.go
+++ b/proxy_map.go
@@ -617,36 +617,6 @@ func (m *Map) getAllFromRemote(ctx context.Context, keyCount int, partitionToKey
 	return result, nil
 }
 
-func (m *Map) getAllFromRemote2(ctx context.Context, keyCount int, partitionToKeys map[int32][]serialization.Data) ([]types.Entry, error) {
-	futures := make([]cb.Future, 0, len(partitionToKeys))
-	for pid := range partitionToKeys {
-		pid := pid
-		request := codec.EncodeMapGetAllRequest(m.name, partitionToKeys[pid])
-		fut := m.invoker.CB().TryContextFuture(ctx, func(ctx context.Context, attempt int) (interface{}, error) {
-			if attempt > 0 {
-				request = request.Copy()
-			}
-			res, err := m.invokeOnPartition(ctx, request, pid)
-			if err != nil {
-				return nil, err
-			}
-			pairs := codec.DecodeMapGetAllResponse(res)
-			return m.convertPairsToEntries(pairs)
-		})
-		futures = append(futures, fut)
-	}
-	result := make([]types.Entry, 0, keyCount)
-	for _, fut := range futures {
-		fr, err := fut.Result()
-		if err != nil {
-			return nil, err
-		}
-		entries := fr.([]types.Entry)
-		result = append(result, entries...)
-	}
-	return result, nil
-}
-
 func (m *Map) deleteFromRemote(ctx context.Context, key interface{}) error {
 	lid := iproxy.ExtractLockID(ctx)
 	keyData, err := m.validateAndSerialize(key)
@@ -909,7 +879,11 @@ func (m *Map) getAll(ctx context.Context, keys []interface{}) ([]types.Entry, er
 	if err != nil {
 		return nil, err
 	}
-	return m.getAllFromRemote2(ctx, len(keys), partitionToKeys)
+	pairs, err := m.getAllFromRemote(ctx, len(keys), partitionToKeys)
+	if err != nil {
+		return nil, err
+	}
+	return m.convertPairsToEntries(pairs)
 }
 
 // GetEntrySet returns a clone of the mappings contained in this map.

--- a/proxy_map.go
+++ b/proxy_map.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2025, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2026, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -587,7 +587,7 @@ func (m *Map) getFromRemote(ctx context.Context, keyData serialization.Data) (in
 	return m.convertToObject(codec.DecodeMapGetResponse(response))
 }
 
-func (m *Map) getAllFromRemote(ctx context.Context, keyCount int, partitionToKeys map[int32][]serialization.Data) ([]proto.Pair, error) {
+func (m *Map) getAllPairsFromRemote(ctx context.Context, keyCount int, partitionToKeys map[int32][]serialization.Data) ([]proto.Pair, error) {
 	futures := make([]cb.Future, 0, len(partitionToKeys))
 	for pid := range partitionToKeys {
 		pid := pid
@@ -614,7 +614,7 @@ func (m *Map) getAllFromRemote(ctx context.Context, keyCount int, partitionToKey
 	return result, nil
 }
 
-func (m *Map) getAllFromRemote2(ctx context.Context, keyCount int, partitionToKeys map[int32][]serialization.Data) ([]types.Entry, error) {
+func (m *Map) getAllEntriesFromRemote(ctx context.Context, keyCount int, partitionToKeys map[int32][]serialization.Data) ([]types.Entry, error) {
 	futures := make([]cb.Future, 0, len(partitionToKeys))
 	for pid := range partitionToKeys {
 		pid := pid
@@ -903,7 +903,7 @@ func (m *Map) getAll(ctx context.Context, keys []interface{}) ([]types.Entry, er
 	if err != nil {
 		return nil, err
 	}
-	return m.getAllFromRemote2(ctx, len(keys), partitionToKeys)
+	return m.getAllEntriesFromRemote(ctx, len(keys), partitionToKeys)
 }
 
 // GetEntrySet returns a clone of the mappings contained in this map.


### PR DESCRIPTION
Although the `Map.GetAll` method must send keys for partitions concurrently, in the current implementation they were sent serially which caused a performance regression.
This PR fixes that by sending keys and receiving the values concurrently in separate goroutines.
This is accomplished by running `tryChan` method of the circuit breaker in a goroutine.

This PR also preallocates the frame buffer with the required size instead of growing it.

These improvements improved the GetAll latency 5 times.
