### PR TITLE
Update PR builder membership test to use `triggering_actor` to make community PR execution easier

### DIFF
--- a/.github/workflows/coverage_runner.yaml
+++ b/.github/workflows/coverage_runner.yaml
@@ -22,7 +22,7 @@ jobs:
         id: composite
         uses: hazelcast/hazelcast-tpm/membership@main
         with:
-          member-name: ${{ github.actor }}
+          member-name: ${{ github.triggering_actor }}
           token: ${{ secrets.GH_TOKEN }}
 
   test_client:


### PR DESCRIPTION
See https://github.com/hazelcast/hazelcast-cpp-client/pull/1442